### PR TITLE
feat: auto-generated Saloon REST client from Mattermost OpenAPI v4 spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 .phpunit.result.cache
 .phpunit.cache/
 composer.lock
+spec/mattermost-openapi-v4.yaml
+spec/mattermost-openapi-core.yaml

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "saloonphp/saloon": "^4.0"
     },
     "require-dev": {
+        "crescat-io/saloon-sdk-generator": "^1.6",
         "larastan/larastan": "^3.0",
         "laravel/framework": "^13.0",
         "laravel/pint": "^1.0",

--- a/spec/mattermost-openapi-clean.yaml
+++ b/spec/mattermost-openapi-clean.yaml
@@ -1,0 +1,19643 @@
+components:
+  responses:
+    '400':
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+      description: The request is malformed.
+    '403':
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+      description: Access to the resource is forbidden for this user.
+    '404':
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+      description: Resource requested not found.
+    '500':
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+      description: There was an internal error in the server.
+    BadRequest:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AppError'
+      description: Invalid or missing parameters in URL or request body
+    Forbidden:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AppError'
+      description: Do not have appropriate permissions
+    InternalServerError:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AppError'
+      description: Something went wrong with the server
+    NotFound:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AppError'
+      description: Resource not found
+    NotImplemented:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AppError'
+      description: Feature is disabled
+    TooLarge:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AppError'
+      description: Content too large
+    TooManyRequests:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AppError'
+      description: Too many requests
+    Unauthorized:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AppError'
+      description: No access token provided
+  schemas:
+    AddOn:
+      properties:
+        display_name:
+          type: string
+        id:
+          type: string
+        name:
+          type: string
+        price_per_seat:
+          type: string
+      type: object
+    Address:
+      properties:
+        city:
+          type: string
+        country:
+          type: string
+        line1:
+          type: string
+        line2:
+          type: string
+        postal_code:
+          type: string
+        state:
+          type: string
+      type: object
+    AppError:
+      properties:
+        id:
+          type: string
+        message:
+          type: string
+        request_id:
+          type: string
+        status_code:
+          type: integer
+      type: object
+    Audit:
+      properties:
+        action:
+          type: string
+        create_at:
+          description: The time in milliseconds a audit was created
+          format: int64
+          type: integer
+        extra_info:
+          type: string
+        id:
+          type: string
+        ip_address:
+          type: string
+        session_id:
+          type: string
+        user_id:
+          type: string
+      type: object
+    AutocompleteSuggestion:
+      properties:
+        Complete:
+          description: Completed suggestion
+          type: string
+        Description:
+          description: Description of the suggested command
+          type: string
+        Hint:
+          description: Hint about suggested input
+          type: string
+        IconData:
+          description: Base64 encoded svg image
+          type: string
+        Suggestion:
+          description: Predicted text user might want to input
+          type: string
+      type: object
+    BoardsLimits:
+      properties:
+        cards:
+          nullable: true
+          type: integer
+        views:
+          nullable: true
+          type: integer
+      type: object
+    Bot:
+      description: A bot account
+      properties:
+        create_at:
+          description: The time in milliseconds a bot was created
+          format: int64
+          type: integer
+        delete_at:
+          description: The time in milliseconds a bot was deleted
+          format: int64
+          type: integer
+        description:
+          type: string
+        display_name:
+          type: string
+        owner_id:
+          description: The user id of the user that currently owns this bot.
+          type: string
+        update_at:
+          description: The time in milliseconds a bot was last updated
+          format: int64
+          type: integer
+        user_id:
+          description: The user id of the associated user entry.
+          type: string
+        username:
+          type: string
+      type: object
+    Channel:
+      properties:
+        create_at:
+          description: The time in milliseconds a channel was created
+          format: int64
+          type: integer
+        creator_id:
+          type: string
+        delete_at:
+          description: The time in milliseconds a channel was deleted
+          format: int64
+          type: integer
+        display_name:
+          type: string
+        extra_update_at:
+          description: Deprecated in Mattermost 5.0 release
+          format: int64
+          type: integer
+        header:
+          type: string
+        id:
+          type: string
+        last_post_at:
+          description: The time in milliseconds of the last post of a channel
+          format: int64
+          type: integer
+        name:
+          type: string
+        purpose:
+          type: string
+        team_id:
+          type: string
+        total_msg_count:
+          type: integer
+        type:
+          type: string
+        update_at:
+          description: The time in milliseconds a channel was last updated
+          format: int64
+          type: integer
+      type: object
+    ChannelData:
+      properties:
+        channel:
+          $ref: '#/components/schemas/Channel'
+        member:
+          $ref: '#/components/schemas/ChannelMember'
+      type: object
+    ChannelListWithTeamData:
+      items:
+        $ref: '#/components/schemas/ChannelWithTeamData'
+      type: array
+    ChannelMember:
+      properties:
+        channel_id:
+          type: string
+        last_update_at:
+          description: The time in milliseconds the channel member was last updated
+          format: int64
+          type: integer
+        last_viewed_at:
+          description: The time in milliseconds the channel was last viewed by the user
+          format: int64
+          type: integer
+        mention_count:
+          type: integer
+        msg_count:
+          type: integer
+        notify_props:
+          $ref: '#/components/schemas/ChannelNotifyProps'
+        roles:
+          type: string
+        user_id:
+          type: string
+      type: object
+    ChannelMemberCountByGroup:
+      description: An object describing group member information in a channel
+      properties:
+        channel_member_count:
+          description: Total number of group members in the channel
+          type: number
+        channel_member_timezones_count:
+          description: Total number of unique timezones for the group members in the channel
+          type: number
+        group_id:
+          description: ID of the group
+          type: string
+      type: object
+    ChannelMemberWithTeamData:
+      allOf:
+      - $ref: '#/components/schemas/ChannelMember'
+      - properties:
+          team_display_name:
+            description: The display name of the team to which this channel belongs.
+            type: string
+          team_name:
+            description: The name of the team to which this channel belongs.
+            type: string
+          team_update_at:
+            description: The time at which the team to which this channel belongs was last updated.
+            type: integer
+        type: object
+    ChannelModeratedRole:
+      properties:
+        enabled:
+          type: boolean
+        value:
+          type: boolean
+      type: object
+    ChannelModeratedRoles:
+      properties:
+        guests:
+          $ref: '#/components/schemas/ChannelModeratedRole'
+        members:
+          $ref: '#/components/schemas/ChannelModeratedRole'
+      type: object
+    ChannelModeratedRolesPatch:
+      properties:
+        guests:
+          type: boolean
+        members:
+          type: boolean
+      type: object
+    ChannelModeration:
+      properties:
+        name:
+          type: string
+        roles:
+          $ref: '#/components/schemas/ChannelModeratedRoles'
+      type: object
+    ChannelModerationPatch:
+      properties:
+        name:
+          type: string
+        roles:
+          $ref: '#/components/schemas/ChannelModeratedRolesPatch'
+      type: object
+    ChannelNotifyProps:
+      properties:
+        desktop:
+          description: Set to "all" to receive desktop notifications for all activity, "mention" for mentions and direct messages
+            only, "none" to disable, or "default" to use the global user notification setting.
+          type: string
+        email:
+          description: Set to "true" to enable email notifications, "false" to disable, or "default" to use the global user
+            notification setting.
+          type: string
+        mark_unread:
+          description: Set to "all" to mark the channel unread for any new message, "mention" to mark unread for new mentions
+            only. Defaults to "all".
+          type: string
+        push:
+          description: Set to "all" to receive push notifications for all activity, "mention" for mentions and direct messages
+            only, "none" to disable, or "default" to use the global user notification setting.
+          type: string
+      type: object
+    ChannelStats:
+      properties:
+        channel_id:
+          type: string
+        member_count:
+          type: integer
+      type: object
+    ChannelUnread:
+      properties:
+        channel_id:
+          type: string
+        mention_count:
+          type: integer
+        msg_count:
+          type: integer
+        team_id:
+          type: string
+      type: object
+    ChannelUnreadAt:
+      properties:
+        channel_id:
+          description: The ID of the channel the user has access to..
+          type: string
+        last_viewed_at:
+          description: time in milliseconds when the user last viewed the channel.
+          type: integer
+        mention_count:
+          description: No. of mentions the user has within the unread posts of the channel.
+          type: integer
+        msg_count:
+          description: No. of messages the user has already read.
+          type: integer
+        team_id:
+          description: The ID of the team the channel belongs to.
+          type: string
+      type: object
+    ChannelWithTeamData:
+      allOf:
+      - $ref: '#/components/schemas/Channel'
+      - properties:
+          policy_id:
+            description: The data retention policy to which this team has been assigned. If no such policy exists, or the
+              caller does not have the `sysconsole_read_compliance_data_retention` permission, this field will be null.
+            type: string
+          team_display_name:
+            description: The display name of the team to which this channel belongs.
+            type: string
+          team_name:
+            description: The name of the team to which this channel belongs.
+            type: string
+          team_update_at:
+            description: The time at which the team to which this channel belongs was last updated.
+            type: integer
+        type: object
+    Checklist:
+      properties:
+        id:
+          description: A unique, 26 characters long, alphanumeric identifier for the checklist.
+          example: 6f6nsgxzoq84fqh1dnlyivgafd
+          type: string
+        items:
+          description: The list of tasks to do.
+          items:
+            $ref: '#/components/schemas/ChecklistItem'
+          type: array
+        title:
+          description: The title of the checklist.
+          example: Triage issue
+          type: string
+      type: object
+    ChecklistItem:
+      properties:
+        assignee_id:
+          description: The identifier of the user that has been assigned to complete this item. If the item has no assignee,
+            this is an empty string.
+          example: pisdatkjtdlkdhht2v4inxuzx1
+          type: string
+        assignee_modified:
+          description: The timestamp for the latest modification of the item's assignee, formatted as the number of milliseconds
+            since the Unix epoch. It equals 0 if the item never got an assignee.
+          example: 1608897821125
+          format: int64
+          type: integer
+        command:
+          description: The slash command associated with this item. If the item has no slash command associated, this is an
+            empty string
+          example: /opsgenie on-call
+          type: string
+        command_last_run:
+          description: The timestamp for the latest execution of the item's command, formatted as the number of milliseconds
+            since the Unix epoch. It equals 0 if the command was never executed.
+          example: 1608552221019
+          format: int64
+          type: integer
+        condition_action:
+          description: A string that represents the action created as a result of a condition evaluation. Empty string means
+            no action, 'hidden' means the item is hidden due to condition not being met, 'shown_because_modified' means the
+            item is shown despite condition not being met because it was recently modified.
+          enum:
+          - ''
+          - hidden
+          - shown_because_modified
+          example: hidden
+          type: string
+        condition_id:
+          description: The ID of the condition that created this checklist item, if any. Empty string if the item was not
+            created by a condition.
+          example: 6f6nsgxzoq84fqh1dnlyivgafd
+          type: string
+        condition_reason:
+          description: A string representation of the condition that affects this checklist item. Empty string if no condition
+            is associated with this item.
+          example: Severity is Critical AND Status is not Closed
+          type: string
+        delete_at:
+          description: The timestamp for the last time the item was skipped, formatted as the number of milliseconds since
+            the Unix epoch. It equals 0 if the item was never skipped.
+          example: 1607774621321
+          format: int64
+          type: integer
+        description:
+          description: A detailed description of the checklist item, formatted with Markdown.
+          example: Ask the customer for more information in [Zendesk](https://www.zendesk.com/).
+          type: string
+        due_date:
+          description: The timestamp for the due date of the checklist item, formatted as the number of milliseconds since
+            the Unix epoch. It equals 0 if not set. For playbooks, this is a relative timestamp; for runs, this is an absolute
+            timestamp.
+          example: 1607774621321
+          format: int64
+          type: integer
+        id:
+          description: A unique, 26 characters long, alphanumeric identifier for the checklist item.
+          example: 6f6nsgxzoq84fqh1dnlyivgafd
+          type: string
+        state:
+          description: The state of the checklist item. An empty string means that the item is not done.
+          enum:
+          - ''
+          - in_progress
+          - closed
+          example: closed
+          type: string
+        state_modified:
+          description: The timestamp for the latest modification of the item's state, formatted as the number of milliseconds
+            since the Unix epoch. It equals 0 if the item was never modified.
+          example: 1607774621321
+          format: int64
+          type: integer
+        task_actions:
+          description: An array of all the task actions associated with this task.
+          items:
+            properties:
+              actions:
+                description: The actions to be executed when the trigger is activated.
+                items:
+                  type: object
+                type: array
+              trigger:
+                description: The trigger configuration for the task action.
+                type: object
+            type: object
+          type: array
+        title:
+          description: The title of the checklist item.
+          example: Gather information from customer.
+          type: string
+        update_at:
+          description: The timestamp for when this checklist item was last modified, formatted as the number of milliseconds
+            since the Unix epoch.
+          example: 1607774621321
+          format: int64
+          type: integer
+      type: object
+    CloudCustomer:
+      properties:
+        billing_address:
+          $ref: '#/components/schemas/Address'
+        company_address:
+          $ref: '#/components/schemas/Address'
+        contact_first_name:
+          type: string
+        contact_last_name:
+          type: string
+        create_at:
+          format: int64
+          type: integer
+        creator_id:
+          type: string
+        email:
+          type: string
+        id:
+          type: string
+        name:
+          type: string
+        num_employees:
+          type: string
+        payment_method:
+          $ref: '#/components/schemas/PaymentMethod'
+      type: object
+    ClusterInfo:
+      properties:
+        config_hash:
+          description: The hash of the configuartion file the node is using
+          type: string
+        hostname:
+          description: The hostname for this node
+          type: string
+        id:
+          description: The unique ID for the node
+          type: string
+        internode_url:
+          description: The URL used to communicate with those node from other nodes
+          type: string
+        is_alive:
+          description: Whether or not the node is alive and well
+          type: boolean
+        last_ping:
+          description: The time of the last ping to this node
+          type: integer
+        version:
+          description: The server version the node is on
+          type: string
+      type: object
+    Command:
+      properties:
+        auto_complete:
+          description: Use auto complete for this command
+          type: boolean
+        auto_complete_desc:
+          description: The description for this command shown when selecting the command
+          type: string
+        auto_complete_hint:
+          description: The hint for this command
+          type: string
+        create_at:
+          description: The time in milliseconds the command was created
+          type: integer
+        creator_id:
+          description: The user id for the commands creator
+          type: string
+        delete_at:
+          description: The time in milliseconds the command was deleted, 0 if never deleted
+          format: int64
+          type: integer
+        description:
+          description: Description for this command
+          type: string
+        display_name:
+          description: Display name for the command
+          type: string
+        icon_url:
+          description: The url to find the icon for this users avatar
+          type: string
+        id:
+          description: The ID of the slash command
+          type: string
+        method:
+          description: Is the trigger done with HTTP Get ('G') or HTTP Post ('P')
+          type: string
+        team_id:
+          description: The team id for which this command is configured
+          type: string
+        token:
+          description: The token which is used to verify the source of the payload
+          type: string
+        trigger:
+          description: The string that triggers this command
+          type: string
+        update_at:
+          description: The time in milliseconds the command was last updated
+          format: int64
+          type: integer
+        url:
+          description: The URL that is triggered
+          type: string
+        username:
+          description: What is the username for the response post
+          type: string
+      type: object
+    CommandResponse:
+      properties:
+        Attachments:
+          items:
+            $ref: '#/components/schemas/SlackAttachment'
+          type: array
+        GotoLocation:
+          type: string
+        IconURL:
+          type: string
+        ResponseType:
+          description: The response type either in_channel or ephemeral
+          type: string
+        Text:
+          type: string
+        Username:
+          type: string
+      type: object
+    ComparisonCondition:
+      properties:
+        field_id:
+          description: The identifier of the field to compare against.
+          example: status
+          type: string
+        value:
+          description: The value to compare with. Format depends on the field type. Stored as JSON.
+          example: '"active"'
+      required:
+      - field_id
+      - value
+      type: object
+    Compliance:
+      properties:
+        count:
+          type: integer
+        create_at:
+          format: int64
+          type: integer
+        desc:
+          type: string
+        emails:
+          type: string
+        end_at:
+          format: int64
+          type: integer
+        id:
+          type: string
+        keywords:
+          type: string
+        start_at:
+          format: int64
+          type: integer
+        status:
+          type: string
+        type:
+          type: string
+        user_id:
+          type: string
+      type: object
+    Condition:
+      properties:
+        condition_expr:
+          $ref: '#/components/schemas/ConditionExprV1'
+        create_at:
+          description: The condition creation timestamp, formatted as the number of milliseconds since the Unix epoch.
+          example: 1606807976289
+          format: int64
+          type: integer
+        id:
+          description: A unique, 26 characters long, alphanumeric identifier for the condition.
+          example: abc123def456ghi789
+          type: string
+        playbook_id:
+          description: The identifier of the playbook this condition belongs to.
+          example: iz0g457ikesz55dhxcfa0fk9yy
+          type: string
+        run_id:
+          description: If this is a run condition (read-only snapshot), the identifier of the run. Empty for playbook conditions.
+          example: mx3xyzdojfgyfdx8sc8of1gdme
+          type: string
+        update_at:
+          description: The condition update timestamp, formatted as the number of milliseconds since the Unix epoch.
+          example: 1606807976289
+          format: int64
+          type: integer
+        version:
+          description: Version number of the condition expression format. Currently only version 1 is supported.
+          example: 1
+          format: int32
+          type: integer
+      required:
+      - version
+      - condition_expr
+      type: object
+    ConditionExprV1:
+      description: A logical condition expression that can combine multiple conditions using AND/OR operators, or perform
+        field comparisons using Is/IsNot operators.
+      example:
+        and:
+        - is:
+            field_id: status
+            value: '"active"'
+        - or:
+          - is:
+              field_id: priority
+              value: '"high"'
+          - is:
+              field_id: priority
+              value: '"critical"'
+      properties:
+        and:
+          description: Logical AND operation. All conditions in the array must be true.
+          items:
+            $ref: '#/components/schemas/ConditionExprV1'
+          type: array
+        is:
+          $ref: '#/components/schemas/ComparisonCondition'
+        isNot:
+          $ref: '#/components/schemas/ComparisonCondition'
+        or:
+          description: Logical OR operation. At least one condition in the array must be true.
+          items:
+            $ref: '#/components/schemas/ConditionExprV1'
+          type: array
+      type: object
+    ConditionList:
+      properties:
+        has_more:
+          description: A boolean describing whether there are more pages after the currently returned.
+          example: false
+          type: boolean
+        items:
+          description: The conditions in this page.
+          items:
+            $ref: '#/components/schemas/Condition'
+          type: array
+        page_count:
+          description: The total number of pages. This depends on the total number of conditions and the per_page parameter.
+          example: 1
+          format: int32
+          type: integer
+        total_count:
+          description: The total number of conditions in the list, regardless of paging.
+          example: 10
+          format: int32
+          type: integer
+      type: object
+    Config:
+      properties:
+        AnalyticsSettings:
+          properties:
+            MaxUsersForStatistics:
+              type: integer
+          type: object
+        ClusterSettings:
+          properties:
+            Enable:
+              type: boolean
+            InterNodeListenAddress:
+              type: string
+            InterNodeUrls:
+              items:
+                type: string
+              type: array
+          type: object
+        ComplianceSettings:
+          properties:
+            Directory:
+              type: string
+            Enable:
+              type: boolean
+            EnableDaily:
+              type: boolean
+          type: object
+        EmailSettings:
+          properties:
+            ConnectionSecurity:
+              type: string
+            EmailBatchingBufferSize:
+              type: integer
+            EmailBatchingInterval:
+              type: integer
+            EnableEmailBatching:
+              type: boolean
+            EnableSignInWithEmail:
+              type: boolean
+            EnableSignInWithUsername:
+              type: boolean
+            EnableSignUpWithEmail:
+              type: boolean
+            FeedbackEmail:
+              type: string
+            FeedbackName:
+              type: string
+            FeedbackOrganization:
+              type: string
+            InviteSalt:
+              type: string
+            PasswordResetSalt:
+              type: string
+            PushNotificationContents:
+              type: string
+            PushNotificationServer:
+              type: string
+            RequireEmailVerification:
+              type: boolean
+            SMTPPassword:
+              type: string
+            SMTPPort:
+              type: string
+            SMTPServer:
+              type: string
+            SMTPUsername:
+              type: string
+            SendEmailNotifications:
+              type: boolean
+            SendPushNotifications:
+              type: boolean
+          type: object
+        FileSettings:
+          properties:
+            AmazonS3AccessKeyId:
+              type: string
+            AmazonS3Bucket:
+              type: string
+            AmazonS3Endpoint:
+              type: string
+            AmazonS3Region:
+              type: string
+            AmazonS3SSL:
+              type: boolean
+            AmazonS3SecretAccessKey:
+              type: string
+            Directory:
+              type: string
+            DriverName:
+              type: string
+            EnablePublicLink:
+              type: boolean
+            InitialFont:
+              type: string
+            MaxFileSize:
+              type: integer
+            PreviewHeight:
+              type: integer
+            PreviewWidth:
+              type: integer
+            ProfileHeight:
+              type: integer
+            ProfileWidth:
+              type: integer
+            PublicLinkSalt:
+              type: string
+            ThumbnailHeight:
+              type: integer
+            ThumbnailWidth:
+              type: integer
+          type: object
+        GitLabSettings:
+          properties:
+            AuthEndpoint:
+              type: string
+            Enable:
+              type: boolean
+            Id:
+              type: string
+            Scope:
+              type: string
+            Secret:
+              type: string
+            TokenEndpoint:
+              type: string
+            UserApiEndpoint:
+              type: string
+          type: object
+        GoogleSettings:
+          properties:
+            AuthEndpoint:
+              type: string
+            Enable:
+              type: boolean
+            Id:
+              type: string
+            Scope:
+              type: string
+            Secret:
+              type: string
+            TokenEndpoint:
+              type: string
+            UserApiEndpoint:
+              type: string
+          type: object
+        LdapSettings:
+          properties:
+            BaseDN:
+              type: string
+            BindPassword:
+              type: string
+            BindUsername:
+              type: string
+            ConnectionSecurity:
+              type: string
+            EmailAttribute:
+              type: string
+            Enable:
+              type: boolean
+            FirstNameAttribute:
+              type: string
+            IdAttribute:
+              type: string
+            LastNameAttribute:
+              type: string
+            LdapPort:
+              type: integer
+            LdapServer:
+              type: string
+            LoginFieldName:
+              type: string
+            MaxPageSize:
+              type: integer
+            NicknameAttribute:
+              type: string
+            PositionAttribute:
+              type: string
+            QueryTimeout:
+              type: integer
+            SkipCertificateVerification:
+              type: boolean
+            SyncIntervalMinutes:
+              type: integer
+            UserFilter:
+              type: string
+            UsernameAttribute:
+              type: string
+          type: object
+        LocalizationSettings:
+          properties:
+            AvailableLocales:
+              type: string
+            DefaultClientLocale:
+              type: string
+            DefaultServerLocale:
+              type: string
+          type: object
+        LogSettings:
+          properties:
+            ConsoleLevel:
+              type: string
+            EnableConsole:
+              type: boolean
+            EnableDiagnostics:
+              type: boolean
+            EnableFile:
+              type: boolean
+            EnableWebhookDebugging:
+              type: boolean
+            FileLevel:
+              type: string
+            FileLocation:
+              type: string
+          type: object
+        MetricsSettings:
+          properties:
+            BlockProfileRate:
+              type: integer
+            Enable:
+              type: boolean
+            ListenAddress:
+              type: string
+          type: object
+        NativeAppSettings:
+          properties:
+            AndroidAppDownloadLink:
+              type: string
+            AppDownloadLink:
+              type: string
+            IosAppDownloadLink:
+              type: string
+          type: object
+        Office365Settings:
+          properties:
+            AuthEndpoint:
+              type: string
+            Enable:
+              type: boolean
+            Id:
+              type: string
+            Scope:
+              type: string
+            Secret:
+              type: string
+            TokenEndpoint:
+              type: string
+            UserApiEndpoint:
+              type: string
+          type: object
+        PasswordSettings:
+          properties:
+            Lowercase:
+              type: boolean
+            MinimumLength:
+              type: integer
+            Number:
+              type: boolean
+            Symbol:
+              type: boolean
+            Uppercase:
+              type: boolean
+          type: object
+        PrivacySettings:
+          properties:
+            ShowEmailAddress:
+              type: boolean
+            ShowFullName:
+              type: boolean
+          type: object
+        RateLimitSettings:
+          properties:
+            Enable:
+              type: boolean
+            MaxBurst:
+              type: integer
+            MemoryStoreSize:
+              type: integer
+            PerSec:
+              type: integer
+            VaryByHeader:
+              type: string
+            VaryByRemoteAddr:
+              type: boolean
+          type: object
+        SamlSettings:
+          properties:
+            AssertionConsumerServiceURL:
+              type: string
+            EmailAttribute:
+              type: string
+            Enable:
+              type: boolean
+            Encrypt:
+              type: boolean
+            FirstNameAttribute:
+              type: string
+            IdpCertificateFile:
+              type: string
+            IdpDescriptorUrl:
+              type: string
+            IdpUrl:
+              type: string
+            LastNameAttribute:
+              type: string
+            LocaleAttribute:
+              type: string
+            LoginButtonText:
+              type: string
+            NicknameAttribute:
+              type: string
+            PositionAttribute:
+              type: string
+            PrivateKeyFile:
+              type: string
+            PublicCertificateFile:
+              type: string
+            UsernameAttribute:
+              type: string
+            Verify:
+              type: boolean
+          type: object
+        ServiceSettings:
+          properties:
+            AllowCorsFrom:
+              type: string
+            ConnectionSecurity:
+              type: string
+            EnableCommands:
+              type: boolean
+            EnableCustomEmoji:
+              type: boolean
+            EnableDeveloper:
+              type: boolean
+            EnableIncomingWebhooks:
+              type: boolean
+            EnableInsecureOutgoingConnections:
+              type: boolean
+            EnableMultifactorAuthentication:
+              type: boolean
+            EnableOAuthServiceProvider:
+              type: boolean
+            EnableOnlyAdminIntegrations:
+              type: boolean
+            EnableOutgoingWebhooks:
+              type: boolean
+            EnablePostIconOverride:
+              type: boolean
+            EnablePostUsernameOverride:
+              type: boolean
+            EnableSecurityFixAlert:
+              type: boolean
+            EnableTesting:
+              type: boolean
+            EnforceMultifactorAuthentication:
+              type: boolean
+            Forward80To443:
+              type: boolean
+            GoogleDeveloperKey:
+              type: string
+            LetsEncryptCertificateCacheFile:
+              type: string
+            ListenAddress:
+              type: string
+            MaximumLoginAttempts:
+              type: integer
+            ReadTimeout:
+              type: integer
+            RestrictCustomEmojiCreation:
+              type: string
+            SegmentDeveloperKey:
+              type: string
+            SessionCacheInMinutes:
+              type: integer
+            SessionLengthMobileInDays:
+              type: integer
+            SessionLengthSSOInDays:
+              type: integer
+            SessionLengthWebInDays:
+              type: integer
+            SiteURL:
+              type: string
+            TLSCertFile:
+              type: string
+            TLSKeyFile:
+              type: string
+            UseLetsEncrypt:
+              type: boolean
+            WebserverMode:
+              type: string
+            WebsocketPort:
+              type: integer
+            WebsocketSecurePort:
+              type: integer
+            WriteTimeout:
+              type: integer
+          type: object
+        SqlSettings:
+          properties:
+            AtRestEncryptKey:
+              type: string
+            DataSource:
+              type: string
+            DataSourceReplicas:
+              items:
+                type: string
+              type: array
+            DriverName:
+              type: string
+            MaxIdleConns:
+              type: integer
+            MaxOpenConns:
+              type: integer
+            Trace:
+              type: boolean
+          type: object
+        SupportSettings:
+          properties:
+            AboutLink:
+              type: string
+            HelpLink:
+              type: string
+            PrivacyPolicyLink:
+              type: string
+            ReportAProblemLink:
+              type: string
+            SupportEmail:
+              type: string
+            TermsOfServiceLink:
+              type: string
+          type: object
+        TeamSettings:
+          properties:
+            CustomBrandText:
+              type: string
+            CustomDescriptionText:
+              type: string
+            EnableCustomBrand:
+              type: boolean
+            EnableOpenServer:
+              type: boolean
+            EnableTeamCreation:
+              type: boolean
+            EnableUserCreation:
+              type: boolean
+            MaxChannelsPerTeam:
+              type: integer
+            MaxNotificationsPerChannel:
+              type: integer
+            MaxUsersPerTeam:
+              type: integer
+            RestrictCreationToDomains:
+              type: string
+            RestrictDirectMessage:
+              type: string
+            RestrictPrivateChannelCreation:
+              type: string
+            RestrictPrivateChannelDeletion:
+              type: string
+            RestrictPrivateChannelManagement:
+              type: string
+            RestrictPublicChannelCreation:
+              type: string
+            RestrictPublicChannelDeletion:
+              type: string
+            RestrictPublicChannelManagement:
+              type: string
+            RestrictTeamInvite:
+              type: string
+            SiteName:
+              type: string
+            UserStatusAwayTimeout:
+              type: integer
+          type: object
+      type: object
+    DataRetentionPolicy:
+      allOf:
+      - $ref: '#/components/schemas/DataRetentionPolicyWithoutId'
+      - properties:
+          id:
+            description: The ID of this retention policy.
+            type: string
+        type: object
+    DataRetentionPolicyCreate:
+      allOf:
+      - $ref: '#/components/schemas/DataRetentionPolicyWithTeamAndChannelIds'
+      required:
+      - display_name
+      - post_duration
+    DataRetentionPolicyForChannel:
+      properties:
+        channel_id:
+          description: The channel ID.
+          type: string
+        post_duration:
+          description: The number of days a message will be retained before being deleted by this policy.
+          type: integer
+      type: object
+    DataRetentionPolicyForTeam:
+      properties:
+        post_duration:
+          description: The number of days a message will be retained before being deleted by this policy.
+          type: integer
+        team_id:
+          description: The team ID.
+          type: string
+      type: object
+    DataRetentionPolicyWithTeamAndChannelCounts:
+      allOf:
+      - $ref: '#/components/schemas/DataRetentionPolicy'
+      - properties:
+          channel_count:
+            description: The number of channels to which this policy is applied.
+            type: integer
+          team_count:
+            description: The number of teams to which this policy is applied.
+            type: integer
+        type: object
+    DataRetentionPolicyWithTeamAndChannelIds:
+      allOf:
+      - $ref: '#/components/schemas/DataRetentionPolicyWithoutId'
+      - properties:
+          channel_ids:
+            description: The IDs of the channels to which this policy should be applied.
+            items:
+              type: string
+            type: array
+          team_ids:
+            description: The IDs of the teams to which this policy should be applied.
+            items:
+              type: string
+            type: array
+        type: object
+    DataRetentionPolicyWithoutId:
+      properties:
+        display_name:
+          description: The display name for this retention policy.
+          type: string
+        post_duration:
+          description: 'The number of days a message will be retained before being deleted by this policy. If this value is
+            less than 0, the policy has infinite retention (i.e. messages are never deleted).
+
+            '
+          type: integer
+      type: object
+    Emoji:
+      properties:
+        create_at:
+          description: The time in milliseconds the emoji was made
+          format: int64
+          type: integer
+        creator_id:
+          description: The ID of the user that made the emoji
+          type: string
+        delete_at:
+          description: The time in milliseconds the emoji was deleted
+          format: int64
+          type: integer
+        id:
+          description: The ID of the emoji
+          type: string
+        name:
+          description: The name of the emoji
+          type: string
+        update_at:
+          description: The time in milliseconds the emoji was last updated
+          format: int64
+          type: integer
+      type: object
+    EnvironmentConfig:
+      properties:
+        AnalyticsSettings:
+          properties:
+            MaxUsersForStatistics:
+              type: boolean
+          type: object
+        ClusterSettings:
+          properties:
+            Enable:
+              type: boolean
+            InterNodeListenAddress:
+              type: boolean
+            InterNodeUrls:
+              type: boolean
+          type: object
+        ComplianceSettings:
+          properties:
+            Directory:
+              type: boolean
+            Enable:
+              type: boolean
+            EnableDaily:
+              type: boolean
+          type: object
+        EmailSettings:
+          properties:
+            ConnectionSecurity:
+              type: boolean
+            EmailBatchingBufferSize:
+              type: boolean
+            EmailBatchingInterval:
+              type: boolean
+            EnableEmailBatching:
+              type: boolean
+            EnableSignInWithEmail:
+              type: boolean
+            EnableSignInWithUsername:
+              type: boolean
+            EnableSignUpWithEmail:
+              type: boolean
+            FeedbackEmail:
+              type: boolean
+            FeedbackName:
+              type: boolean
+            FeedbackOrganization:
+              type: boolean
+            InviteSalt:
+              type: boolean
+            PasswordResetSalt:
+              type: boolean
+            PushNotificationContents:
+              type: boolean
+            PushNotificationServer:
+              type: boolean
+            RequireEmailVerification:
+              type: boolean
+            SMTPPassword:
+              type: boolean
+            SMTPPort:
+              type: boolean
+            SMTPServer:
+              type: boolean
+            SMTPUsername:
+              type: boolean
+            SendEmailNotifications:
+              type: boolean
+            SendPushNotifications:
+              type: boolean
+          type: object
+        FileSettings:
+          properties:
+            AmazonS3AccessKeyId:
+              type: boolean
+            AmazonS3Bucket:
+              type: boolean
+            AmazonS3Endpoint:
+              type: boolean
+            AmazonS3Region:
+              type: boolean
+            AmazonS3SSL:
+              type: boolean
+            AmazonS3SecretAccessKey:
+              type: boolean
+            Directory:
+              type: boolean
+            DriverName:
+              type: boolean
+            EnablePublicLink:
+              type: boolean
+            InitialFont:
+              type: boolean
+            MaxFileSize:
+              type: boolean
+            PreviewHeight:
+              type: boolean
+            PreviewWidth:
+              type: boolean
+            ProfileHeight:
+              type: boolean
+            ProfileWidth:
+              type: boolean
+            PublicLinkSalt:
+              type: boolean
+            ThumbnailHeight:
+              type: boolean
+            ThumbnailWidth:
+              type: boolean
+          type: object
+        GitLabSettings:
+          properties:
+            AuthEndpoint:
+              type: boolean
+            Enable:
+              type: boolean
+            Id:
+              type: boolean
+            Scope:
+              type: boolean
+            Secret:
+              type: boolean
+            TokenEndpoint:
+              type: boolean
+            UserApiEndpoint:
+              type: boolean
+          type: object
+        GoogleSettings:
+          properties:
+            AuthEndpoint:
+              type: boolean
+            Enable:
+              type: boolean
+            Id:
+              type: boolean
+            Scope:
+              type: boolean
+            Secret:
+              type: boolean
+            TokenEndpoint:
+              type: boolean
+            UserApiEndpoint:
+              type: boolean
+          type: object
+        LdapSettings:
+          properties:
+            BaseDN:
+              type: boolean
+            BindPassword:
+              type: boolean
+            BindUsername:
+              type: boolean
+            ConnectionSecurity:
+              type: boolean
+            EmailAttribute:
+              type: boolean
+            Enable:
+              type: boolean
+            FirstNameAttribute:
+              type: boolean
+            IdAttribute:
+              type: boolean
+            LastNameAttribute:
+              type: boolean
+            LdapPort:
+              type: boolean
+            LdapServer:
+              type: boolean
+            LoginFieldName:
+              type: boolean
+            MaxPageSize:
+              type: boolean
+            NicknameAttribute:
+              type: boolean
+            PositionAttribute:
+              type: boolean
+            QueryTimeout:
+              type: boolean
+            SkipCertificateVerification:
+              type: boolean
+            SyncIntervalMinutes:
+              type: boolean
+            UserFilter:
+              type: boolean
+            UsernameAttribute:
+              type: boolean
+          type: object
+        LocalizationSettings:
+          properties:
+            AvailableLocales:
+              type: boolean
+            DefaultClientLocale:
+              type: boolean
+            DefaultServerLocale:
+              type: boolean
+          type: object
+        LogSettings:
+          properties:
+            ConsoleLevel:
+              type: boolean
+            EnableConsole:
+              type: boolean
+            EnableDiagnostics:
+              type: boolean
+            EnableFile:
+              type: boolean
+            EnableWebhookDebugging:
+              type: boolean
+            FileLevel:
+              type: boolean
+            FileLocation:
+              type: boolean
+          type: object
+        MetricsSettings:
+          properties:
+            BlockProfileRate:
+              type: boolean
+            Enable:
+              type: boolean
+            ListenAddress:
+              type: boolean
+          type: object
+        NativeAppSettings:
+          properties:
+            AndroidAppDownloadLink:
+              type: boolean
+            AppDownloadLink:
+              type: boolean
+            IosAppDownloadLink:
+              type: boolean
+          type: object
+        Office365Settings:
+          properties:
+            AuthEndpoint:
+              type: boolean
+            Enable:
+              type: boolean
+            Id:
+              type: boolean
+            Scope:
+              type: boolean
+            Secret:
+              type: boolean
+            TokenEndpoint:
+              type: boolean
+            UserApiEndpoint:
+              type: boolean
+          type: object
+        PasswordSettings:
+          properties:
+            Lowercase:
+              type: boolean
+            MinimumLength:
+              type: boolean
+            Number:
+              type: boolean
+            Symbol:
+              type: boolean
+            Uppercase:
+              type: boolean
+          type: object
+        PrivacySettings:
+          properties:
+            ShowEmailAddress:
+              type: boolean
+            ShowFullName:
+              type: boolean
+          type: object
+        RateLimitSettings:
+          properties:
+            Enable:
+              type: boolean
+            MaxBurst:
+              type: boolean
+            MemoryStoreSize:
+              type: boolean
+            PerSec:
+              type: boolean
+            VaryByHeader:
+              type: boolean
+            VaryByRemoteAddr:
+              type: boolean
+          type: object
+        SamlSettings:
+          properties:
+            AssertionConsumerServiceURL:
+              type: boolean
+            EmailAttribute:
+              type: boolean
+            Enable:
+              type: boolean
+            Encrypt:
+              type: boolean
+            FirstNameAttribute:
+              type: boolean
+            IdpCertificateFile:
+              type: boolean
+            IdpDescriptorUrl:
+              type: boolean
+            IdpUrl:
+              type: boolean
+            LastNameAttribute:
+              type: boolean
+            LocaleAttribute:
+              type: boolean
+            LoginButtonText:
+              type: boolean
+            NicknameAttribute:
+              type: boolean
+            PositionAttribute:
+              type: boolean
+            PrivateKeyFile:
+              type: boolean
+            PublicCertificateFile:
+              type: boolean
+            UsernameAttribute:
+              type: boolean
+            Verify:
+              type: boolean
+          type: object
+        ServiceSettings:
+          properties:
+            AllowCorsFrom:
+              type: boolean
+            ConnectionSecurity:
+              type: boolean
+            EnableCommands:
+              type: boolean
+            EnableCustomEmoji:
+              type: boolean
+            EnableDeveloper:
+              type: boolean
+            EnableIncomingWebhooks:
+              type: boolean
+            EnableInsecureOutgoingConnections:
+              type: boolean
+            EnableMultifactorAuthentication:
+              type: boolean
+            EnableOAuthServiceProvider:
+              type: boolean
+            EnableOnlyAdminIntegrations:
+              type: boolean
+            EnableOutgoingWebhooks:
+              type: boolean
+            EnablePostIconOverride:
+              type: boolean
+            EnablePostUsernameOverride:
+              type: boolean
+            EnableSecurityFixAlert:
+              type: boolean
+            EnableTesting:
+              type: boolean
+            EnforceMultifactorAuthentication:
+              type: boolean
+            Forward80To443:
+              type: boolean
+            GoogleDeveloperKey:
+              type: boolean
+            LetsEncryptCertificateCacheFile:
+              type: boolean
+            ListenAddress:
+              type: boolean
+            MaximumLoginAttempts:
+              type: boolean
+            ReadTimeout:
+              type: boolean
+            RestrictCustomEmojiCreation:
+              type: boolean
+            SegmentDeveloperKey:
+              type: boolean
+            SessionCacheInMinutes:
+              type: boolean
+            SessionLengthMobileInDays:
+              type: boolean
+            SessionLengthSSOInDays:
+              type: boolean
+            SessionLengthWebInDays:
+              type: boolean
+            SiteURL:
+              type: boolean
+            TLSCertFile:
+              type: boolean
+            TLSKeyFile:
+              type: boolean
+            UseLetsEncrypt:
+              type: boolean
+            WebserverMode:
+              type: boolean
+            WebsocketPort:
+              type: boolean
+            WebsocketSecurePort:
+              type: boolean
+            WriteTimeout:
+              type: boolean
+          type: object
+        SqlSettings:
+          properties:
+            AtRestEncryptKey:
+              type: boolean
+            DataSource:
+              type: boolean
+            DataSourceReplicas:
+              type: boolean
+            DriverName:
+              type: boolean
+            MaxIdleConns:
+              type: boolean
+            MaxOpenConns:
+              type: boolean
+            Trace:
+              type: boolean
+          type: object
+        SupportSettings:
+          properties:
+            AboutLink:
+              type: boolean
+            HelpLink:
+              type: boolean
+            PrivacyPolicyLink:
+              type: boolean
+            ReportAProblemLink:
+              type: boolean
+            SupportEmail:
+              type: boolean
+            TermsOfServiceLink:
+              type: boolean
+          type: object
+        TeamSettings:
+          properties:
+            CustomBrandText:
+              type: boolean
+            CustomDescriptionText:
+              type: boolean
+            EnableCustomBrand:
+              type: boolean
+            EnableOpenServer:
+              type: boolean
+            EnableTeamCreation:
+              type: boolean
+            EnableUserCreation:
+              type: boolean
+            MaxChannelsPerTeam:
+              type: boolean
+            MaxNotificationsPerChannel:
+              type: boolean
+            MaxUsersPerTeam:
+              type: boolean
+            RestrictCreationToDomains:
+              type: boolean
+            RestrictDirectMessage:
+              type: boolean
+            RestrictPrivateChannelCreation:
+              type: boolean
+            RestrictPrivateChannelDeletion:
+              type: boolean
+            RestrictPrivateChannelManagement:
+              type: boolean
+            RestrictPublicChannelCreation:
+              type: boolean
+            RestrictPublicChannelDeletion:
+              type: boolean
+            RestrictPublicChannelManagement:
+              type: boolean
+            RestrictTeamInvite:
+              type: boolean
+            SiteName:
+              type: boolean
+            UserStatusAwayTimeout:
+              type: boolean
+          type: object
+      type: object
+    Error:
+      properties:
+        details:
+          description: Further details on where and why this error happened.
+          example: Specific details about the error, depending on the case.
+          type: string
+        error:
+          description: A message with the error description.
+          example: Error retrieving the resource.
+          type: string
+      required:
+      - error
+      - details
+      type: object
+    FileInfo:
+      properties:
+        create_at:
+          description: The time in milliseconds a file was created
+          format: int64
+          type: integer
+        delete_at:
+          description: The time in milliseconds a file was deleted
+          format: int64
+          type: integer
+        extension:
+          description: The extension at the end of the file name
+          type: string
+        has_preview_image:
+          description: If this file is an image, whether or not it has a preview-sized version
+          type: boolean
+        height:
+          description: If this file is an image, the height of the file
+          type: integer
+        id:
+          description: The unique identifier for this file
+          type: string
+        mime_type:
+          description: The MIME type of the file
+          type: string
+        name:
+          description: The name of the file
+          type: string
+        post_id:
+          description: If this file is attached to a post, the ID of that post
+          type: string
+        size:
+          description: The size of the file in bytes
+          type: integer
+        update_at:
+          description: The time in milliseconds a file was last updated
+          format: int64
+          type: integer
+        user_id:
+          description: The ID of the user that uploaded this file
+          type: string
+        width:
+          description: If this file is an image, the width of the file
+          type: integer
+      type: object
+    FileInfoList:
+      properties:
+        file_infos:
+          additionalProperties:
+            $ref: '#/components/schemas/FileInfo'
+          type: object
+        next_file_id:
+          description: The ID of next file info. Not omitted when empty or not relevant.
+          type: string
+        order:
+          example:
+          - file_info_id1
+          - file_info_id2
+          items:
+            type: string
+          type: array
+        prev_file_id:
+          description: The ID of previous file info. Not omitted when empty or not relevant.
+          type: string
+      type: object
+    FilesLimits:
+      properties:
+        total_storage:
+          format: int64
+          nullable: true
+          type: integer
+      type: object
+    GlobalDataRetentionPolicy:
+      properties:
+        file_deletion_enabled:
+          description: Indicates whether data retention policy deletion of file attachments is enabled globally.
+          type: boolean
+        file_retention_cutoff:
+          description: The current server timestamp before which files should be deleted.
+          type: integer
+        message_deletion_enabled:
+          description: Indicates whether data retention policy deletion of messages is enabled globally.
+          type: boolean
+        message_retention_cutoff:
+          description: The current server timestamp before which messages should be deleted.
+          type: integer
+      type: object
+    Group:
+      properties:
+        create_at:
+          format: int64
+          type: integer
+        delete_at:
+          format: int64
+          type: integer
+        description:
+          type: string
+        display_name:
+          type: string
+        has_syncables:
+          type: boolean
+        id:
+          type: string
+        name:
+          type: string
+        remote_id:
+          type: string
+        source:
+          type: string
+        update_at:
+          format: int64
+          type: integer
+      type: object
+    GroupSyncableChannel:
+      properties:
+        auto_add:
+          type: boolean
+        channel_id:
+          type: string
+        create_at:
+          format: int64
+          type: integer
+        delete_at:
+          format: int64
+          type: integer
+        group_id:
+          type: string
+        update_at:
+          format: int64
+          type: integer
+      type: object
+    GroupSyncableChannels:
+      properties:
+        auto_add:
+          type: boolean
+        channel_display_name:
+          type: string
+        channel_id:
+          type: string
+        channel_type:
+          type: string
+        create_at:
+          format: int64
+          type: integer
+        delete_at:
+          format: int64
+          type: integer
+        group_id:
+          type: string
+        team_display_name:
+          type: string
+        team_id:
+          type: string
+        team_type:
+          type: string
+        update_at:
+          format: int64
+          type: integer
+      type: object
+    GroupSyncableTeam:
+      properties:
+        auto_add:
+          type: boolean
+        create_at:
+          format: int64
+          type: integer
+        delete_at:
+          format: int64
+          type: integer
+        group_id:
+          type: string
+        team_id:
+          type: string
+        update_at:
+          format: int64
+          type: integer
+      type: object
+    GroupSyncableTeams:
+      properties:
+        auto_add:
+          type: boolean
+        create_at:
+          format: int64
+          type: integer
+        delete_at:
+          format: int64
+          type: integer
+        group_id:
+          type: string
+        team_display_name:
+          type: string
+        team_id:
+          type: string
+        team_type:
+          type: string
+        update_at:
+          format: int64
+          type: integer
+      type: object
+    GroupWithSchemeAdmin:
+      description: group augmented with scheme admin information
+      properties:
+        group:
+          $ref: '#/components/schemas/Group'
+        scheme_admin:
+          type: boolean
+      type: object
+    GroupsAssociatedToChannels:
+      additionalProperties:
+        items:
+          $ref: '#/components/schemas/GroupWithSchemeAdmin'
+        type: array
+      description: a map of channel id(s) to the set of groups that constrain the corresponding channel in a team
+      type: object
+    IncomingWebhook:
+      properties:
+        channel_id:
+          description: The ID of a public channel or private group that receives the webhook payloads
+          type: string
+        create_at:
+          description: The time in milliseconds a incoming webhook was created
+          format: int64
+          type: integer
+        delete_at:
+          description: The time in milliseconds a incoming webhook was deleted
+          format: int64
+          type: integer
+        description:
+          description: The description for this incoming webhook
+          type: string
+        display_name:
+          description: The display name for this incoming webhook
+          type: string
+        id:
+          description: The unique identifier for this incoming webhook
+          type: string
+        update_at:
+          description: The time in milliseconds a incoming webhook was last updated
+          format: int64
+          type: integer
+      type: object
+    InsightUserInformation:
+      properties:
+        create_at:
+          format: int64
+          type: integer
+        first_name:
+          type: string
+        id:
+          type: string
+        last_name:
+          type: string
+        last_picture_update:
+          type: string
+        nickname:
+          type: string
+        username:
+          type: string
+      type: object
+    IntegrationsLimits:
+      properties:
+        enabled:
+          nullable: true
+          type: integer
+      type: object
+    IntegrityCheckResult:
+      description: an object with the result of the integrity check.
+      properties:
+        data:
+          $ref: '#/components/schemas/RelationalIntegrityCheckData'
+        err:
+          description: a string value set in case of error.
+          type: string
+      type: object
+    Invoice:
+      properties:
+        create_at:
+          format: int64
+          type: integer
+        id:
+          type: string
+        item:
+          items:
+            $ref: '#/components/schemas/InvoiceLineItem'
+          type: array
+        number:
+          type: string
+        period_end:
+          format: int64
+          type: integer
+        period_start:
+          format: int64
+          type: integer
+        status:
+          type: string
+        subscription_id:
+          type: string
+        tax:
+          format: int64
+          type: integer
+        total:
+          format: int64
+          type: integer
+      type: object
+    InvoiceLineItem:
+      properties:
+        description:
+          type: string
+        metadata:
+          items:
+            type: string
+          type: array
+        price_id:
+          type: string
+        price_per_unit:
+          format: int64
+          type: integer
+        quantity:
+          format: int64
+          type: integer
+        total:
+          format: int64
+          type: integer
+      type: object
+    Job:
+      properties:
+        create_at:
+          description: The time at which the job was created
+          format: int64
+          type: integer
+        data:
+          description: A freeform data field containing additional information about the job
+          type: object
+        id:
+          description: The unique id of the job
+          type: string
+        last_activity_at:
+          description: The last time at which the job had activity
+          format: int64
+          type: integer
+        progress:
+          description: The progress (as a percentage) of the job
+          type: integer
+        start_at:
+          description: The time at which the job was started
+          format: int64
+          type: integer
+        status:
+          description: The status of the job
+          type: string
+        type:
+          description: The type of job
+          type: string
+      type: object
+    KnownUsers:
+      properties:
+        items:
+          type: string
+      type: array
+    LDAPGroup:
+      description: A LDAP group
+      properties:
+        has_syncables:
+          type: boolean
+        mattermost_group_id:
+          type: string
+        name:
+          type: string
+        primary_key:
+          type: string
+      type: object
+    LDAPGroupsPaged:
+      description: A paged list of LDAP groups
+      properties:
+        count:
+          description: Total number of groups
+          type: number
+        groups:
+          items:
+            $ref: '#/components/schemas/LDAPGroup'
+          type: array
+      type: object
+    LicenseRenewalLink:
+      properties:
+        renewal_link:
+          description: License renewal link
+          type: string
+      type: object
+    MarketplacePlugin:
+      properties:
+        download_url:
+          description: URL to download the plugin.
+          type: string
+        homepage_url:
+          description: URL that leads to the homepage of the plugin.
+          type: string
+        icon_data:
+          description: Base64 encoding of a plugin icon SVG.
+          type: string
+        installed_version:
+          description: Version number of the already installed plugin, if any.
+          type: string
+        labels:
+          description: A list of the plugin labels.
+          items:
+            type: string
+          type: array
+        manifest:
+          $ref: '#/components/schemas/PluginManifest'
+        release_notes_url:
+          description: URL that leads to the release notes of the plugin.
+          type: string
+        signature:
+          description: Base64 encoded signature of the plugin.
+          type: string
+      type: object
+    MessagesLimits:
+      properties:
+        history:
+          nullable: true
+          type: integer
+      type: object
+    NewTeamMember:
+      properties:
+        create_at:
+          description: The creation timestamp of the team member record.
+          type: integer
+        first_name:
+          type: string
+        id:
+          description: The user's ID.
+          type: string
+        last_name:
+          type: string
+        nickname:
+          type: string
+        position:
+          description: The user's position field value.
+          type: string
+        username:
+          type: string
+      type: object
+    NewTeamMembersList:
+      properties:
+        has_next:
+          description: Indicates if there is another page of new team members that can be fetched.
+          type: boolean
+        items:
+          description: List of new team members.
+          items:
+            $ref: '#/components/schemas/NewTeamMember'
+          type: array
+        total_count:
+          description: The total count of new team members for the given time range.
+          type: integer
+      type: object
+    Notice:
+      properties:
+        action:
+          description: Optional action to perform on action button click. (defaults to closing the notice)
+          type: string
+        actionParam:
+          description: "Optional action parameter. \nExample: {\"action\": \"url\", actionParam: \"/console/some-page\"}"
+          type: string
+        actionText:
+          description: Optional override for the action button text (defaults to OK)
+          type: string
+        description:
+          description: Notice content. Use {{Mattermost}} instead of plain text to support white-labeling. Text supports Markdown.
+          type: string
+        id:
+          description: Notice ID
+          type: string
+        image:
+          description: URL of image to display
+          type: string
+        sysAdminOnly:
+          description: Does this notice apply only to sysadmins
+          type: boolean
+        teamAdminOnly:
+          description: Does this notice apply only to team admins
+          type: boolean
+        title:
+          description: Notice title. Use {{Mattermost}} instead of plain text to support white-labeling. Text supports Markdown.
+          type: string
+      type: object
+    OAuthApp:
+      properties:
+        callback_urls:
+          description: A list of callback URLs for the appliation
+          items:
+            type: string
+          type: array
+        client_secret:
+          description: The client secret of the application
+          type: string
+        create_at:
+          description: The time of registration for the application
+          format: int64
+          type: integer
+        description:
+          description: A short description of the application
+          type: string
+        homepage:
+          description: A link to the website of the application
+          type: string
+        icon_url:
+          description: A URL to an icon to display with the application
+          type: string
+        id:
+          description: The client id of the application
+          type: string
+        is_trusted:
+          description: Set this to `true` to skip asking users for permission
+          type: boolean
+        name:
+          description: The name of the client application
+          type: string
+        update_at:
+          description: The last time of update for the application
+          format: int64
+          type: integer
+      type: object
+    OpenGraph:
+      description: OpenGraph metadata of a webpage
+      properties:
+        article:
+          description: Article object used in OpenGraph metadata of a webpage, if type is article
+          properties:
+            authors:
+              items:
+                properties:
+                  first_name:
+                    type: string
+                  gender:
+                    type: string
+                  last_name:
+                    type: string
+                  username:
+                    type: string
+                type: object
+              type: array
+            expiration_time:
+              type: string
+            modified_time:
+              type: string
+            published_time:
+              type: string
+            section:
+              type: string
+            tags:
+              items:
+                type: string
+              type: array
+          type: object
+        audios:
+          items:
+            description: Audio object used in OpenGraph metadata of a webpage
+            properties:
+              secure_url:
+                type: string
+              type:
+                type: string
+              url:
+                type: string
+            type: object
+          type: array
+        book:
+          description: Book object used in OpenGraph metadata of a webpage, if type is book
+          properties:
+            authors:
+              items:
+                properties:
+                  first_name:
+                    type: string
+                  gender:
+                    type: string
+                  last_name:
+                    type: string
+                  username:
+                    type: string
+                type: object
+              type: array
+            isbn:
+              type: string
+            release_date:
+              type: string
+            tags:
+              items:
+                type: string
+              type: array
+          type: object
+        description:
+          type: string
+        determiner:
+          type: string
+        images:
+          items:
+            description: Image object used in OpenGraph metadata of a webpage
+            properties:
+              height:
+                type: integer
+              secure_url:
+                type: string
+              type:
+                type: string
+              url:
+                type: string
+              width:
+                type: integer
+            type: object
+          type: array
+        locale:
+          type: string
+        locales_alternate:
+          items:
+            type: string
+          type: array
+        profile:
+          properties:
+            first_name:
+              type: string
+            gender:
+              type: string
+            last_name:
+              type: string
+            username:
+              type: string
+          type: object
+        site_name:
+          type: string
+        title:
+          type: string
+        type:
+          type: string
+        url:
+          type: string
+        videos:
+          items:
+            description: Video object used in OpenGraph metadata of a webpage
+            properties:
+              height:
+                type: integer
+              secure_url:
+                type: string
+              type:
+                type: string
+              url:
+                type: string
+              width:
+                type: integer
+            type: object
+          type: array
+      type: object
+    OrderedSidebarCategories:
+      description: List of user's categories with their channels
+      properties:
+        categories:
+          items:
+            $ref: '#/components/schemas/SidebarCategoryWithChannels'
+          type: array
+        order:
+          items:
+            type: string
+          type: array
+      type: object
+    OrphanedRecord:
+      description: an object containing information about an orphaned record.
+      properties:
+        child_id:
+          description: the id of the child relation (table) entry.
+          type: string
+        parent_id:
+          description: the id of the parent relation (table) entry.
+          type: string
+      type: object
+    OutgoingWebhook:
+      properties:
+        callback_urls:
+          description: The URLs to POST the payloads to when the webhook is triggered
+          items:
+            type: string
+          type: array
+        channel_id:
+          description: The ID of a public channel that the webhook watchs
+          type: string
+        content_type:
+          default: application/x-www-form-urlencoded
+          description: The format to POST the data in, either `application/json` or `application/x-www-form-urlencoded`
+          type: string
+        create_at:
+          description: The time in milliseconds a outgoing webhook was created
+          format: int64
+          type: integer
+        creator_id:
+          description: The Id of the user who created the webhook
+          type: string
+        delete_at:
+          description: The time in milliseconds a outgoing webhook was deleted
+          format: int64
+          type: integer
+        description:
+          description: The description for this outgoing webhook
+          type: string
+        display_name:
+          description: The display name for this outgoing webhook
+          type: string
+        id:
+          description: The unique identifier for this outgoing webhook
+          type: string
+        team_id:
+          description: The ID of the team that the webhook watchs
+          type: string
+        trigger_when:
+          description: When to trigger the webhook, `0` when a trigger word is present at all and `1` if the message starts
+            with a trigger word
+          type: integer
+        trigger_words:
+          description: List of words for the webhook to trigger on
+          items:
+            type: string
+          type: array
+        update_at:
+          description: The time in milliseconds a outgoing webhook was last updated
+          format: int64
+          type: integer
+      type: object
+    OwnerInfo:
+      properties:
+        user_id:
+          description: A unique, 26 characters long, alphanumeric identifier for the owner.
+          example: ahz0s61gh275i7z2ag4g1ntvjm
+          type: string
+        username:
+          description: Owner's username.
+          example: aaron.medina
+          type: string
+      required:
+      - user_id
+      - username
+      type: object
+    PaymentMethod:
+      properties:
+        card_brand:
+          type: string
+        exp_month:
+          type: integer
+        exp_year:
+          type: integer
+        last_four:
+          type: integer
+        name:
+          type: string
+        type:
+          type: string
+      type: object
+    PaymentSetupIntent:
+      properties:
+        client_secret:
+          type: string
+        id:
+          type: string
+      type: object
+    Playbook:
+      properties:
+        checklists:
+          description: The stages defined in this playbook.
+          items:
+            $ref: '#/components/schemas/Checklist'
+          type: array
+        create_at:
+          description: The playbook creation timestamp, formatted as the number of milliseconds since the Unix epoch.
+          example: 1602235338837
+          format: int64
+          type: integer
+        create_public_playbook_run:
+          description: A boolean indicating whether the playbook runs created from this playbook should be public or private.
+          example: true
+          type: boolean
+        delete_at:
+          description: The playbook deletion timestamp, formatted as the number of milliseconds since the Unix epoch. It equals
+            0 if the playbook is not deleted.
+          example: 0
+          format: int64
+          type: integer
+        description:
+          description: The description of the playbook.
+          example: A playbook to follow when there is a playbook run regarding the availability of the cloud service.
+          type: string
+        id:
+          description: A unique, 26 characters long, alphanumeric identifier for the playbook.
+          example: iz0g457ikesz55dhxcfa0fk9yy
+          type: string
+        member_ids:
+          description: The identifiers of all the users that are members of this playbook.
+          items:
+            description: User ID of the playbook member.
+            example: ilh6s1j4yefbdhxhtlzt179i6m
+            type: string
+          type: array
+        num_stages:
+          description: The number of stages defined in this playbook.
+          example: 3
+          format: int64
+          type: integer
+        num_steps:
+          description: The total number of steps from all the stages defined in this playbook.
+          example: 18
+          format: int64
+          type: integer
+        team_id:
+          description: The identifier of the team where the playbook is in.
+          example: p03rbi6viyztysbqnkvcqyel2i
+          type: string
+        title:
+          description: The title of the playbook.
+          example: Cloud PlaybookRuns
+          type: string
+      type: object
+    PlaybookAutofollows:
+      properties:
+        items:
+          description: The user IDs of who marked this playbook to auto-follow.
+          items:
+            type: string
+          type: array
+        total_count:
+          description: The total number of users who marked this playbook to auto-follow runs.
+          example: 12
+          format: int32
+          type: integer
+      type: object
+    PlaybookList:
+      properties:
+        has_more:
+          description: A boolean describing whether there are more pages after the currently returned.
+          example: true
+          type: boolean
+        items:
+          description: The playbooks in this page.
+          items:
+            $ref: '#/components/schemas/Playbook'
+          type: array
+        page_count:
+          description: The total number of pages. This depends on the total number of playbooks in the database and the per_page
+            parameter sent with the request.
+          example: 2
+          format: int32
+          type: integer
+        total_count:
+          description: The total number of playbooks in the list, regardless of the paging.
+          example: 305
+          format: int32
+          type: integer
+      type: object
+    PlaybookRun:
+      properties:
+        active_stage:
+          description: Zero-based index of the currently active stage.
+          example: 1
+          format: int32
+          type: integer
+        active_stage_title:
+          description: The title of the currently active stage.
+          example: Triage issue
+          type: string
+        channel_id:
+          description: The identifier of the playbook run's channel.
+          example: hwrmiyzj3kadcilh3ukfcnsbt6
+          type: string
+        checklists:
+          items:
+            $ref: '#/components/schemas/Checklist'
+          type: array
+        create_at:
+          description: The playbook run creation timestamp, formatted as the number of milliseconds since the Unix epoch.
+          example: 1606807976289
+          format: int64
+          type: integer
+        delete_at:
+          description: The playbook run deletion timestamp, formatted as the number of milliseconds since the Unix epoch.
+            It equals 0 if the playbook run is not deleted.
+          example: 0
+          format: int64
+          type: integer
+        end_at:
+          description: The playbook run finish timestamp, formatted as the number of milliseconds since the Unix epoch. It
+            equals 0 if the playbook run is not finished.
+          example: 0
+          format: int64
+          type: integer
+        id:
+          description: A unique, 26 characters long, alphanumeric identifier for the playbook run.
+          example: mx3xyzdojfgyfdx8sc8of1gdme
+          type: string
+        is_active:
+          description: True if the playbook run is ongoing; false if the playbook run is ended.
+          example: false
+          type: boolean
+        name:
+          description: The name of the playbook run.
+          example: Server down in EU cluster
+          type: string
+        owner_user_id:
+          description: The identifier of the user that is commanding the playbook run.
+          example: bqnbdf8uc0a8yz4i39qrpgkvtg
+          type: string
+        playbook_id:
+          description: The identifier of the playbook with from which this playbook run was created.
+          example: 0y4a0ntte97cxvfont8y84wa7x
+          type: string
+        post_id:
+          description: If the playbook run was created from a post, this field contains the identifier of such post. If not,
+            this field is empty.
+          example: b2ntfcrl4ujivl456ab4b3aago
+          type: string
+        summary:
+          description: The summary of the playbook run.
+          example: There is one server in the EU cluster that is not responding since April 12.
+          type: string
+        team_id:
+          description: The identifier of the team where the playbook run's channel is in.
+          example: 61ji2mpflefup3cnuif80r5rde
+          type: string
+      type: object
+    PlaybookRunList:
+      properties:
+        has_more:
+          description: A boolean describing whether there are more pages after the currently returned.
+          example: true
+          type: boolean
+        items:
+          description: The playbook runs in this page.
+          items:
+            $ref: '#/components/schemas/PlaybookRun'
+          type: array
+        page_count:
+          description: The total number of pages. This depends on the total number of playbook runs in the database and the
+            per_page parameter sent with the request.
+          example: 2
+          format: int32
+          type: integer
+        total_count:
+          description: The total number of playbook runs in the list, regardless of the paging.
+          example: 305
+          format: int32
+          type: integer
+      type: object
+    PlaybookRunMetadata:
+      properties:
+        channel_display_name:
+          description: Display name of the channel associated to the playbook run.
+          example: Server down in EU cluster
+          type: string
+        channel_name:
+          description: Name of the channel associated to the playbook run.
+          example: server-down-in-eu-cluster
+          type: string
+        num_members:
+          description: Number of users that have been members of the playbook run at any point.
+          example: 25
+          format: int64
+          type: integer
+        team_name:
+          description: Name of the team the playbook run is in.
+          example: sre-staff
+          type: string
+        total_posts:
+          description: Number of posts in the channel associated to the playbook run.
+          example: 202
+          format: int64
+          type: integer
+      type: object
+    PluginManifest:
+      properties:
+        backend:
+          description: Deprecated in Mattermost 5.2 release.
+          properties:
+            executable:
+              description: Path to the executable binary.
+              type: string
+          type: object
+        description:
+          description: Description of what the plugin is and does.
+          type: string
+        id:
+          description: Globally unique identifier that represents the plugin.
+          type: string
+        min_server_version:
+          description: 'The minimum Mattermost server version required for the plugin.
+
+
+            Available as server version 5.6.
+
+            '
+          type: string
+        name:
+          description: Name of the plugin.
+          type: string
+        server:
+          properties:
+            executable:
+              description: Path to the executable binary.
+              type: string
+            executables:
+              description: Paths to executable binaries, specifying multiple entry points for different platforms when bundled
+                together in a single plugin.
+              properties:
+                darwin-amd64:
+                  type: string
+                linux-amd64:
+                  type: string
+                windows-amd64:
+                  type: string
+              type: object
+          type: object
+        settings_schema:
+          description: Settings schema used to define the System Console UI for the plugin.
+          type: object
+        version:
+          description: Version number of the plugin.
+          type: string
+        webapp:
+          properties:
+            bundle_path:
+              description: Path to the webapp JavaScript bundle.
+              type: string
+          type: object
+      type: object
+    PluginManifestWebapp:
+      properties:
+        id:
+          description: Globally unique identifier that represents the plugin.
+          type: string
+        version:
+          description: Version number of the plugin.
+          type: string
+        webapp:
+          properties:
+            bundle_path:
+              description: Path to the webapp JavaScript bundle.
+              type: string
+          type: object
+      type: object
+    PluginStatus:
+      properties:
+        cluster_id:
+          description: ID of the cluster in which plugin is running
+          type: string
+        description:
+          description: Description of what the plugin is and does.
+          type: string
+        name:
+          description: Name of the plugin.
+          type: string
+        plugin_id:
+          description: Globally unique identifier that represents the plugin.
+          type: string
+        plugin_path:
+          description: Path to the plugin on the server
+          type: string
+        state:
+          description: State of the plugin
+          enum:
+          - NotRunning
+          - Starting
+          - Running
+          - FailedToStart
+          - FailedToStayRunning
+          - Stopping
+          type: number
+        version:
+          description: Version number of the plugin.
+          type: string
+      type: object
+    Post:
+      properties:
+        channel_id:
+          type: string
+        create_at:
+          description: The time in milliseconds a post was created
+          format: int64
+          type: integer
+        delete_at:
+          description: The time in milliseconds a post was deleted
+          format: int64
+          type: integer
+        edit_at:
+          format: int64
+          type: integer
+        file_ids:
+          items:
+            type: string
+          type: array
+        hashtag:
+          type: string
+        id:
+          type: string
+        message:
+          type: string
+        metadata:
+          $ref: '#/components/schemas/PostMetadata'
+        original_id:
+          type: string
+        pending_post_id:
+          type: string
+        props:
+          type: object
+        root_id:
+          type: string
+        type:
+          type: string
+        update_at:
+          description: The time in milliseconds a post was last updated
+          format: int64
+          type: integer
+        user_id:
+          type: string
+      type: object
+    PostAcknowledgement:
+      properties:
+        acknowledged_at:
+          description: The time in milliseconds in which this acknowledgement was made.
+          format: int64
+          type: integer
+        post_id:
+          description: The ID of the post to which this acknowledgement was made.
+          type: string
+        user_id:
+          description: The ID of the user that made this acknowledgement.
+          type: string
+      type: object
+    PostIdToReactionsMap:
+      additionalProperties:
+        items:
+          $ref: '#/components/schemas/Reaction'
+        type: array
+      type: object
+    PostList:
+      properties:
+        has_next:
+          description: Whether there are more items after this page.
+          type: boolean
+        next_post_id:
+          description: The ID of next post. Not omitted when empty or not relevant.
+          type: string
+        order:
+          example:
+          - post_id1
+          - post_id12
+          items:
+            type: string
+          type: array
+        posts:
+          additionalProperties:
+            $ref: '#/components/schemas/Post'
+          type: object
+        prev_post_id:
+          description: The ID of previous post. Not omitted when empty or not relevant.
+          type: string
+      type: object
+    PostListWithSearchMatches:
+      properties:
+        matches:
+          additionalProperties:
+            items:
+              type: string
+            type: array
+          description: A mapping of post IDs to a list of matched terms within the post. This field will only be populated
+            on servers running version 5.1 or greater with Elasticsearch enabled.
+          example:
+            post_id1:
+            - search match 1
+            - search match 2
+          type: object
+        order:
+          example:
+          - post_id1
+          - post_id12
+          items:
+            type: string
+          type: array
+        posts:
+          additionalProperties:
+            $ref: '#/components/schemas/Post'
+          type: object
+      type: object
+    PostMetadata:
+      description: Additional information used to display a post.
+      properties:
+        acknowledgements:
+          description: 'Any acknowledgements made to this point.
+
+            '
+          items:
+            $ref: '#/components/schemas/PostAcknowledgement'
+          type: array
+        embeds:
+          description: 'Information about content embedded in the post including OpenGraph previews, image link previews,
+            and message attachments. This field will be null if the post does not contain embedded content.
+
+            '
+          items:
+            properties:
+              data:
+                description: 'Any additional information about the embedded content. Only used at this time to store OpenGraph
+                  metadata.
+
+                  This field will be null for non-OpenGraph embeds.
+
+                  '
+                type: object
+              type:
+                description: The type of content that is embedded in this point.
+                enum:
+                - image
+                - message_attachment
+                - opengraph
+                - link
+                type: string
+              url:
+                description: The URL of the embedded content, if one exists.
+                type: string
+            type: object
+          type: array
+        emojis:
+          description: 'The custom emojis that appear in this point or have been used in reactions to this post. This field
+            will be null if the post does not contain custom emojis.
+
+            '
+          items:
+            $ref: '#/components/schemas/Emoji'
+          type: array
+        files:
+          description: 'The FileInfo objects for any files attached to the post. This field will be null if the post does
+            not have any file attachments.
+
+            '
+          items:
+            $ref: '#/components/schemas/FileInfo'
+          type: array
+        images:
+          description: 'An object mapping the URL of an external image to an object containing the dimensions of that image.
+            This field will be null if the post or its embedded content does not reference any external images.
+
+            '
+          items:
+            properties:
+              height:
+                type: integer
+              width:
+                type: integer
+            type: object
+          type: object
+        priority:
+          description: 'Post priority set for this post. This field will be null if no priority metadata has been set.
+
+            '
+          properties:
+            priority:
+              description: The priority label of a post, could be either empty, important, or urgent.
+              type: string
+            requested_ack:
+              description: Whether the post author has requested for acknowledgements or not.
+              type: boolean
+          type: object
+        reactions:
+          description: 'Any reactions made to this point. This field will be null if no reactions have been made to this post.
+
+            '
+          items:
+            $ref: '#/components/schemas/Reaction'
+          type: array
+      type: object
+    PostsUsage:
+      properties:
+        count:
+          description: Total no. of posts
+          type: number
+      type: object
+    Preference:
+      properties:
+        category:
+          type: string
+        name:
+          type: string
+        user_id:
+          description: The ID of the user that owns this preference
+          type: string
+        value:
+          type: string
+      type: object
+    Product:
+      properties:
+        add_ons:
+          items:
+            $ref: '#/components/schemas/AddOn'
+          type: array
+        description:
+          type: string
+        id:
+          type: string
+        name:
+          type: string
+        price_per_seat:
+          type: string
+      type: object
+    ProductLimits:
+      properties:
+        boards:
+          $ref: '#/components/schemas/BoardsLimits'
+          nullable: true
+        files:
+          $ref: '#/components/schemas/FilesLimits'
+          nullable: true
+        integrations:
+          $ref: '#/components/schemas/IntegrationsLimits'
+          nullable: true
+        messages:
+          $ref: '#/components/schemas/MessagesLimits'
+          nullable: true
+        teams:
+          $ref: '#/components/schemas/TeamsLimits'
+          nullable: true
+      type: object
+    PropertyField:
+      properties:
+        attrs:
+          additionalProperties: true
+          description: Additional attributes for the property field (options for select fields, visibility, etc.).
+          example:
+            options:
+            - color: '#ff0000'
+              id: opt1
+              name: High
+            sortOrder: 1
+            visibility: when_set
+          type: object
+        create_at:
+          description: The property field creation timestamp, formatted as the number of milliseconds since the Unix epoch.
+          example: 1602235338837
+          format: int64
+          type: integer
+        delete_at:
+          description: The property field deletion timestamp, formatted as the number of milliseconds since the Unix epoch.
+            It equals 0 if not deleted.
+          example: 0
+          format: int64
+          type: integer
+        description:
+          description: The description of the property field.
+          example: Issue priority level
+          type: string
+        id:
+          description: A unique, 26 characters long, alphanumeric identifier for the property field.
+          example: p7fj3k2l5m8n9q1r4s6t8v0w2x
+          type: string
+        name:
+          description: The name of the property field.
+          example: Priority
+          type: string
+        type:
+          description: The type of the property field.
+          enum:
+          - text
+          - select
+          - multiselect
+          example: select
+          type: string
+        update_at:
+          description: The property field update timestamp, formatted as the number of milliseconds since the Unix epoch.
+          example: 1602235338837
+          format: int64
+          type: integer
+      type: object
+    PropertyFieldRequest:
+      properties:
+        attrs:
+          additionalProperties: true
+          description: Additional attributes for the property field.
+          properties:
+            options:
+              description: Available options for select/multiselect fields.
+              items:
+                properties:
+                  color:
+                    description: Color associated with the option.
+                    example: '#ff0000'
+                    type: string
+                  id:
+                    description: Option ID (generated if not provided).
+                    example: opt1
+                    type: string
+                  name:
+                    description: Display name of the option.
+                    example: High
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            parentID:
+              description: Parent field ID for hierarchical fields.
+              example: parent_field_id
+              type: string
+            sortOrder:
+              description: Display order of the field.
+              example: 1
+              type: number
+            visibility:
+              description: When to show this field.
+              enum:
+              - hidden
+              - when_set
+              - always
+              example: when_set
+              type: string
+          type: object
+        name:
+          description: The name of the property field.
+          example: Priority
+          type: string
+        type:
+          description: The type of the property field.
+          enum:
+          - text
+          - select
+          - multiselect
+          example: select
+          type: string
+      required:
+      - name
+      - type
+      type: object
+    PropertyValue:
+      properties:
+        create_at:
+          description: The property value creation timestamp, formatted as the number of milliseconds since the Unix epoch.
+          example: 1602235338837
+          format: int64
+          type: integer
+        delete_at:
+          description: The property value deletion timestamp, formatted as the number of milliseconds since the Unix epoch.
+            It equals 0 if not deleted.
+          example: 0
+          format: int64
+          type: integer
+        field_id:
+          description: The identifier of the property field this value belongs to.
+          example: p7fj3k2l5m8n9q1r4s6t8v0w2x
+          type: string
+        id:
+          description: A unique, 26 characters long, alphanumeric identifier for the property value.
+          example: v8z9a1b2c3d4e5f6g7h8i9j0k1l
+          type: string
+        update_at:
+          description: The property value update timestamp, formatted as the number of milliseconds since the Unix epoch.
+          example: 1602235338837
+          format: int64
+          type: integer
+        value:
+          description: The JSON-encoded value of the property.
+          example: '"High Priority"'
+          format: json
+          type: string
+      type: object
+    PropertyValueRequest:
+      properties:
+        value:
+          description: The JSON-encoded value to set for the property.
+          example: '"High Priority Issue"'
+          format: json
+          type: string
+      required:
+      - value
+      type: object
+    PushNotification:
+      properties:
+        ack_id:
+          type: string
+        badge:
+          type: number
+        category:
+          type: string
+        channel_id:
+          type: string
+        channel_name:
+          type: string
+        cont_ava:
+          type: number
+        device_id:
+          type: string
+        from_webhook:
+          type: string
+        is_id_loaded:
+          type: boolean
+        message:
+          type: string
+        override_icon_url:
+          type: string
+        override_username:
+          type: string
+        platform:
+          type: string
+        post_id:
+          type: string
+        root_id:
+          type: string
+        sender_id:
+          type: string
+        sender_name:
+          type: string
+        server_id:
+          type: string
+        sound:
+          type: string
+        team_id:
+          type: string
+        type:
+          type: string
+        version:
+          type: string
+      type: object
+    Reaction:
+      properties:
+        create_at:
+          description: The time in milliseconds this reaction was made
+          format: int64
+          type: integer
+        emoji_name:
+          description: The name of the emoji that was used for this reaction
+          type: string
+        post_id:
+          description: The ID of the post to which this reaction was made
+          type: string
+        user_id:
+          description: The ID of the user that made this reaction
+          type: string
+      type: object
+    RelationalIntegrityCheckData:
+      description: an object containing the results of a relational integrity check.
+      properties:
+        child_id_attr:
+          description: the name of the attribute (column) containing the child id.
+          type: string
+        child_name:
+          description: the name of the child relation (table).
+          type: string
+        parent_id_attr:
+          description: the name of the attribute (column) containing the parent id.
+          type: string
+        parent_name:
+          description: the name of the parent relation (table).
+          type: string
+        records:
+          description: the list of orphaned records found.
+          items:
+            $ref: '#/components/schemas/OrphanedRecord'
+          type: array
+      type: object
+    RemoteClusterInfo:
+      properties:
+        create_at:
+          description: The time in milliseconds a remote cluster was created
+          format: int64
+          type: integer
+        display_name:
+          description: The display name for the remote cluster
+          type: string
+        last_ping_at:
+          description: The time in milliseconds a remote cluster was last pinged successfully
+          format: int64
+          type: integer
+      type: object
+    RetentionPolicyForChannelList:
+      properties:
+        policies:
+          description: The list of channel policies.
+          items:
+            $ref: '#/components/schemas/DataRetentionPolicyForChannel'
+          type: array
+        total_count:
+          description: The total number of channel policies.
+          type: integer
+      type: object
+    RetentionPolicyForTeamList:
+      properties:
+        policies:
+          description: The list of team policies.
+          items:
+            $ref: '#/components/schemas/DataRetentionPolicyForTeam'
+          type: array
+        total_count:
+          description: The total number of team policies.
+          type: integer
+      type: object
+    Role:
+      properties:
+        description:
+          description: A human readable description of the role.
+          type: string
+        display_name:
+          description: The human readable name for the role.
+          type: string
+        id:
+          description: The unique identifier of the role.
+          type: string
+        name:
+          description: The unique name of the role, used when assigning roles to users/groups in contexts.
+          type: string
+        permissions:
+          description: A list of the unique names of the permissions this role grants.
+          items:
+            type: string
+          type: array
+        scheme_managed:
+          description: indicates if this role is managed by a scheme (true), or is a custom stand-alone role (false).
+          type: boolean
+      type: object
+    SamlCertificateStatus:
+      properties:
+        idp_certificate_file:
+          description: Status is good when `true`
+          type: boolean
+        private_key_file:
+          description: Status is good when `true`
+          type: boolean
+        public_certificate_file:
+          description: Status is good when `true`
+          type: boolean
+      type: object
+    Scheme:
+      properties:
+        create_at:
+          description: The time at which the scheme was created.
+          format: int64
+          type: integer
+        default_channel_admin_role:
+          description: The id of the default channel admin role for this scheme.
+          type: string
+        default_channel_user_role:
+          description: The id of the default channel user role for this scheme.
+          type: string
+        default_team_admin_role:
+          description: The id of the default team admin role for this scheme.
+          type: string
+        default_team_user_role:
+          description: The id of the default team user role for this scheme.
+          type: string
+        delete_at:
+          description: The time at which the scheme was deleted.
+          format: int64
+          type: integer
+        description:
+          description: A human readable description of the scheme.
+          type: string
+        id:
+          description: The unique identifier of the scheme.
+          type: string
+        name:
+          description: The human readable name for the scheme.
+          type: string
+        scope:
+          description: The scope to which this scheme can be applied, either "team" or "channel".
+          type: string
+        update_at:
+          description: The time at which the scheme was last updated.
+          format: int64
+          type: integer
+      type: object
+    Server_Busy:
+      properties:
+        busy:
+          description: True if the server is marked as busy (under high load)
+          type: boolean
+        expires:
+          description: timestamp - number of seconds since Jan 1, 1970 UTC.
+          format: int64
+          type: integer
+      type: object
+    Session:
+      properties:
+        create_at:
+          description: The time in milliseconds a session was created
+          format: int64
+          type: integer
+        device_id:
+          type: string
+        expires_at:
+          description: The time in milliseconds a session will expire
+          format: int64
+          type: integer
+        id:
+          type: string
+        is_oauth:
+          type: boolean
+        last_activity_at:
+          description: The time in milliseconds of the last activity of a session
+          format: int64
+          type: integer
+        props:
+          type: object
+        roles:
+          type: string
+        team_members:
+          items:
+            $ref: '#/components/schemas/TeamMember'
+          type: array
+        token:
+          type: string
+        user_id:
+          type: string
+      type: object
+    SharedChannel:
+      properties:
+        create_at:
+          description: Time in milliseconds that the channel was shared
+          type: integer
+        creator_id:
+          description: Id of the user that shared the channel
+          type: string
+        display_name:
+          description: Channel display name as it appears locally
+          type: string
+        header:
+          type: string
+        home:
+          description: Is this the home cluster for the shared channel
+          type: boolean
+        id:
+          description: Channel id of the shared channel
+          type: string
+        name:
+          description: Channel name as it is shared (may be different than original channel name)
+          type: string
+        purpose:
+          type: string
+        readonly:
+          description: Is this shared channel shared as read only
+          type: boolean
+        remote_id:
+          description: Id of the remote cluster where the shared channel is homed
+          type: string
+        team_id:
+          type: string
+        update_at:
+          description: Time in milliseconds that the shared channel record was last updated
+          type: integer
+      type: object
+    SidebarCategory:
+      description: User's sidebar category
+      properties:
+        display_name:
+          type: string
+        id:
+          type: string
+        team_id:
+          type: string
+        type:
+          enum:
+          - channels
+          - custom
+          - direct_messages
+          - favorites
+          type: string
+        user_id:
+          type: string
+      type: object
+    SidebarCategoryWithChannels:
+      description: User's sidebar category with it's channels
+      properties:
+        channel_ids:
+          items:
+            type: string
+          type: array
+        display_name:
+          type: string
+        id:
+          type: string
+        team_id:
+          type: string
+        type:
+          enum:
+          - channels
+          - custom
+          - direct_messages
+          - favorites
+          type: string
+        user_id:
+          type: string
+      type: object
+    SlackAttachment:
+      properties:
+        AuthorIcon:
+          type: string
+        AuthorLink:
+          type: string
+        AuthorName:
+          type: string
+        Color:
+          type: string
+        Fallback:
+          type: string
+        Fields:
+          items:
+            $ref: '#/components/schemas/SlackAttachmentField'
+          type: array
+        Footer:
+          type: string
+        FooterIcon:
+          type: string
+        Id:
+          type: string
+        ImageURL:
+          type: string
+        Pretext:
+          type: string
+        Text:
+          type: string
+        ThumbURL:
+          type: string
+        Timestamp:
+          description: The timestamp of the slack attachment, either type of string or integer
+          type: string
+        Title:
+          type: string
+        TitleLink:
+          type: string
+      type: object
+    SlackAttachmentField:
+      properties:
+        Short:
+          type: boolean
+        Title:
+          type: string
+        Value:
+          description: The value of the attachment, set as string but capable with golang interface
+          type: string
+      type: object
+    Status:
+      properties:
+        last_activity_at:
+          format: int64
+          type: integer
+        manual:
+          type: boolean
+        status:
+          type: string
+        user_id:
+          type: string
+      type: object
+    StatusOK:
+      properties:
+        status:
+          description: Will contain "ok" if the request was successful and there was nothing else to return
+          type: string
+      type: object
+    StorageUsage:
+      properties:
+        bytes:
+          description: Total file storage usage for the instance in bytes rounded down to the most significant digit
+          type: number
+      type: object
+    Subscription:
+      properties:
+        add_ons:
+          items:
+            type: string
+          type: array
+        create_at:
+          format: int64
+          type: integer
+        customer_id:
+          type: string
+        dns:
+          type: string
+        end_at:
+          format: int64
+          type: integer
+        id:
+          type: string
+        product_id:
+          type: string
+        seats:
+          type: integer
+        start_at:
+          format: int64
+          type: integer
+      type: object
+    SubscriptionStats:
+      properties:
+        is_paid_tier:
+          type: string
+        remaining_seats:
+          type: integer
+      type: object
+    System:
+      properties:
+        name:
+          description: System property name
+          type: string
+        value:
+          description: System property value
+          type: string
+      type: object
+    SystemStatusResponse:
+      properties:
+        AndroidLatestVersion:
+          description: Latest Android version supported
+          type: string
+        AndroidMinVersion:
+          description: Minimum Android version supported
+          type: string
+        CanReceiveNotifications:
+          description: Whether the device id provided can receive notifications ("true", "false" or "unknown"). Included when
+            device_id parameter set.
+          type: string
+        DesktopLatestVersion:
+          description: Latest desktop version supported
+          type: string
+        DesktopMinVersion:
+          description: Minimum desktop version supported
+          type: string
+        IosLatestVersion:
+          description: Latest iOS version supported
+          type: string
+        IosMinVersion:
+          description: Minimum iOS version supported
+          type: string
+        database_status:
+          description: Status of database ("OK" or "UNHEALTHY"). Included when get_server_status parameter set.
+          type: string
+        filestore_status:
+          description: Status of filestore ("OK" or "UNHEALTHY"). Included when get_server_status parameter set.
+          type: string
+        status:
+          description: Status of server ("OK" or "UNHEALTHY"). Included when get_server_status parameter set.
+          type: string
+      type: object
+    Team:
+      properties:
+        allow_open_invite:
+          type: boolean
+        allowed_domains:
+          type: string
+        create_at:
+          description: The time in milliseconds a team was created
+          format: int64
+          type: integer
+        delete_at:
+          description: The time in milliseconds a team was deleted
+          format: int64
+          type: integer
+        description:
+          type: string
+        display_name:
+          type: string
+        email:
+          type: string
+        id:
+          type: string
+        invite_id:
+          type: string
+        name:
+          type: string
+        policy_id:
+          description: The data retention policy to which this team has been assigned. If no such policy exists, or the caller
+            does not have the `sysconsole_read_compliance_data_retention` permission, this field will be null.
+          type: string
+        type:
+          type: string
+        update_at:
+          description: The time in milliseconds a team was last updated
+          format: int64
+          type: integer
+      type: object
+    TeamExists:
+      properties:
+        exists:
+          type: boolean
+      type: object
+    TeamMap:
+      description: A mapping of teamIds to teams.
+      properties:
+        team_id:
+          $ref: '#/components/schemas/Team'
+      type: object
+    TeamMember:
+      properties:
+        delete_at:
+          description: The time in milliseconds that this team member was deleted.
+          type: integer
+        explicit_roles:
+          description: The list of roles explicitly assigned to this team member, as a space separated list of role names.
+            This list does *not* include any roles granted implicitly through permissions schemes.
+          type: string
+        roles:
+          description: The complete list of roles assigned to this team member, as a space-separated list of role names, including
+            any roles granted implicitly through permissions schemes.
+          type: string
+        scheme_admin:
+          description: Whether this team member holds the default admin role defined by the team's permissions scheme.
+          type: boolean
+        scheme_user:
+          description: Whether this team member holds the default user role defined by the team's permissions scheme.
+          type: boolean
+        team_id:
+          description: The ID of the team this member belongs to.
+          type: string
+        user_id:
+          description: The ID of the user this member relates to.
+          type: string
+      type: object
+    TeamStats:
+      properties:
+        active_member_count:
+          type: integer
+        team_id:
+          type: string
+        total_member_count:
+          type: integer
+      type: object
+    TeamUnread:
+      properties:
+        mention_count:
+          type: integer
+        msg_count:
+          type: integer
+        team_id:
+          type: string
+      type: object
+    TeamsLimits:
+      properties:
+        active:
+          nullable: true
+          type: integer
+      type: object
+    TermsOfService:
+      properties:
+        create_at:
+          description: The time at which the terms of service was created.
+          format: int64
+          type: integer
+        id:
+          description: The unique identifier of the terms of service.
+          type: string
+        text:
+          description: The text of terms of service. Supports Markdown.
+          type: string
+        user_id:
+          description: The unique identifier of the user who created these terms of service.
+          type: string
+      type: object
+    Timezone:
+      properties:
+        automaticTimezone:
+          description: This value is set automatically when the "useAutomaticTimezone" is set to "true".
+          type: string
+        manualTimezone:
+          description: Value when setting manually the timezone, i.e. "Europe/Berlin".
+          type: string
+        useAutomaticTimezone:
+          description: Set to "true" to use the browser/system timezone, "false" to set manually. Defaults to "true".
+          type: boolean
+      type: object
+    TopChannel:
+      properties:
+        display_name:
+          type: string
+        id:
+          type: string
+        message_count:
+          description: The number of messages posted in the channel by users over the given time period (not including messages
+            posted by bots).
+          type: string
+        name:
+          type: string
+        team_id:
+          type: string
+        type:
+          type: string
+      type: object
+    TopChannelList:
+      properties:
+        has_next:
+          description: Indicates if there is another page of channels that can be fetched.
+          type: boolean
+        items:
+          description: List of channels.
+          items:
+            $ref: '#/components/schemas/TopChannel'
+          type: array
+      type: object
+    TopDM:
+      properties:
+        outgoing_message_count:
+          format: int64
+          type: integer
+        post_count:
+          format: int64
+          type: integer
+        second_participant:
+          $ref: '#/components/schemas/TopDMInsightUserInformation'
+      type: object
+    TopDMInsightUserInformation:
+      allOf:
+      - $ref: '#/components/schemas/InsightUserInformation'
+      - properties:
+          position:
+            type: string
+        type: object
+    TopDMList:
+      properties:
+        has_next:
+          description: Indicates if there is another page of top DMs that can be fetched.
+          type: boolean
+        items:
+          description: List of top DMs.
+          items:
+            $ref: '#/components/schemas/TopDM'
+          type: array
+      type: object
+    TopReaction:
+      properties:
+        count:
+          description: The number of the times this emoji has been used.
+          format: int64
+          type: integer
+        emoji_name:
+          description: The name of the emoji used for this reaction.
+          type: string
+      type: object
+    TopReactionList:
+      properties:
+        has_next:
+          description: Indicates if there is another page of reactions that can be fetched.
+          type: boolean
+        items:
+          description: List of reactions.
+          items:
+            $ref: '#/components/schemas/TopReaction'
+          type: array
+      type: object
+    TopThread:
+      properties:
+        Participants:
+          items:
+            type: string
+          type: array
+        channel_display_name:
+          type: string
+        channel_id:
+          type: string
+        channel_name:
+          type: string
+        post:
+          $ref: '#/components/schemas/Post'
+        user_information:
+          $ref: '#/components/schemas/InsightUserInformation'
+          description: User who created the post
+      type: object
+    TopThreadList:
+      properties:
+        has_next:
+          description: Indicates if there is another page of top threads that can be fetched.
+          type: boolean
+        items:
+          description: List of top threads.
+          items:
+            $ref: '#/components/schemas/TopThread'
+          type: array
+      type: object
+    TriggerIdReturn:
+      properties:
+        trigger_id:
+          description: The trigger_id returned by the slash command.
+          example: ceenjwsg6tgdzjpofxqemy1aio
+          type: string
+      required:
+      - trigger_id
+      type: object
+    UploadSession:
+      description: an object containing information used to keep track of a file upload.
+      properties:
+        channel_id:
+          description: The ID of the channel to upload to.
+          type: string
+        create_at:
+          description: The time the upload was created in milliseconds.
+          format: int64
+          type: integer
+        file_offset:
+          description: The amount of data uploaded in bytes.
+          format: int64
+          type: integer
+        file_size:
+          description: The size of the file to upload in bytes.
+          format: int64
+          type: integer
+        filename:
+          description: The name of the file to upload.
+          type: string
+        id:
+          description: The unique identifier for the upload.
+          type: string
+        type:
+          description: The type of the upload.
+          enum:
+          - attachment
+          - import
+          type: string
+        user_id:
+          description: The ID of the user performing the upload.
+          type: string
+      type: object
+    User:
+      properties:
+        auth_service:
+          type: string
+        create_at:
+          description: The time in milliseconds a user was created
+          format: int64
+          type: integer
+        delete_at:
+          description: The time in milliseconds a user was deleted
+          format: int64
+          type: integer
+        email:
+          type: string
+        email_verified:
+          type: boolean
+        failed_attempts:
+          type: integer
+        first_name:
+          type: string
+        id:
+          type: string
+        last_name:
+          type: string
+        last_password_update:
+          format: int64
+          type: integer
+        last_picture_update:
+          format: int64
+          type: integer
+        locale:
+          type: string
+        mfa_active:
+          type: boolean
+        nickname:
+          type: string
+        notify_props:
+          $ref: '#/components/schemas/UserNotifyProps'
+        props:
+          type: object
+        roles:
+          type: string
+        terms_of_service_create_at:
+          description: The time in milliseconds the user accepted the terms of service
+          format: int64
+          type: integer
+        terms_of_service_id:
+          description: ID of accepted terms of service, if any. This field is not present if empty.
+          type: string
+        timezone:
+          $ref: '#/components/schemas/Timezone'
+        update_at:
+          description: The time in milliseconds a user was last updated
+          format: int64
+          type: integer
+        username:
+          type: string
+      type: object
+    UserAccessToken:
+      properties:
+        description:
+          description: A description of the token usage
+          type: string
+        id:
+          description: Unique identifier for the token
+          type: string
+        token:
+          description: The token used for authentication
+          type: string
+        user_id:
+          description: The user the token authenticates for
+          type: string
+      type: object
+    UserAccessTokenSanitized:
+      properties:
+        description:
+          description: A description of the token usage
+          type: string
+        id:
+          description: Unique identifier for the token
+          type: string
+        is_active:
+          description: Indicates whether the token is active
+          type: boolean
+        user_id:
+          description: The user the token authenticates for
+          type: string
+      type: object
+    UserAuthData:
+      properties:
+        auth_data:
+          description: Service-specific authentication data
+          type: string
+        auth_service:
+          description: The authentication service such as "email", "gitlab", or "ldap"
+          type: string
+      required:
+      - auth_data
+      - auth_service
+      type: object
+    UserAutocomplete:
+      properties:
+        out_of_channel:
+          description: A special case list of users returned when autocompleting in a specific channel. Omitted when empty
+            or not relevant
+          items:
+            $ref: '#/components/schemas/User'
+          type: array
+        users:
+          description: A list of users that are the main result of the query
+          items:
+            $ref: '#/components/schemas/User'
+          type: array
+      type: object
+    UserAutocompleteInChannel:
+      properties:
+        in_channel:
+          description: A list of user objects in the channel
+          items:
+            $ref: '#/components/schemas/User'
+          type: array
+        out_of_channel:
+          description: A list of user objects not in the channel
+          items:
+            $ref: '#/components/schemas/User'
+          type: array
+      type: object
+    UserAutocompleteInTeam:
+      properties:
+        in_team:
+          description: A list of user objects in the team
+          items:
+            $ref: '#/components/schemas/User'
+          type: array
+      type: object
+    UserNotifyProps:
+      properties:
+        channel:
+          description: Set to "true" to enable channel-wide notifications (@channel, @all, etc.), "false" to disable. Defaults
+            to "true".
+          type: string
+        desktop:
+          description: Set to "all" to receive desktop notifications for all activity, "mention" for mentions and direct messages
+            only, and "none" to disable. Defaults to "all".
+          type: string
+        desktop_sound:
+          description: Set to "true" to enable sound on desktop notifications, "false" to disable. Defaults to "true".
+          type: string
+        email:
+          description: Set to "true" to enable email notifications, "false" to disable. Defaults to "true".
+          type: string
+        first_name:
+          description: Set to "true" to enable mentions for first name. Defaults to "true" if a first name is set, "false"
+            otherwise.
+          type: string
+        mention_keys:
+          description: A comma-separated list of words to count as mentions. Defaults to username and @username.
+          type: string
+        push:
+          description: Set to "all" to receive push notifications for all activity, "mention" for mentions and direct messages
+            only, and "none" to disable. Defaults to "mention".
+          type: string
+      type: object
+    UserTermsOfService:
+      properties:
+        create_at:
+          description: The time in milliseconds that this action was performed.
+          format: int64
+          type: integer
+        terms_of_service_id:
+          description: The unique identifier of the terms of service the action was performed on.
+          type: string
+        user_id:
+          description: The unique identifier of the user who performed this terms of service action.
+          type: string
+      type: object
+    UserThread:
+      description: a thread that user is following
+      properties:
+        id:
+          description: ID of the post that is this thread's root
+          type: string
+        last_reply_at:
+          description: timestamp of the last post to this thread
+          format: int64
+          type: integer
+        last_viewed_at:
+          description: timestamp of the last time the user viewed this thread
+          format: int64
+          type: integer
+        participants:
+          description: list of users participating in this thread. only includes IDs unless 'extended' was set to 'true'
+          items:
+            $ref: '#/components/schemas/Post'
+          type: array
+        post:
+          $ref: '#/components/schemas/Post'
+        reply_count:
+          description: number of replies in this thread
+          type: integer
+      type: object
+    UserThreads:
+      properties:
+        threads:
+          description: Array of threads
+          items:
+            $ref: '#/components/schemas/UserThread'
+          type: array
+        total:
+          description: Total number of threads (used for paging)
+          type: integer
+      type: object
+    UsersStats:
+      properties:
+        total_users_count:
+          type: integer
+      type: object
+    WebhookOnCreationPayload:
+      allOf:
+      - $ref: '#/components/schemas/PlaybookRun'
+      - properties:
+          channel_url:
+            description: Absolute URL to the playbook run's channel.
+            example: https://example.com/ad-1/channels/channel-name
+            type: string
+          details_url:
+            description: Absolute URL to the playbook run's details.
+            example: https://example.com/ad-1/playbooks/runs/playbookRunID
+            type: string
+        type: object
+    WebhookOnStatusUpdatePayload:
+      allOf:
+      - $ref: '#/components/schemas/PlaybookRun'
+      - properties:
+          channel_url:
+            description: Absolute URL to the playbook run's channel.
+            example: https://example.com/ad-1/channels/channel-name
+            type: string
+          details_url:
+            description: Absolute URL to the playbook run's details.
+            example: https://example.com/ad-1/playbooks/runs/playbookRunID
+            type: string
+        type: object
+  securitySchemes:
+    BearerAuth:
+      scheme: bearer
+      type: http
+    bearerAuth:
+      bearerFormat: Token
+      scheme: bearer
+      type: http
+externalDocs:
+  description: Find out more about Mattermost
+  url: https://about.mattermost.com
+info:
+  contact:
+    email: feedback@mattermost.com
+  description: 'There is also a work-in-progress [Postman API reference](https://documenter.getpostman.com/view/4508214/RW8FERUn).
+
+    '
+  termsOfService: https://about.mattermost.com/default-terms/
+  title: Mattermost API Reference
+  version: 4.0.0
+  x-logo:
+    backgroundColor: '#FFFFFF'
+    url: https://mattermost.com/wp-content/uploads/2022/02/logoHorizontal.png
+openapi: 3.0.0
+paths:
+  /api/v4/bots:
+    get:
+      description: 'Get a page of a list of bots.
+
+        ##### Permissions
+
+        Must have `read_bots` permission for bots you are managing, and `read_others_bots` permission for bots others are
+        managing.
+
+        __Minimum server version__: 5.10
+
+        '
+      operationId: GetBots
+      parameters:
+      - description: The page to select.
+        in: query
+        name: page
+        schema:
+          default: 0
+          type: integer
+      - description: The number of users per page. There is a maximum limit of 200 users per page.
+        in: query
+        name: per_page
+        schema:
+          default: 60
+          type: integer
+      - description: If deleted bots should be returned.
+        in: query
+        name: include_deleted
+        schema:
+          type: boolean
+      - description: When true, only orphaned bots will be returned. A bot is consitered orphaned if it's owner has been deactivated.
+        in: query
+        name: only_orphaned
+        schema:
+          type: boolean
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/Bot'
+                type: array
+          description: Bot page retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Get bots
+      tags:
+      - bots
+      x-code-samples:
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$resp = $driver->getBotModel()->getBots([\n    \"page\" => 0,\n    \"per_page\" => 60,\n    \"include_deleted\"\
+          \ => true,\n    \"only_orphaned\" => true,\n]);\n\nif ($resp->getStatusCode() == 200) {\n    $bots = json_decode($resp->getBody());\n\
+          }\n"
+    post:
+      description: 'Create a new bot account on the system. Username is required.
+
+        ##### Permissions
+
+        Must have `create_bot` permission.
+
+        __Minimum server version__: 5.10
+
+        '
+      operationId: CreateBot
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                description:
+                  type: string
+                display_name:
+                  type: string
+                username:
+                  type: string
+              required:
+              - username
+              type: object
+        description: Bot to be created
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Bot'
+          description: Bot creation successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Create a bot
+      tags:
+      - bots
+      x-code-samples:
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$resp = $driver->getBotModel()->createBot([\n    \"username\" => \"userbot\",\n    \"display_name\" => \"AwesomeBot\"\
+          ,\n    \"description\" => \"test bot\"\n]);\n\nif ($resp->getStatusCode() == 200) {\n    $createdBot = json_decode($resp->getBody());\n\
+          }\n"
+  /api/v4/bots/{bot_user_id}:
+    get:
+      description: 'Get a bot specified by its bot id.
+
+        ##### Permissions
+
+        Must have `read_bots` permission for bots you are managing, and `read_others_bots` permission for bots others are
+        managing.
+
+        __Minimum server version__: 5.10
+
+        '
+      operationId: GetBot
+      parameters:
+      - description: Bot user ID
+        in: path
+        name: bot_user_id
+        required: true
+        schema:
+          type: string
+      - description: If deleted bots should be returned.
+        in: query
+        name: include_deleted
+        schema:
+          type: boolean
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Bot'
+          description: Bot successfully retrieved.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Get a bot
+      tags:
+      - bots
+      x-code-samples:
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$botUserID = \"4xp9fdt77pncbef59f4k1qe83o\";\n\n$resp = $driver->getBotModel()->getBot($botUserID, [\n    \"include_deleted\"\
+          \ => true,\n]);\n\nif ($resp->getStatusCode() == 200) {\n    $bot = json_decode($resp->getBody());\n}\n"
+    put:
+      description: "Partially update a bot by providing only the fields you want to update. Omitted fields will not be updated.\
+        \ The fields that can be updated are defined in the request body, all other provided fields will be ignored.\n#####\
+        \ Permissions\nMust have `manage_bots` permission. \n__Minimum server version__: 5.10\n"
+      operationId: PatchBot
+      parameters:
+      - description: Bot user ID
+        in: path
+        name: bot_user_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                description:
+                  type: string
+                display_name:
+                  type: string
+                username:
+                  type: string
+              required:
+              - username
+              type: object
+        description: Bot to be created
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Bot'
+          description: Bot patch successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Patch a bot
+      tags:
+      - bots
+      x-code-samples:
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$botUserID = \"4xp9fdt77pncbef59f4k1qe83o\";\n\n$resp = $driver->getBotModel()->patchBot($botUserID, [\n    \"\
+          username\" => \"userbot2\",\n    \"display_name\" => \"AwesomeBot2\",\n    \"description\" => \"test bot2\"\n]);\n\
+          \nif ($resp->getStatusCode() == 200) {\n    $bot = json_decode($resp->getBody());\n}\n"
+  /api/v4/bots/{bot_user_id}/assign/{user_id}:
+    post:
+      description: "Assign a bot to a specified user.\n##### Permissions\nMust have `manage_bots` permission. \n__Minimum\
+        \ server version__: 5.10\n"
+      operationId: AssignBot
+      parameters:
+      - description: Bot user ID
+        in: path
+        name: bot_user_id
+        required: true
+        schema:
+          type: string
+      - description: The user ID to assign the bot to.
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Bot'
+          description: Bot successfully assigned.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Assign a bot to a user
+      tags:
+      - bots
+      x-code-samples:
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$botUserID = \"4xp9fdt77pncbef59f4k1qe83o\";\n$userID = \"adWv1qPZmHdtxk7Lmqh6RtxWxS\";\n\n$resp = $driver->getBotModel()->assignBotToUser($botUserID,\
+          \ $userID);\n\nif ($resp->getStatusCode() == 200) {\n    $assignedBot = json_decode($resp->getBody());\n}\n"
+  /api/v4/bots/{bot_user_id}/convert_to_user:
+    post:
+      description: 'Convert a bot into a user.
+
+
+        __Minimum server version__: 5.26
+
+
+        ##### Permissions
+
+        Must have `manage_system` permission.
+
+        '
+      operationId: ConvertBotToUser
+      parameters:
+      - description: Bot user ID
+        in: path
+        name: bot_user_id
+        required: true
+        schema:
+          type: string
+      - description: Whether to give the user the system admin role.
+        in: query
+        name: set_system_admin
+        schema:
+          default: false
+          type: boolean
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                email:
+                  type: string
+                first_name:
+                  type: string
+                last_name:
+                  type: string
+                locale:
+                  type: string
+                nickname:
+                  type: string
+                notify_props:
+                  $ref: '#/components/schemas/UserNotifyProps'
+                password:
+                  type: string
+                position:
+                  type: string
+                props:
+                  type: object
+                username:
+                  type: string
+              type: object
+        description: Data to be used in the user creation
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: Bot successfully converted
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Convert a bot into a user
+      tags:
+      - bots
+      - users
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+
+          userId := "BbaYBYDV5IDOZFiJGBSzkw1k5u"
+
+          patch := &model.UserPatch{}
+
+          patch.Email = model.NewString("test@domain.com")
+
+          patch.Username = model.NewString("testUsername")
+
+          patch.Password = model.NewString("password")
+
+
+          user, resp := Client.ConvertBotToUser(userId, userPatch, false)
+
+          '
+  /api/v4/bots/{bot_user_id}/disable:
+    post:
+      description: "Disable a bot.\n##### Permissions\nMust have `manage_bots` permission. \n__Minimum server version__: 5.10\n"
+      operationId: DisableBot
+      parameters:
+      - description: Bot user ID
+        in: path
+        name: bot_user_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Bot'
+          description: Bot successfully disabled.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Disable a bot
+      tags:
+      - bots
+      x-code-samples:
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$botUserID = \"4xp9fdt77pncbef59f4k1qe83o\";\n\n$resp = $driver->getBotModel()->disableBot($botUserID);\n\nif\
+          \ ($resp->getStatusCode() == 200) {\n    $disabledBot = json_decode($resp->getBody());\n}\n"
+  /api/v4/bots/{bot_user_id}/enable:
+    post:
+      description: "Enable a bot.\n##### Permissions\nMust have `manage_bots` permission. \n__Minimum server version__: 5.10\n"
+      operationId: EnableBot
+      parameters:
+      - description: Bot user ID
+        in: path
+        name: bot_user_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Bot'
+          description: Bot successfully enabled.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Enable a bot
+      tags:
+      - bots
+      x-code-samples:
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$botUserID = \"4xp9fdt77pncbef59f4k1qe83o\";\n\n$resp = $driver->getBotModel()->enableBot($botUserID);\n\nif ($resp->getStatusCode()\
+          \ == 200) {\n    $enabledBot = json_decode($resp->getBody());\n}\n"
+  /api/v4/channels:
+    get:
+      description: '##### Permissions
+
+        `manage_system`
+
+        '
+      operationId: GetAllChannels
+      parameters:
+      - description: A group id to exclude channels that are associated with that group via GroupChannel records. This can
+          also be left blank with `not_associated_to_group=`.
+        in: query
+        name: not_associated_to_group
+        schema:
+          type: string
+      - description: The page to select.
+        in: query
+        name: page
+        schema:
+          default: 0
+          type: integer
+      - description: The number of channels per page.
+        in: query
+        name: per_page
+        schema:
+          default: 0
+          type: integer
+      - description: Whether to exclude default channels (ex Town Square, Off-Topic) from the results.
+        in: query
+        name: exclude_default_channels
+        schema:
+          default: false
+          type: boolean
+      - description: Include channels that have been archived. This correlates to the `DeleteAt` flag being set in the database.
+        in: query
+        name: include_deleted
+        schema:
+          default: false
+          type: boolean
+      - description: 'Appends a total count of returned channels inside the response object - ex: `{ "channels": [], "total_count"
+          : 0 }`.      '
+        in: query
+        name: include_total_count
+        schema:
+          default: false
+          type: boolean
+      - description: 'If set to true, channels which are part of a data retention policy will be excluded. The `sysconsole_read_compliance`
+          permission is required to use this parameter.
+
+          __Minimum server version__: 5.35'
+        in: query
+        name: exclude_policy_constrained
+        schema:
+          default: false
+          type: boolean
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChannelListWithTeamData'
+          description: Channel list retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Get a list of all channels
+      tags:
+      - channels
+    post:
+      description: 'Create a new channel.
+
+        ##### Permissions
+
+        If creating a public channel, `create_public_channel` permission is required. If creating a private channel, `create_private_channel`
+        permission is required.
+
+        '
+      operationId: CreateChannel
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                display_name:
+                  description: The non-unique UI name for the channel
+                  type: string
+                header:
+                  description: Markdown-formatted text to display in the header of the channel
+                  type: string
+                name:
+                  description: The unique handle for the channel, will be present in the channel URL
+                  type: string
+                purpose:
+                  description: A short description of the purpose of the channel
+                  type: string
+                team_id:
+                  description: The team ID of the team to create the channel on
+                  type: string
+                type:
+                  description: '''O'' for a public channel, ''P'' for a private channel'
+                  type: string
+              required:
+              - name
+              - display_name
+              - type
+              - team_id
+              type: object
+        description: Channel object to be created
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Channel'
+          description: Channel creation successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Create a channel
+      tags:
+      - channels
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          channel := &model.Channel{DisplayName: <YOUR CHANNEL DISPLAYNAME>, Name: <YOUR CHANNEL NAME>, Type: <CHANNEL TYPE
+          OPEN/PRIVATE>, TeamId: <YOUR TEAM ID>}
+
+
+          // CreateChannel
+
+          rchannel, resp := Client.CreateChannel(channel)
+
+          '
+  /api/v4/channels/direct:
+    post:
+      description: 'Create a new direct message channel between two users.
+
+        ##### Permissions
+
+        Must be one of the two users and have `create_direct_channel` permission. Having the `manage_system` permission voids
+        the previous requirements.
+
+        '
+      operationId: CreateDirectChannel
+      requestBody:
+        content:
+          application/json:
+            schema:
+              items:
+                type: string
+              maxItems: 2
+              minItems: 2
+              type: array
+        description: The two user ids to be in the direct message
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Channel'
+          description: Direct channel creation successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Create a direct message channel
+      tags:
+      - channels
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          // CreateDirectChannel
+
+          dm, resp := Client.CreateDirectChannel(<ID OF User1>, <ID OF User2>)
+
+          '
+  /api/v4/channels/group:
+    post:
+      description: 'Create a new group message channel to group of users. If the logged in user''s id is not included in the
+        list, it will be appended to the end.
+
+        ##### Permissions
+
+        Must have `create_group_channel` permission.
+
+        '
+      operationId: CreateGroupChannel
+      requestBody:
+        content:
+          application/json:
+            schema:
+              items:
+                type: string
+              type: array
+        description: User ids to be in the group message channel
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Channel'
+          description: Group channel creation successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Create a group message channel
+      tags:
+      - channels
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          userIds := []string{<ID OF User1>, <ID OF User2>, <ID OF User3> ...}
+
+
+          // CreateGroupChannel
+
+          rgc, resp := Client.CreateGroupChannel(userIds)
+
+          '
+  /api/v4/channels/group/search:
+    post:
+      description: 'Get a list of group channels for a user which members'' usernames match the search term.
+
+
+        __Minimum server version__: 5.14
+
+        '
+      operationId: SearchGroupChannels
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                term:
+                  description: The search term to match against the members' usernames of the group channels
+                  type: string
+              required:
+              - term
+              type: object
+        description: Search criteria
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/Channel'
+                type: array
+          description: Channels search successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+      summary: Search Group Channels
+      tags:
+      - channels
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          search := &model.ChannelSearch{Term: <MEMBER USERNAME>}
+
+
+          // SearchGroupChannels
+
+          channels, resp := Client.SearchGroupChannels(search)
+
+          '
+  /api/v4/channels/members/{user_id}/view:
+    post:
+      description: 'Perform all the actions involved in viewing a channel. This includes marking channels as read, clearing
+        push notifications, and updating the active channel.
+
+        ##### Permissions
+
+        Must be logged in as user or have `edit_other_users` permission.
+
+
+        __Response only includes `last_viewed_at_times` in Mattermost server 4.3 and newer.__
+
+        '
+      operationId: ViewChannel
+      parameters:
+      - description: User ID to perform the view action for
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                channel_id:
+                  description: The channel ID that is being viewed. Use a blank string to indicate that all channels have
+                    lost focus.
+                  type: string
+                prev_channel_id:
+                  description: The channel ID of the previous channel, used when switching channels. Providing this ID will
+                    cause push notifications to clear on the channel being switched to.
+                  type: string
+              required:
+              - channel_id
+              type: object
+        description: Paremeters affecting how and which channels to view
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  last_viewed_at_times:
+                    description: A JSON object mapping channel IDs to the channel view times
+                    type: object
+                  status:
+                    description: Value should be "OK" if successful
+                    type: string
+                type: object
+          description: Channel view successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: View channel
+      tags:
+      - channels
+      x-code-samples:
+      - lang: Go
+        source: "import \"github.com/mattermost/mattermost-server/v5/model\"\nClient := model.NewAPIv4Client(\"https://your-mattermost-url.com\"\
+          )\nClient.Login(\"email@domain.com\", \"Password1\")\n\nview := &model.ChannelView{\n  ChannelId: <CHANNELID>,\n\
+          }\n// ViewChannel\npass, resp := Client.ViewChannel(<USERID>, view)\n"
+  /api/v4/channels/search:
+    post:
+      description: 'Returns all private and open type channels where ''term'' matches on the name, display name, or purpose
+        of
+
+        the channel.
+
+
+        Configured ''default'' channels (ex Town Square and Off-Topic) can be excluded from the results
+
+        with the `exclude_default_channels` boolean parameter.
+
+
+        Channels that are associated (via GroupChannel records) to a given group can be excluded from the results
+
+        with the `not_associated_to_group` parameter and a group id string.
+
+        '
+      operationId: SearchAllChannels
+      parameters:
+      - description: 'Is the request from system_console. If this is set to true, it filters channels by the logged in user.
+
+          '
+        in: query
+        name: system_console
+        required: false
+        schema:
+          default: true
+          type: boolean
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                deleted:
+                  description: 'Filters results to only return deleted / archived channels
+
+
+                    __Minimum server version__: 5.26
+
+                    '
+                  type: boolean
+                exclude_default_channels:
+                  description: Exclude default channels from the results by setting this parameter to true.
+                  type: boolean
+                exclude_group_constrained:
+                  description: 'Filters results to exclude channels constrained to a group
+
+
+                    __Minimum server version__: 5.26
+
+                    '
+                  type: boolean
+                exclude_policy_constrained:
+                  default: false
+                  description: 'If set to true, only channels which do not have a granular retention policy assigned to them
+                    will be returned. The `sysconsole_read_compliance_data_retention` permission is required to use this parameter.
+
+                    __Minimum server version__: 5.35
+
+                    '
+                  type: boolean
+                group_constrained:
+                  description: 'Filters results to only return channels constrained to a group
+
+
+                    __Minimum server version__: 5.26
+
+                    '
+                  type: boolean
+                include_search_by_id:
+                  default: false
+                  description: 'If set to true, returns channels where given search ''term'' matches channel ID.
+
+                    __Minimum server version__: 5.35
+
+                    '
+                  type: boolean
+                not_associated_to_group:
+                  description: A group id to exclude channels that are associated to that group via GroupChannel records.
+                  type: string
+                page:
+                  description: The page number to return, if paginated. If this parameter is not present with the `per_page`
+                    parameter then the results will be returned un-paged.
+                  type: string
+                per_page:
+                  description: The number of entries to return per page, if paginated. If this parameter is not present with
+                    the `page` parameter then the results will be returned un-paged.
+                  type: string
+                private:
+                  description: 'Filters results to only return Private channels, can be used in conjunction with `public`
+                    to return both `private` and `public` channels
+
+
+                    __Minimum server version__: 5.26
+
+                    '
+                  type: boolean
+                public:
+                  description: 'Filters results to only return Public / Open channels, can be used in conjunction with `private`
+                    to return both `public` and `private` channels
+
+
+                    __Minimum server version__: 5.26
+
+                    '
+                  type: boolean
+                team_ids:
+                  description: 'Filters results to channels belonging to the given team ids
+
+
+                    __Minimum server version__: 5.26
+
+                    '
+                  items:
+                    type: string
+                  type: array
+                term:
+                  description: The string to search in the channel name, display name, and purpose.
+                  type: string
+              required:
+              - term
+              type: object
+        description: The search terms and logic to use in the search.
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  channels:
+                    description: The channels that matched the query.
+                    items:
+                      $ref: '#/components/schemas/Channel'
+                    type: array
+                  total_count:
+                    description: The total number of results, regardless of page and per_page requested.
+                    type: number
+                type: object
+          description: Paginated channel response. (Note that the non-paginated response—returned if the request body does
+            not contain both `page` and `per_page` fields—is a simple array of channels.)
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+      summary: Search all private and open type channels across all teams
+      tags:
+      - channels
+  /api/v4/channels/{channel_id}:
+    delete:
+      description: 'Archives a channel. This will set the `deleteAt` to the current timestamp in the database. Soft deleted
+        channels may not be accessible in the user interface. They can be viewed and unarchived in the **System Console >
+        User Management > Channels** based on your license. Direct and group message channels cannot be deleted.
+
+
+        As of server version 5.28, optionally use the `permanent=true` query parameter to permanently delete the channel for
+        compliance reasons. To use this feature `ServiceSettings.EnableAPIChannelDeletion` must be set to `true` in the server''s
+        configuration.  If you permanently delete a channel this action is not recoverable outside of a database backup.
+
+
+        ##### Permissions
+
+        `delete_public_channel` permission if the channel is public,
+
+        `delete_private_channel` permission if the channel is private,
+
+        or have `manage_system` permission.
+
+        '
+      operationId: DeleteChannel
+      parameters:
+      - description: Channel GUID
+        in: path
+        name: channel_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: Channel deletion successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Delete a channel
+      tags:
+      - channels
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          // DeleteChannel
+
+          pass, resp := Client.DeleteChannel(<CHANNELID>)
+
+          '
+    get:
+      description: 'Get channel from the provided channel id string.
+
+        ##### Permissions
+
+        `read_channel` permission for the channel.
+
+        '
+      operationId: GetChannel
+      parameters:
+      - description: Channel GUID
+        in: path
+        name: channel_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Channel'
+          description: Channel retrieval successful
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Get a channel
+      tags:
+      - channels
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          // GetChannel
+
+          channel, resp := Client.GetChannel(<CHANNELID>, "")
+
+          '
+    put:
+      description: 'Update a channel. The fields that can be updated are listed as parameters. Omitted fields will be treated
+        as blanks.
+
+        ##### Permissions
+
+        If updating a public channel, `manage_public_channel_members` permission is required. If updating a private channel,
+        `manage_private_channel_members` permission is required.
+
+        '
+      operationId: UpdateChannel
+      parameters:
+      - description: Channel GUID
+        in: path
+        name: channel_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                display_name:
+                  description: The non-unique UI name for the channel
+                  type: string
+                header:
+                  description: Markdown-formatted text to display in the header of the channel
+                  type: string
+                id:
+                  description: The channel's id, not updatable
+                  type: string
+                name:
+                  description: The unique handle for the channel, will be present in the channel URL
+                  type: string
+                purpose:
+                  description: A short description of the purpose of the channel
+                  type: string
+              required:
+              - id
+              type: object
+        description: Channel object to be updated
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Channel'
+          description: Channel update successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Update a channel
+      tags:
+      - channels
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          channel := &model.Channel{DisplayName: <YOUR CHANNEL NEW DISPLAYNAME>, ChannelId: <CHANNELID>, TeamId: <YOUR TEAM
+          ID>}
+
+
+          // UpdateChannel
+
+          updatedChannel, resp := Client.UpdateChannel(channel)
+
+          '
+  /api/v4/channels/{channel_id}/groups:
+    get:
+      description: 'Retrieve the list of groups associated with a given channel.
+
+
+        ##### Permissions
+
+        Must have `manage_system` permission.
+
+
+        __Minimum server version__: 5.11
+
+        '
+      operationId: GetGroupsByChannel
+      parameters:
+      - description: Channel GUID
+        in: path
+        name: channel_id
+        required: true
+        schema:
+          type: string
+      - description: The page to select.
+        in: query
+        name: page
+        schema:
+          default: 0
+          type: integer
+      - description: The number of groups per page.
+        in: query
+        name: per_page
+        schema:
+          default: 60
+          type: integer
+      - description: Boolean which filters the group entries with the `allow_reference` attribute set.
+        in: query
+        name: filter_allow_reference
+        schema:
+          default: false
+          type: boolean
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/Group'
+                type: array
+          description: Group list retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+      summary: Get channel groups
+      tags:
+      - groups
+  /api/v4/channels/{channel_id}/member_counts_by_group:
+    get:
+      description: 'Returns a set of ChannelMemberCountByGroup objects which contain a `group_id`, `channel_member_count`
+        and a `channel_member_timezones_count`.
+
+        ##### Permissions
+
+        Must have `read_channel` permission for the given channel.
+
+        __Minimum server version__: 5.24
+
+        '
+      operationId: GetChannelMemberCountsByGroup
+      parameters:
+      - description: Channel GUID
+        in: path
+        name: channel_id
+        required: true
+        schema:
+          type: string
+      - description: Defines if member timezone counts should be returned or not
+        in: query
+        name: include_timezones
+        schema:
+          default: false
+          type: boolean
+      responses:
+        '200':
+          description: Successfully returns member counts by group for the given channel.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Channel members counts for each group that has atleast one member in the channel
+      tags:
+      - channels
+      x-code-samples:
+      - lang: curl
+        source: "curl -X GET \\\n  'http://your-mattermost-url.com/api/v4/channels/3wyp678obid8pggjmhmhwpah1r/member_counts_by_group?include_timezones=true'\
+          \ \\\n  -H 'Authorization: Bearer kno8tcdotpbx3dj1gzcbx9jrqy' \\\n  -H 'Content-Type: application/json' \\\n  -H\
+          \ 'X-Requested-With: XMLHttpRequest'\n"
+  /api/v4/channels/{channel_id}/members:
+    get:
+      description: 'Get a page of members for a channel.
+
+        ##### Permissions
+
+        `read_channel` permission for the channel.
+
+        '
+      operationId: GetChannelMembers
+      parameters:
+      - description: Channel GUID
+        in: path
+        name: channel_id
+        required: true
+        schema:
+          type: string
+      - description: The page to select.
+        in: query
+        name: page
+        schema:
+          default: 0
+          type: integer
+      - description: The number of members per page. There is a maximum limit of 200 members.
+        in: query
+        name: per_page
+        schema:
+          default: 60
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/ChannelMember'
+                type: array
+          description: Channel members retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Get channel members
+      tags:
+      - channels
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          // GetChannelMembers
+
+          members, resp := Client.GetChannelMembers(th.BasicChannel.Id, 0, 60, "")
+
+          '
+    post:
+      description: Add a user to a channel by creating a channel member object.
+      operationId: AddChannelMember
+      parameters:
+      - description: The channel ID
+        in: path
+        name: channel_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                post_root_id:
+                  description: The ID of root post where link to add channel member originates
+                  type: string
+                user_id:
+                  description: The ID of user to add into the channel
+                  type: string
+              required:
+              - user_id
+              type: object
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChannelMember'
+          description: Channel member creation successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Add user to channel
+      tags:
+      - channels
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          // AddChannelMember
+
+          cm, resp := Client.AddChannelMember(<CHANNEL ID>, <ID OF USER TO ADD>)
+
+
+          // AddChannelMemberWithRootId
+
+          cm, resp := Client.AddChannelMemberWithRootId(<CHANNEL ID>, <ID OF USER TO ADD>, <POST ROOT ID>)
+
+          '
+  /api/v4/channels/{channel_id}/members/ids:
+    post:
+      description: 'Get a list of channel members based on the provided user ids.
+
+        ##### Permissions
+
+        Must have the `read_channel` permission.
+
+        '
+      operationId: GetChannelMembersByIds
+      parameters:
+      - description: Channel GUID
+        in: path
+        name: channel_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              items:
+                type: string
+              type: array
+        description: List of user ids
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/ChannelMember'
+                type: array
+          description: Channel member list retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Get channel members by ids
+      tags:
+      - channels
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          usersIds := []string{<Id of User1>, <Id of User2>, ...}
+
+
+          // GetChannelMembersByIds
+
+          cm, resp := Client.GetChannelMembersByIds(<CHANNELID>, usersIds)
+
+          '
+  /api/v4/channels/{channel_id}/members/{user_id}:
+    delete:
+      description: 'Delete a channel member, effectively removing them from a channel.
+
+
+        In server version 5.3 and later, channel members can only be deleted from public or private channels.
+
+        ##### Permissions
+
+        `manage_public_channel_members` permission if the channel is public.
+
+        `manage_private_channel_members` permission if the channel is private.
+
+        '
+      operationId: RemoveUserFromChannel
+      parameters:
+      - description: Channel GUID
+        in: path
+        name: channel_id
+        required: true
+        schema:
+          type: string
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: Channel member deletion successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Remove user from channel
+      tags:
+      - channels
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          // RemoveUserFromChannel
+
+          pass, resp := Client.RemoveUserFromChannel(<CHANNELID>, <USERID>)
+
+          '
+    get:
+      description: 'Get a channel member.
+
+        ##### Permissions
+
+        `read_channel` permission for the channel.
+
+        '
+      operationId: GetChannelMember
+      parameters:
+      - description: Channel GUID
+        in: path
+        name: channel_id
+        required: true
+        schema:
+          type: string
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChannelMember'
+          description: Channel member retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Get channel member
+      tags:
+      - channels
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          // GetChannelMember
+
+          member, resp := Client.GetChannelMember(<CHANNELID>, <USERID>, "")
+
+          '
+  /api/v4/channels/{channel_id}/members/{user_id}/notify_props:
+    put:
+      description: 'Update a user''s notification properties for a channel. Only the provided fields are updated.
+
+        ##### Permissions
+
+        Must be logged in as the user or have `edit_other_users` permission.
+
+        '
+      operationId: UpdateChannelNotifyProps
+      parameters:
+      - description: Channel GUID
+        in: path
+        name: channel_id
+        required: true
+        schema:
+          type: string
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChannelNotifyProps'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: Channel notification properties update successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Update channel notifications
+      tags:
+      - channels
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          props := map[string]string{}
+
+          props[model.DESKTOP_NOTIFY_PROP] = model.CHANNEL_NOTIFY_MENTION
+
+          props[model.MARK_UNREAD_NOTIFY_PROP] = model.CHANNEL_MARK_UNREAD_MENTION
+
+
+          // UpdateChannelNotifyProps
+
+          pass, resp := Client.UpdateChannelNotifyProps(<CHANNELID>, <USERID>, props)
+
+          '
+  /api/v4/channels/{channel_id}/members/{user_id}/roles:
+    put:
+      description: 'Update a user''s roles for a channel.
+
+        ##### Permissions
+
+        Must have `manage_channel_roles` permission for the channel.
+
+        '
+      operationId: UpdateChannelRoles
+      parameters:
+      - description: Channel GUID
+        in: path
+        name: channel_id
+        required: true
+        schema:
+          type: string
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                roles:
+                  type: string
+              required:
+              - roles
+              type: object
+        description: Space-delimited channel roles to assign to the user
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: Channel roles update successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Update channel roles
+      tags:
+      - channels
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          // UpdateChannelRoles
+
+          pass, resp := Client.UpdateChannelRoles(<CHANNELID>, <USERIDTOPROMOTE>, "channel_admin channel_user")
+
+          '
+  /api/v4/channels/{channel_id}/members/{user_id}/schemeRoles:
+    put:
+      description: 'Update a channel member''s scheme_admin/scheme_user properties. Typically this should either be `scheme_admin=false,
+        scheme_user=true` for ordinary channel member, or `scheme_admin=true, scheme_user=true` for a channel admin.
+
+        __Minimum server version__: 5.0
+
+        ##### Permissions
+
+        Must be authenticated and have the `manage_channel_roles` permission.
+
+        '
+      operationId: UpdateChannelMemberSchemeRoles
+      parameters:
+      - description: Channel GUID
+        in: path
+        name: channel_id
+        required: true
+        schema:
+          type: string
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                scheme_admin:
+                  type: boolean
+                scheme_user:
+                  type: boolean
+              required:
+              - scheme_admin
+              - scheme_user
+              type: object
+        description: Scheme properties.
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: Channel member's scheme-derived roles updated successfully.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Update the scheme-derived roles of a channel member.
+      tags:
+      - channels
+  /api/v4/channels/{channel_id}/members_minus_group_members:
+    get:
+      description: 'Get the set of users who are members of the channel minus the set of users who are members of the given
+        groups.
+
+        Each user object contains an array of group objects representing the group memberships for that user.
+
+        Each user object contains the boolean fields `scheme_guest`, `scheme_user`, and `scheme_admin` representing the roles
+        that user has for the given channel.
+
+
+        ##### Permissions
+
+        Must have `manage_system` permission.
+
+
+        __Minimum server version__: 5.14
+
+        '
+      operationId: ChannelMembersMinusGroupMembers
+      parameters:
+      - description: Channel GUID
+        in: path
+        name: channel_id
+        required: true
+        schema:
+          type: string
+      - description: A comma-separated list of group ids.
+        in: query
+        name: group_ids
+        required: true
+        schema:
+          default: ''
+          type: string
+      - description: The page to select.
+        in: query
+        name: page
+        schema:
+          default: 0
+          type: integer
+      - description: The number of users per page.
+        in: query
+        name: per_page
+        schema:
+          default: 0
+          type: integer
+      responses:
+        '200':
+          description: Successfully returns users specified by the pagination, and the total_count.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Channel members minus group members.
+      tags:
+      - channels
+      x-code-samples:
+      - lang: curl
+        source: "curl -X GET \\\n  'http://your-mattermost-url.com/api/v4/channels/3wyp678obid8pggjmhmhwpah1r/members_minus_group_members?group_ids=eoezijg8zffgjmch8icy5bjd1e,ugaw6wjc3tfxpcr1eq5u5k8dhe&page=0&per_page=100'\
+          \ \\\n  -H 'Authorization: Bearer kno8tcdotpbx3dj1gzcbx9jrqy' \\\n  -H 'Content-Type: application/json' \\\n  -H\
+          \ 'X-Requested-With: XMLHttpRequest'\n"
+  /api/v4/channels/{channel_id}/moderations:
+    get:
+      description: '##### Permissions
+
+        Must have `manage_system` permission.
+
+
+        __Minimum server version__: 5.22
+
+        '
+      operationId: GetChannelModerations
+      parameters:
+      - description: Channel GUID
+        in: path
+        name: channel_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/ChannelModeration'
+                type: array
+          description: Retreived successfully
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Get information about channel's moderation.
+      tags:
+      - channels
+  /api/v4/channels/{channel_id}/moderations/patch:
+    put:
+      description: '##### Permissions
+
+        Must have `manage_system` permission.
+
+
+        __Minimum server version__: 5.22
+
+        '
+      operationId: PatchChannelModerations
+      parameters:
+      - description: Channel GUID
+        in: path
+        name: channel_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChannelModerationPatch'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/ChannelModeration'
+                type: array
+          description: Patched successfully
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Update a channel's moderation settings.
+      tags:
+      - channels
+  /api/v4/channels/{channel_id}/move:
+    post:
+      description: 'Move a channel to another team.
+
+
+        __Minimum server version__: 5.26
+
+
+        ##### Permissions
+
+
+        Must have `manage_system` permission.
+
+        '
+      operationId: MoveChannel
+      parameters:
+      - description: Channel GUID
+        in: path
+        name: channel_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                force:
+                  description: Remove members those are not member of target team before moving the channel.
+                  type: boolean
+                team_id:
+                  type: string
+              required:
+              - team_id
+              type: object
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Channel'
+          description: Channel move successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Move a channel
+      tags:
+      - channels
+  /api/v4/channels/{channel_id}/patch:
+    put:
+      description: 'Partially update a channel by providing only the fields you want to update. Omitted fields will not be
+        updated. The fields that can be updated are defined in the request body, all other provided fields will be ignored.
+
+        ##### Permissions
+
+        If updating a public channel, `manage_public_channel_members` permission is required. If updating a private channel,
+        `manage_private_channel_members` permission is required.
+
+        '
+      operationId: PatchChannel
+      parameters:
+      - description: Channel GUID
+        in: path
+        name: channel_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                display_name:
+                  description: The non-unique UI name for the channel
+                  type: string
+                header:
+                  description: Markdown-formatted text to display in the header of the channel
+                  type: string
+                name:
+                  description: The unique handle for the channel, will be present in the channel URL
+                  type: string
+                purpose:
+                  description: A short description of the purpose of the channel
+                  type: string
+              type: object
+        description: Channel object to be updated
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Channel'
+          description: Channel patch successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Patch a channel
+      tags:
+      - channels
+      x-code-samples:
+      - lang: Go
+        source: "import \"github.com/mattermost/mattermost-server/v5/model\"\nClient := model.NewAPIv4Client(\"https://your-mattermost-url.com\"\
+          )\nClient.Login(\"email@domain.com\", \"Password1\")\n\npatch := &model.ChannelPatch{\n  Name:        new(string),\n\
+          \  DisplayName: new(string),\n  Header:      new(string),\n  Purpose:     new(string),\n}\n*patch.Name = \"<SOME_NEW_NAME>\"\
+          \n*patch.DisplayName = \"<SOME_NEW_DISPLAYNAME>\"\n*patch.Header = \"<SOME_NEW_HEADER>\"\n*patch.Purpose = \"<SOME_NEW_PURPOSE>\"\
+          \n\n// PatchChannel\nchannel, resp := Client.PatchChannel(<CHANNELID>, patch)\n"
+  /api/v4/channels/{channel_id}/pinned:
+    get:
+      description: Get a list of pinned posts for channel.
+      operationId: GetPinnedPosts
+      parameters:
+      - description: Channel GUID
+        in: path
+        name: channel_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PostList'
+          description: The list of channel pinned posts
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Get a channel's pinned posts
+      tags:
+      - channels
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          // GetPinnedPosts
+
+          posts, resp := Client.GetPinnedPosts(<CHANNELID>, "")
+
+          '
+  /api/v4/channels/{channel_id}/posts:
+    get:
+      description: 'Get a page of posts in a channel. Use the query parameters to modify the behaviour of this endpoint. The
+        parameter `since` must not be used with any of `before`, `after`, `page`, and `per_page` parameters.
+
+        If `since` is used, it will always return all posts modified since that time, ordered by their create time limited
+        till 1000. A caveat with this parameter is that there is no guarantee that the returned posts will be consecutive.
+        It is left to the clients to maintain state and fill any missing holes in the post order.
+
+        ##### Permissions
+
+        Must have `read_channel` permission for the channel.
+
+        '
+      operationId: GetPostsForChannel
+      parameters:
+      - description: The channel ID to get the posts for
+        in: path
+        name: channel_id
+        required: true
+        schema:
+          type: string
+      - description: The page to select
+        in: query
+        name: page
+        schema:
+          default: 0
+          type: integer
+      - description: The number of posts per page
+        in: query
+        name: per_page
+        schema:
+          default: 60
+          type: integer
+      - description: Provide a non-zero value in Unix time milliseconds to select posts modified after that time
+        in: query
+        name: since
+        schema:
+          type: integer
+      - description: A post id to select the posts that came before this one
+        in: query
+        name: before
+        schema:
+          type: string
+      - description: A post id to select the posts that came after this one
+        in: query
+        name: after
+        schema:
+          type: string
+      - description: Whether to include deleted posts or not. Must have system admin permissions.
+        in: query
+        name: include_deleted
+        schema:
+          default: false
+          type: boolean
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PostList'
+          description: Post list retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Get posts for a channel
+      tags:
+      - posts
+  /api/v4/channels/{channel_id}/privacy:
+    put:
+      description: 'Updates channel''s privacy allowing changing a channel from Public to Private and back.
+
+
+        __Minimum server version__: 5.16
+
+
+        ##### Permissions
+
+        `manage_team` permission for the channels team on version < 5.28. `convert_public_channel_to_private` permission for
+        the channel if updating privacy to ''P'' on version >= 5.28. `convert_private_channel_to_public` permission for the
+        channel if updating privacy to ''O'' on version >= 5.28.
+
+        '
+      operationId: UpdateChannelPrivacy
+      parameters:
+      - description: Channel GUID
+        in: path
+        name: channel_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                privacy:
+                  description: 'Channel privacy setting: ''O'' for a public channel, ''P'' for a private channel'
+                  type: string
+              required:
+              - privacy
+              type: object
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Channel'
+          description: Channel conversion successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Update channel's privacy
+      tags:
+      - channels
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          // Update channel''s privacy to Public
+
+          updatedChannel, resp := Client.UpdateChannelPrivacy(<CHANNELID>, model.CHANNEL_OPEN)
+
+
+          // Update channel''s privacy to Private
+
+          updatedChannel, resp := Client.UpdateChannelPrivacy(<CHANNELID>, model.CHANNEL_PRIVATE)
+
+          '
+  /api/v4/channels/{channel_id}/restore:
+    post:
+      description: 'Restore channel from the provided channel id string.
+
+
+        __Minimum server version__: 3.10
+
+
+        ##### Permissions
+
+        `manage_team` permission for the team of the channel.
+
+        '
+      operationId: RestoreChannel
+      parameters:
+      - description: Channel GUID
+        in: path
+        name: channel_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Channel'
+          description: Channel restore successful
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Restore a channel
+      tags:
+      - channels
+  /api/v4/channels/{channel_id}/scheme:
+    put:
+      description: 'Set a channel''s scheme, more specifically sets the scheme_id value of a channel record.
+
+
+        ##### Permissions
+
+        Must have `manage_system` permission.
+
+
+        __Minimum server version__: 4.10
+
+        '
+      operationId: UpdateChannelScheme
+      parameters:
+      - description: Channel GUID
+        in: path
+        name: channel_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                scheme_id:
+                  description: The ID of the scheme.
+                  type: string
+              required:
+              - scheme_id
+              type: object
+        description: Scheme GUID
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: Update channel scheme successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+      summary: Set a channel's scheme
+      tags:
+      - channels
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          channelID := "4xp9fdt77pncbef59f4k1qe83o"
+
+          schemeID := "qjda3stwafbgpqjaxej3k76sga"
+
+          ok, resp := UpdateChannelScheme(channelID, schemeID)
+
+          '
+      - lang: curl
+        source: "curl -X PUT \\\n  https://your-mattermost-url.com/api/v4/channels/4xp9fdt77pncbef59f4k1qe83o/scheme \\\n\
+          \  -H 'Authorization: Bearer frn8fu5rtpyc5m4xy6q3oj4yur' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\"\
+          scheme_id\": \"qjda3stwafbgpqjaxej3k76sga\"}'\n"
+  /api/v4/channels/{channel_id}/stats:
+    get:
+      description: 'Get statistics for a channel.
+
+        ##### Permissions
+
+        Must have the `read_channel` permission.
+
+        '
+      operationId: GetChannelStats
+      parameters:
+      - description: Channel GUID
+        in: path
+        name: channel_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChannelStats'
+          description: Channel statistics retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Get channel statistics
+      tags:
+      - channels
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          // GetChannelStats
+
+          stats, resp := Client.GetChannelStats(<CHANNELID>)
+
+          '
+  /api/v4/channels/{channel_id}/timezones:
+    get:
+      description: 'Get a list of timezones for the users who are in this channel.
+
+
+        __Minimum server version__: 5.6
+
+
+        ##### Permissions
+
+        Must have the `read_channel` permission.
+
+        '
+      operationId: GetChannelMembersTimezones
+      parameters:
+      - description: Channel GUID
+        in: path
+        name: channel_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  type: string
+                type: array
+          description: Timezone retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Get timezones in a channel
+      tags:
+      - channels
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          // GetChannelStats
+
+          stats, resp := Client.GetChannelTimezones(<CHANNELID>)
+
+          '
+  /api/v4/commands:
+    get:
+      description: 'List commands for a team.
+
+        ##### Permissions
+
+        `manage_slash_commands` if need list custom commands.
+
+        '
+      operationId: ListCommands
+      parameters:
+      - description: The team id.
+        in: query
+        name: team_id
+        schema:
+          type: string
+      - description: 'To get only the custom commands. If set to false will get the custom
+
+          if the user have access plus the system commands, otherwise just the system commands.
+
+          '
+        in: query
+        name: custom_only
+        schema:
+          default: false
+          type: boolean
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/Command'
+                type: array
+          description: List Commands retrieve successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+      summary: List commands for a team
+      tags:
+      - commands
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          // ListCommands
+
+          // The second parameter is to set if you want only custom commands (true) or defaults commands (false)
+
+          listCommands, resp := Client.ListCommands(<TEAMID>, true)
+
+          '
+    post:
+      description: 'Create a command for a team.
+
+        ##### Permissions
+
+        `manage_slash_commands` for the team the command is in.
+
+        '
+      operationId: CreateCommand
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                method:
+                  description: '`''P''` for post request, `''G''` for get request'
+                  type: string
+                team_id:
+                  description: Team ID to where the command should be created
+                  type: string
+                trigger:
+                  description: Activation word to trigger the command
+                  type: string
+                url:
+                  description: The URL that the command will make the request
+                  type: string
+              required:
+              - team_id
+              - method
+              - trigger
+              - url
+              type: object
+        description: command to be created
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Command'
+          description: Command creation successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+      summary: Create a command
+      tags:
+      - commands
+      x-code-samples:
+      - lang: Go
+        source: "import \"github.com/mattermost/mattermost-server/v5/model\"\n\nClient := model.NewAPIv4Client(\"https://your-mattermost-url.com\"\
+          )\nClient.Login(\"email@domain.com\", \"Password1\")\n\nnewCmd := &model.Command {\n  TeamId:       <TEAMID>,\n\
+          \  URL:          \"http://nowhere.com\",\n  Method:       model.COMMAND_METHOD_POST,\n  Trigger:      \"trigger\"\
+          ,\n  AutoComplete: false,\n  Description:  \"Description\",\n  DisplayName:  \"Display name\",\n  IconURL:     \
+          \ \"IconURL\",\n  Username:     \"Username\"\n}\n\n// CreateCommand\ncreatedCmd, resp := Client.CreateCommand(newCmd)\n"
+  /api/v4/commands/execute:
+    post:
+      description: 'Execute a command on a team.
+
+        ##### Permissions
+
+        Must have `use_slash_commands` permission for the team the command is in.
+
+        '
+      operationId: ExecuteCommand
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                channel_id:
+                  description: Channel Id where the command will execute
+                  type: string
+                command:
+                  description: The slash command to execute, including parameters. Eg, `'/echo bounces around the room'`
+                  type: string
+              required:
+              - channel_id
+              - command
+              type: object
+        description: command to be executed
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CommandResponse'
+          description: Command execution successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+      summary: Execute a command
+      tags:
+      - commands
+  /api/v4/commands/{command_id}:
+    delete:
+      description: 'Delete a command based on command id string.
+
+        ##### Permissions
+
+        Must have `manage_slash_commands` permission for the team the command is in.
+
+        '
+      operationId: DeleteCommand
+      parameters:
+      - description: ID of the command to delete
+        in: path
+        name: command_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: Command deletion successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Delete a command
+      tags:
+      - commands
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          // DeleteCommand
+
+          ok, resp := Client.DeleteCommand(<COMMANDID>)
+
+          '
+    get:
+      description: 'Get a command definition based on command id string.
+
+        ##### Permissions
+
+        Must have `manage_slash_commands` permission for the team the command is in.
+
+
+        __Minimum server version__: 5.22
+
+        '
+      operationId: GetCommandById
+      parameters:
+      - description: ID of the command to get
+        in: path
+        name: command_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Command'
+          description: Command get successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Get a command
+      tags:
+      - commands
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          // GetCommand
+
+          cmd, resp := Client.GetCommand(<COMMANDID>)
+
+          '
+    put:
+      description: 'Update a single command based on command id string and Command struct.
+
+        ##### Permissions
+
+        Must have `manage_slash_commands` permission for the team the command is in.
+
+        '
+      operationId: UpdateCommand
+      parameters:
+      - description: ID of the command to update
+        in: path
+        name: command_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Command'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Command'
+          description: Command updated successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Update a command
+      tags:
+      - commands
+      x-code-samples:
+      - lang: Go
+        source: "import \"github.com/mattermost/mattermost-server/v5/model\"\n\nClient := model.NewAPIv4Client(\"https://your-mattermost-url.com\"\
+          )\nClient.Login(\"email@domain.com\", \"Password1\")\n\ncmdToUpdate := &model.Command{\n  CreatorId: <USERID>,\n\
+          \  TeamId:    <TEAMID>,\n  URL:       \"<http://nowhere.com/change>\",\n  Trigger:   <NEWTRIGGERNAME>,\n  Id:  \
+          \      <COMMANDID>,\n}\n\n// UpdateCommand\nlistCommands, resp := Client.UpdateCommand(cmdToUpdate)\n"
+  /api/v4/commands/{command_id}/move:
+    put:
+      description: 'Move a command to a different team based on command id string.
+
+        ##### Permissions
+
+        Must have `manage_slash_commands` permission for the team the command is currently in and the destination team.
+
+
+        __Minimum server version__: 5.22
+
+        '
+      operationId: MoveCommand
+      parameters:
+      - description: ID of the command to move
+        in: path
+        name: command_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                team_id:
+                  description: Destination teamId
+                  type: string
+              type: object
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: Command move successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Move a command
+      tags:
+      - commands
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          // MoveCommand
+
+          ok, resp := Client.MoveCommand(<TEAMID>,<COMMANDID>)
+
+          '
+  /api/v4/commands/{command_id}/regen_token:
+    put:
+      description: 'Generate a new token for the command based on command id string.
+
+        ##### Permissions
+
+        Must have `manage_slash_commands` permission for the team the command is in.
+
+        '
+      operationId: RegenCommandToken
+      parameters:
+      - description: ID of the command to generate the new token
+        in: path
+        name: command_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  token:
+                    description: The new token
+                    type: string
+                type: object
+          description: Token generation successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Generate a new token
+      tags:
+      - commands
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          // RegenCommandToken
+
+          newToken, resp := Client.RegenCommandToken(<COMMANDID>)
+
+          '
+  /api/v4/emoji:
+    get:
+      description: 'Get a page of metadata for custom emoji on the system. Since server version 4.7, sort using the `sort`
+        query parameter.
+
+        ##### Permissions
+
+        Must be authenticated.
+
+        '
+      operationId: GetEmojiList
+      parameters:
+      - description: The page to select.
+        in: query
+        name: page
+        schema:
+          default: 0
+          type: integer
+      - description: The number of emojis per page.
+        in: query
+        name: per_page
+        schema:
+          default: 60
+          type: integer
+      - description: Either blank for no sorting or "name" to sort by emoji names. Minimum server version for sorting is 4.7.
+        in: query
+        name: sort
+        schema:
+          default: ''
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Emoji'
+          description: Emoji list retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+      summary: Get a list of custom emoji
+      tags:
+      - emoji
+    post:
+      description: 'Create a custom emoji for the team.
+
+        ##### Permissions
+
+        Must be authenticated.
+
+        '
+      operationId: CreateEmoji
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              properties:
+                emoji:
+                  description: A JSON object containing a `name` field with the name of the emoji and a `creator_id` field
+                    with the id of the authenticated user.
+                  type: string
+                image:
+                  description: A file to be uploaded
+                  format: binary
+                  type: string
+              required:
+              - image
+              - emoji
+              type: object
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Emoji'
+          description: Emoji creation successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '413':
+          $ref: '#/components/responses/TooLarge'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+      summary: Create a custom emoji
+      tags:
+      - emoji
+  /api/v4/emoji/autocomplete:
+    get:
+      description: 'Get a list of custom emoji with names starting with or matching the provided name. Returns a maximum of
+        100 results.
+
+        ##### Permissions
+
+        Must be authenticated.
+
+
+        __Minimum server version__: 4.7
+
+        '
+      operationId: AutocompleteEmoji
+      parameters:
+      - description: The emoji name to search.
+        in: query
+        name: name
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Emoji'
+          description: Emoji list retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+      summary: Autocomplete custom emoji
+      tags:
+      - emoji
+  /api/v4/emoji/name/{emoji_name}:
+    get:
+      description: 'Get some metadata for a custom emoji using its name.
+
+        ##### Permissions
+
+        Must be authenticated.
+
+
+        __Minimum server version__: 4.7
+
+        '
+      operationId: GetEmojiByName
+      parameters:
+      - description: Emoji name
+        in: path
+        name: emoji_name
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Emoji'
+          description: Emoji retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+      summary: Get a custom emoji by name
+      tags:
+      - emoji
+  /api/v4/emoji/search:
+    post:
+      description: 'Search for custom emoji by name based on search criteria provided in the request body. A maximum of 200
+        results are returned.
+
+        ##### Permissions
+
+        Must be authenticated.
+
+
+        __Minimum server version__: 4.7
+
+        '
+      operationId: SearchEmoji
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                prefix_only:
+                  description: Set to only search for names starting with the search term.
+                  type: string
+                term:
+                  description: The term to match against the emoji name.
+                  type: string
+              required:
+              - term
+              type: object
+        description: Search criteria
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/Emoji'
+                type: array
+          description: Emoji list retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+      summary: Search custom emoji
+      tags:
+      - emoji
+  /api/v4/emoji/{emoji_id}:
+    delete:
+      description: 'Delete a custom emoji.
+
+        ##### Permissions
+
+        Must have the `manage_team` or `manage_system` permissions or be the user who created the emoji.
+
+        '
+      operationId: DeleteEmoji
+      parameters:
+      - description: Emoji GUID
+        in: path
+        name: emoji_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Emoji'
+          description: Emoji delete successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+      summary: Delete a custom emoji
+      tags:
+      - emoji
+    get:
+      description: 'Get some metadata for a custom emoji.
+
+        ##### Permissions
+
+        Must be authenticated.
+
+        '
+      operationId: GetEmoji
+      parameters:
+      - description: Emoji GUID
+        in: path
+        name: emoji_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Emoji'
+          description: Emoji retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+      summary: Get a custom emoji
+      tags:
+      - emoji
+  /api/v4/emoji/{emoji_id}/image:
+    get:
+      description: 'Get the image for a custom emoji.
+
+        ##### Permissions
+
+        Must be authenticated.
+
+        '
+      operationId: GetEmojiImage
+      parameters:
+      - description: Emoji GUID
+        in: path
+        name: emoji_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Emoji image retrieval successful
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+      summary: Get custom emoji image
+      tags:
+      - emoji
+  /api/v4/files:
+    post:
+      description: 'Uploads a file that can later be attached to a post.
+
+
+        This request can either be a multipart/form-data request with a channel_id, files and optional
+
+        client_ids defined in the FormData, or it can be a request with the channel_id and filename
+
+        defined as query parameters with the contents of a single file in the body of the request.
+
+
+        Only multipart/form-data requests are supported by server versions up to and including 4.7.
+
+        Server versions 4.8 and higher support both types of requests.
+
+
+        ##### Permissions
+
+        Must have `upload_file` permission.
+
+        '
+      operationId: UploadFile
+      parameters:
+      - description: The ID of the channel that this file will be uploaded to
+        in: query
+        name: channel_id
+        required: false
+        schema:
+          type: string
+      - description: The name of the file to be uploaded
+        in: query
+        name: filename
+        required: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              properties:
+                channel_id:
+                  description: The ID of the channel that this file will be uploaded to
+                  type: string
+                client_ids:
+                  description: A unique identifier for the file that will be returned in the response
+                  type: string
+                files:
+                  description: A file to be uploaded
+                  format: binary
+                  type: string
+              type: object
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                properties:
+                  client_ids:
+                    description: A list of the client_ids that were provided in the request
+                    items:
+                      type: string
+                    type: array
+                  file_infos:
+                    description: A list of file metadata that has been stored in the database
+                    items:
+                      $ref: '#/components/schemas/FileInfo'
+                    type: array
+                type: object
+          description: Corresponding lists of the provided client_ids and the metadata that has been stored in the database
+            for each one
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '413':
+          $ref: '#/components/responses/TooLarge'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+      summary: Upload a file
+      tags:
+      - files
+      x-code-samples:
+      - lang: Go
+        source: "import \"github.com/mattermost/mattermost-server/v5/model\"\n\nClient := model.NewAPIv4Client(\"https://your-mattermost-url.com\"\
+          )\nClient.Login(\"email@domain.com\", \"Password1\")\n\nfile, err := os.Open(\"file.png\")\nif err != nil {\n  fmt.Fprintf(os.Stderr,\
+          \ \"%v\\n\", err)\n}\ndefer file.Close();\n\nbuf := bytes.NewBuffer(nil)\nio.Copy(buf, file)\ndata := buf.Bytes()\n\
+          \nchannelID := \"4xp9fdt77pncbef59f4k1qe83o\"\nfilename := \"file.png\"\n\nfileUploadResponse, response := Client.UploadFile(data,\
+          \ channelID, filename)\n"
+      - lang: Curl
+        source: 'curl -F ''files=@PATH/TO/LOCAL/FILE'' \
+
+          -F ''channel_id=CHANNEL_ID'' \
+
+          --header ''authorization: Bearer c49adc55z3f53ck7xtp8ebq1ir''
+
+          https://your-mattermost-url.com/api/v4/files
+
+          '
+  /api/v4/files/{file_id}:
+    get:
+      description: 'Gets a file that has been uploaded previously.
+
+        ##### Permissions
+
+        Must have `read_channel` permission or be uploader of the file.
+
+        '
+      operationId: GetFile
+      parameters:
+      - description: The ID of the file to get
+        in: path
+        name: file_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AppError'
+          description: Do not have appropriate permissions
+          headers:
+            First-Inaccessible-File-Time:
+              description: This header is included with the value "1" if the file is past the cloud's plan limit.
+              schema:
+                type: integer
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+      summary: Get a file
+      tags:
+      - files
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          fileID := "4xp9fdt77pncbef59f4k1qe83o"
+
+
+          data, resp := Client.GetFile(fileID)
+
+          '
+  /api/v4/files/{file_id}/info:
+    get:
+      description: 'Gets a file''s info.
+
+        ##### Permissions
+
+        Must have `read_channel` permission or be uploader of the file.
+
+        '
+      operationId: GetFileInfo
+      parameters:
+      - description: The ID of the file info to get
+        in: path
+        name: file_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FileInfo'
+          description: The stored metadata for the given file
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AppError'
+          description: Do not have appropriate permissions
+          headers:
+            First-Inaccessible-File-Time:
+              description: This header is included with the value "1" if the file is past the cloud's plan limit.
+              schema:
+                type: integer
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+      summary: Get metadata for a file
+      tags:
+      - files
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          fileID := "4xp9fdt77pncbef59f4k1qe83o"
+
+
+          info, resp := Client.GetFileInfo(fileID)
+
+          '
+  /api/v4/files/{file_id}/link:
+    get:
+      description: 'Gets a public link for a file that can be accessed without logging into Mattermost.
+
+        ##### Permissions
+
+        Must have `read_channel` permission or be uploader of the file.
+
+        '
+      operationId: GetFileLink
+      parameters:
+      - description: The ID of the file to get a link for
+        in: path
+        name: file_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  link:
+                    type: string
+                type: object
+          description: A publicly accessible link to the given file
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AppError'
+          description: Do not have appropriate permissions
+          headers:
+            First-Inaccessible-File-Time:
+              description: This header is included with the value "1" if the file is past the cloud's plan limit.
+              schema:
+                type: integer
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+      summary: Get a public file link
+      tags:
+      - files
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          fileID := "4xp9fdt77pncbef59f4k1qe83o"
+
+
+          data, resp := Client.GetFileLink(fileID)
+
+          '
+  /api/v4/files/{file_id}/preview:
+    get:
+      description: 'Gets a file''s preview.
+
+        ##### Permissions
+
+        Must have `read_channel` permission or be uploader of the file.
+
+        '
+      operationId: GetFilePreview
+      parameters:
+      - description: The ID of the file to get
+        in: path
+        name: file_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AppError'
+          description: Do not have appropriate permissions
+          headers:
+            First-Inaccessible-File-Time:
+              description: This header is included with the value "1" if the file is past the cloud's plan limit.
+              schema:
+                type: integer
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+      summary: Get a file's preview
+      tags:
+      - files
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          fileID := "4xp9fdt77pncbef59f4k1qe83o"
+
+
+          data, resp := Client.GetFilePreview(fileID)
+
+          '
+  /api/v4/files/{file_id}/public:
+    get:
+      description: '##### Permissions
+
+        No permissions required.
+
+        '
+      operationId: GetFilePublic
+      parameters:
+      - description: The ID of the file to get
+        in: path
+        name: file_id
+        required: true
+        schema:
+          type: string
+      - description: File hash
+        in: query
+        name: h
+        required: true
+        schema:
+          type: string
+      responses:
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AppError'
+          description: Do not have appropriate permissions
+          headers:
+            First-Inaccessible-File-Time:
+              description: This header is included with the value "1" if the file is past the cloud's plan limit.
+              schema:
+                type: integer
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+      summary: Get a public file
+      tags:
+      - files
+  /api/v4/files/{file_id}/thumbnail:
+    get:
+      description: 'Gets a file''s thumbnail.
+
+        ##### Permissions
+
+        Must have `read_channel` permission or be uploader of the file.
+
+        '
+      operationId: GetFileThumbnail
+      parameters:
+      - description: The ID of the file to get
+        in: path
+        name: file_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AppError'
+          description: Do not have appropriate permissions
+          headers:
+            First-Inaccessible-File-Time:
+              description: This header is included with the value "1" if the file is past the cloud's plan limit.
+              schema:
+                type: integer
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+      summary: Get a file's thumbnail
+      tags:
+      - files
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          fileID := "4xp9fdt77pncbef59f4k1qe83o"
+
+
+          data, resp := Client.GetFileThumbnail(fileID)
+
+          '
+  /api/v4/hooks/incoming:
+    get:
+      description: 'Get a page of a list of incoming webhooks. Optionally filter for a specific team using query parameters.
+
+        ##### Permissions
+
+        `manage_webhooks` for the system or `manage_webhooks` for the specific team.
+
+        '
+      operationId: GetIncomingWebhooks
+      parameters:
+      - description: The page to select.
+        in: query
+        name: page
+        schema:
+          default: 0
+          type: integer
+      - description: The number of hooks per page.
+        in: query
+        name: per_page
+        schema:
+          default: 60
+          type: integer
+      - description: The ID of the team to get hooks for.
+        in: query
+        name: team_id
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/IncomingWebhook'
+                type: array
+          description: Incoming webhooks retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: List incoming webhooks
+      tags:
+      - webhooks
+    post:
+      description: 'Create an incoming webhook for a channel.
+
+        ##### Permissions
+
+        `manage_webhooks` for the team the webhook is in.
+
+
+        `manage_others_incoming_webhooks` for the team the webhook is in if the user is different than the requester.
+
+        '
+      operationId: CreateIncomingWebhook
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                channel_id:
+                  description: The ID of a public channel or private group that receives the webhook payloads.
+                  type: string
+                description:
+                  description: The description for this incoming webhook
+                  type: string
+                display_name:
+                  description: The display name for this incoming webhook
+                  type: string
+                icon_url:
+                  description: The profile picture this incoming webhook will use when posting.
+                  type: string
+                user_id:
+                  description: The ID of the owner of the webhook if different than the requester. Required for [local mode](https://docs.mattermost.com/administration/mmctl-cli-tool.html#local-mode).
+                  type: string
+                username:
+                  description: The username this incoming webhook will post as.
+                  type: string
+              required:
+              - channel_id
+              type: object
+        description: Incoming webhook to be created
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IncomingWebhook'
+          description: Incoming webhook creation successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Create an incoming webhook
+      tags:
+      - webhooks
+  /api/v4/hooks/incoming/{hook_id}:
+    delete:
+      description: 'Delete an incoming webhook given the hook id.
+
+        ##### Permissions
+
+        `manage_webhooks` for system or `manage_webhooks` for the specific team or `manage_webhooks` for the channel.
+
+        '
+      operationId: DeleteIncomingWebhook
+      parameters:
+      - description: Incoming webhook GUID
+        in: path
+        name: hook_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: Webhook deletion successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Delete an incoming webhook
+      tags:
+      - webhooks
+    get:
+      description: 'Get an incoming webhook given the hook id.
+
+        ##### Permissions
+
+        `manage_webhooks` for system or `manage_webhooks` for the specific team or `manage_webhooks` for the channel.
+
+        '
+      operationId: GetIncomingWebhook
+      parameters:
+      - description: Incoming Webhook GUID
+        in: path
+        name: hook_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IncomingWebhook'
+          description: Webhook retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Get an incoming webhook
+      tags:
+      - webhooks
+    put:
+      description: 'Update an incoming webhook given the hook id.
+
+        ##### Permissions
+
+        `manage_webhooks` for system or `manage_webhooks` for the specific team or `manage_webhooks` for the channel.
+
+        '
+      operationId: UpdateIncomingWebhook
+      parameters:
+      - description: Incoming Webhook GUID
+        in: path
+        name: hook_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                channel_id:
+                  description: The ID of a public channel or private group that receives the webhook payloads.
+                  type: string
+                description:
+                  description: The description for this incoming webhook
+                  type: string
+                display_name:
+                  description: The display name for this incoming webhook
+                  type: string
+                icon_url:
+                  description: The profile picture this incoming webhook will use when posting.
+                  type: string
+                id:
+                  description: Incoming webhook GUID
+                  type: string
+                username:
+                  description: The username this incoming webhook will post as.
+                  type: string
+              required:
+              - id
+              - channel_id
+              - display_name
+              - description
+              type: object
+        description: Incoming webhook to be updated
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IncomingWebhook'
+          description: Webhook update successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Update an incoming webhook
+      tags:
+      - webhooks
+  /api/v4/hooks/outgoing:
+    get:
+      description: 'Get a page of a list of outgoing webhooks. Optionally filter for a specific team or channel using query
+        parameters.
+
+        ##### Permissions
+
+        `manage_webhooks` for the system or `manage_webhooks` for the specific team/channel.
+
+        '
+      operationId: GetOutgoingWebhooks
+      parameters:
+      - description: The page to select.
+        in: query
+        name: page
+        schema:
+          default: 0
+          type: integer
+      - description: The number of hooks per page.
+        in: query
+        name: per_page
+        schema:
+          default: 60
+          type: integer
+      - description: The ID of the team to get hooks for.
+        in: query
+        name: team_id
+        schema:
+          type: string
+      - description: The ID of the channel to get hooks for.
+        in: query
+        name: channel_id
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/OutgoingWebhook'
+                type: array
+          description: Outgoing webhooks retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: List outgoing webhooks
+      tags:
+      - webhooks
+    post:
+      description: 'Create an outgoing webhook for a team.
+
+        ##### Permissions
+
+        `manage_webhooks` for the team the webhook is in.
+
+
+        `manage_others_outgoing_webhooks` for the team the webhook is in if the user is different than the requester.
+
+        '
+      operationId: CreateOutgoingWebhook
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                callback_urls:
+                  description: The URLs to POST the payloads to when the webhook is triggered
+                  items:
+                    type: string
+                  type: array
+                channel_id:
+                  description: The ID of a public channel that the webhook watchs
+                  type: string
+                content_type:
+                  default: application/x-www-form-urlencoded
+                  description: The format to POST the data in, either `application/json` or `application/x-www-form-urlencoded`
+                  type: string
+                creator_id:
+                  description: The ID of the owner of the webhook if different than the requester. Required in [local mode](https://docs.mattermost.com/administration/mmctl-cli-tool.html#local-mode).
+                  type: string
+                description:
+                  description: The description for this outgoing webhook
+                  type: string
+                display_name:
+                  description: The display name for this outgoing webhook
+                  type: string
+                team_id:
+                  description: The ID of the team that the webhook watchs
+                  type: string
+                trigger_when:
+                  description: When to trigger the webhook, `0` when a trigger word is present at all and `1` if the message
+                    starts with a trigger word
+                  type: integer
+                trigger_words:
+                  description: List of words for the webhook to trigger on
+                  items:
+                    type: string
+                  type: array
+              required:
+              - team_id
+              - display_name
+              - trigger_words
+              - callback_urls
+              type: object
+        description: Outgoing webhook to be created
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OutgoingWebhook'
+          description: Outgoing webhook creation successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Create an outgoing webhook
+      tags:
+      - webhooks
+  /api/v4/hooks/outgoing/{hook_id}:
+    delete:
+      description: 'Delete an outgoing webhook given the hook id.
+
+        ##### Permissions
+
+        `manage_webhooks` for system or `manage_webhooks` for the specific team or `manage_webhooks` for the channel.
+
+        '
+      operationId: DeleteOutgoingWebhook
+      parameters:
+      - description: Outgoing webhook GUID
+        in: path
+        name: hook_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: Webhook deletion successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Delete an outgoing webhook
+      tags:
+      - webhooks
+    get:
+      description: 'Get an outgoing webhook given the hook id.
+
+        ##### Permissions
+
+        `manage_webhooks` for system or `manage_webhooks` for the specific team or `manage_webhooks` for the channel.
+
+        '
+      operationId: GetOutgoingWebhook
+      parameters:
+      - description: Outgoing webhook GUID
+        in: path
+        name: hook_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OutgoingWebhook'
+          description: Outgoing webhook retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Get an outgoing webhook
+      tags:
+      - webhooks
+    put:
+      description: 'Update an outgoing webhook given the hook id.
+
+        ##### Permissions
+
+        `manage_webhooks` for system or `manage_webhooks` for the specific team or `manage_webhooks` for the channel.
+
+        '
+      operationId: UpdateOutgoingWebhook
+      parameters:
+      - description: outgoing Webhook GUID
+        in: path
+        name: hook_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                channel_id:
+                  description: The ID of a public channel or private group that receives the webhook payloads.
+                  type: string
+                description:
+                  description: The description for this incoming webhook
+                  type: string
+                display_name:
+                  description: The display name for this incoming webhook
+                  type: string
+                id:
+                  description: Outgoing webhook GUID
+                  type: string
+              required:
+              - id
+              - channel_id
+              - display_name
+              - description
+              type: object
+        description: Outgoing webhook to be updated
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OutgoingWebhook'
+          description: Webhook update successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Update an outgoing webhook
+      tags:
+      - webhooks
+  /api/v4/hooks/outgoing/{hook_id}/regen_token:
+    post:
+      description: 'Regenerate the token for the outgoing webhook.
+
+        ##### Permissions
+
+        `manage_webhooks` for system or `manage_webhooks` for the specific team or `manage_webhooks` for the channel.
+
+        '
+      operationId: RegenOutgoingHookToken
+      parameters:
+      - description: Outgoing webhook GUID
+        in: path
+        name: hook_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: Webhook token regenerate successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Regenerate the token for the outgoing webhook.
+      tags:
+      - webhooks
+  /api/v4/posts:
+    post:
+      description: 'Create a new post in a channel. To create the post as a comment on another post, provide `root_id`.
+
+        ##### Permissions
+
+        Must have `create_post` permission for the channel the post is being created in.
+
+        '
+      operationId: CreatePost
+      parameters:
+      - description: Whether to set the user status as online or not.
+        in: query
+        name: set_online
+        required: false
+        schema:
+          type: boolean
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                channel_id:
+                  description: The channel ID to post in
+                  type: string
+                file_ids:
+                  description: A list of file IDs to associate with the post. Note that posts are limited to 5 files maximum.
+                    Please use additional posts for more files.
+                  items:
+                    type: string
+                  type: array
+                message:
+                  description: The message contents, can be formatted with Markdown
+                  type: string
+                metadata:
+                  description: A JSON object to add post metadata, e.g the post's priority
+                  properties:
+                    priority:
+                      description: An object containing the post's priority properties
+                      properties:
+                        priority:
+                          description: The priority label of the post, could empty, important, or urgent
+                          type: string
+                        requested_ack:
+                          description: Set to true to request for acknowledgements
+                          type: boolean
+                      type: object
+                  type: object
+                props:
+                  description: A general JSON property bag to attach to the post
+                  type: object
+                root_id:
+                  description: The post ID to comment on
+                  type: string
+              required:
+              - channel_id
+              - message
+              type: object
+        description: Post object to create
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Post'
+          description: Post creation successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Create a post
+      tags:
+      - posts
+  /api/v4/posts/ephemeral:
+    post:
+      description: 'Create a new ephemeral post in a channel.
+
+        ##### Permissions
+
+        Must have `create_post_ephemeral` permission (currently only given to system admin)
+
+        '
+      operationId: CreatePostEphemeral
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                post:
+                  description: Post object to create
+                  properties:
+                    channel_id:
+                      description: The channel ID to post in
+                      type: string
+                    message:
+                      description: The message contents, can be formatted with Markdown
+                      type: string
+                  required:
+                  - channel_id
+                  - message
+                  type: object
+                user_id:
+                  description: The target user id for the ephemeral post
+                  type: string
+              required:
+              - user_id
+              - post
+              type: object
+        description: Ephemeral Post object to send
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Post'
+          description: Post creation successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Create a ephemeral post
+      tags:
+      - posts
+      x-code-samples:
+      - lang: Go
+        source: "client := model.NewAPIv4Client(\"https://your-mattermost-url.com\")\nclient.Login(\"email@domain.com\", \"\
+          Password1\")\n\nephemeralPost := &model.PostEphemeral{\n  UserID: \"<ID OF THE USER THAT WOULD RECEIVE THE POST>\"\
+          ,\n  Post: &model.Post{\n    ChannelId: \"<ID OF CHANNEL>\",\n    Message:   \"<YOUR MESSAGE>\",\n  },\n}\n\ncreatedPost,\
+          \ response := client.CreatePostEphemeral(ephemeralPost)\n"
+  /api/v4/posts/ids:
+    post:
+      description: 'Fetch a list of posts based on the provided postIDs
+
+        ##### Permissions
+
+        Must have `read_channel` permission for the channel the post is in or if the channel is public, have the `read_public_channels`
+        permission for the team.
+
+        '
+      operationId: getPostsByIds
+      requestBody:
+        content:
+          application/json:
+            schema:
+              items:
+                type: string
+              type: array
+        description: List of post ids
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/Post'
+                type: array
+          description: Post list retrieval successful
+          headers:
+            Has-Inaccessible-Posts:
+              description: Indicates whether the posts have been truncated as per the cloud's plan limit.
+              schema:
+                type: boolean
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Get posts by a list of ids
+      tags:
+      - posts
+  /api/v4/posts/ids/reactions:
+    post:
+      description: 'Get a list of reactions made by all users to a given post.
+
+        ##### Permissions
+
+        Must have `read_channel` permission for the channel the post is in.
+
+
+        __Minimum server version__: 5.8
+
+        '
+      operationId: GetBulkReactions
+      requestBody:
+        content:
+          application/json:
+            schema:
+              items:
+                type: string
+              type: array
+        description: Array of post IDs
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PostIdToReactionsMap'
+          description: Reactions retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Bulk get the reaction for posts
+      tags:
+      - reactions
+  /api/v4/posts/{post_id}:
+    delete:
+      description: 'Soft deletes a post, by marking the post as deleted in the database. Soft deleted posts will not be returned
+        in post queries.
+
+        ##### Permissions
+
+        Must be logged in as the user or have `delete_others_posts` permission.
+
+        '
+      operationId: DeletePost
+      parameters:
+      - description: ID of the post to delete
+        in: path
+        name: post_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: Post deletion successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Delete a post
+      tags:
+      - posts
+    get:
+      description: 'Get a single post.
+
+        ##### Permissions
+
+        Must have `read_channel` permission for the channel the post is in or if the channel is public, have the `read_public_channels`
+        permission for the team.
+
+        '
+      operationId: GetPost
+      parameters:
+      - description: ID of the post to get
+        in: path
+        name: post_id
+        required: true
+        schema:
+          type: string
+      - description: Defines if result should include deleted posts, must have 'manage_system' (admin) permission.
+        in: query
+        name: include_deleted
+        required: false
+        schema:
+          default: false
+          type: boolean
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Post'
+          description: Post retrieval successful
+          headers:
+            Has-Inaccessible-Posts:
+              description: This header is included with the value "true" if the post is past the cloud's plan limit.
+              schema:
+                type: boolean
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Get a post
+      tags:
+      - posts
+    put:
+      description: 'Update a post. Only the fields listed below are updatable, omitted fields will be treated as blank.
+
+        ##### Permissions
+
+        Must have `edit_post` permission for the channel the post is in.
+
+        '
+      operationId: UpdatePost
+      parameters:
+      - description: ID of the post to update
+        in: path
+        name: post_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                has_reactions:
+                  description: Set to `true` if the post has reactions to it
+                  type: boolean
+                id:
+                  description: ID of the post to update
+                  type: string
+                is_pinned:
+                  description: Set to `true` to pin the post to the channel it is in
+                  type: boolean
+                message:
+                  description: The message text of the post
+                  type: string
+                props:
+                  description: A general JSON property bag to attach to the post
+                  type: string
+              required:
+              - id
+              type: object
+        description: Post object that is to be updated
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Post'
+          description: Post update successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Update a post
+      tags:
+      - posts
+  /api/v4/posts/{post_id}/actions/{action_id}:
+    post:
+      description: 'Perform a post action, which allows users to interact with integrations through posts.
+
+        ##### Permissions
+
+        Must be authenticated and have the `read_channel` permission to the channel the post is in.
+
+        '
+      operationId: DoPostAction
+      parameters:
+      - description: Post GUID
+        in: path
+        name: post_id
+        required: true
+        schema:
+          type: string
+      - description: Action GUID
+        in: path
+        name: action_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: Post action successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Perform a post action
+      tags:
+      - posts
+  /api/v4/posts/{post_id}/files/info:
+    get:
+      description: 'Gets a list of file information objects for the files attached to a post.
+
+        ##### Permissions
+
+        Must have `read_channel` permission for the channel the post is in.
+
+        '
+      operationId: GetFileInfosForPost
+      parameters:
+      - description: ID of the post
+        in: path
+        name: post_id
+        required: true
+        schema:
+          type: string
+      - description: Defines if result should include deleted posts, must have 'manage_system' (admin) permission.
+        in: query
+        name: include_deleted
+        required: false
+        schema:
+          default: false
+          type: boolean
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/FileInfo'
+                type: array
+          description: File info retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Get file info for post
+      tags:
+      - posts
+  /api/v4/posts/{post_id}/patch:
+    put:
+      description: 'Partially update a post by providing only the fields you want to update. Omitted fields will not be updated.
+        The fields that can be updated are defined in the request body, all other provided fields will be ignored.
+
+        ##### Permissions
+
+        Must have the `edit_post` permission.
+
+        '
+      operationId: PatchPost
+      parameters:
+      - description: Post GUID
+        in: path
+        name: post_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                file_ids:
+                  description: The list of files attached to this post
+                  items:
+                    type: string
+                  type: array
+                has_reactions:
+                  description: Set to `true` if the post has reactions to it
+                  type: boolean
+                is_pinned:
+                  description: Set to `true` to pin the post to the channel it is in
+                  type: boolean
+                message:
+                  description: The message text of the post
+                  type: string
+                props:
+                  description: A general JSON property bag to attach to the post
+                  type: string
+              type: object
+        description: Post object that is to be updated
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Post'
+          description: Post patch successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Patch a post
+      tags:
+      - posts
+  /api/v4/posts/{post_id}/pin:
+    post:
+      description: 'Pin a post to a channel it is in based from the provided post id string.
+
+        ##### Permissions
+
+        Must be authenticated and have the `read_channel` permission to the channel the post is in.
+
+        '
+      operationId: PinPost
+      parameters:
+      - description: Post GUID
+        in: path
+        name: post_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: Pinned post successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Pin a post to the channel
+      tags:
+      - posts
+  /api/v4/posts/{post_id}/reactions:
+    get:
+      description: 'Get a list of reactions made by all users to a given post.
+
+        ##### Permissions
+
+        Must have `read_channel` permission for the channel the post is in.
+
+        '
+      operationId: GetReactions
+      parameters:
+      - description: ID of a post
+        in: path
+        name: post_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/Reaction'
+                type: array
+          description: List reactions retrieve successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Get a list of reactions to a post
+      tags:
+      - reactions
+  /api/v4/posts/{post_id}/thread:
+    get:
+      description: 'Get a post and the rest of the posts in the same thread.
+
+        ##### Permissions
+
+        Must have `read_channel` permission for the channel the post is in or if the channel is public, have the `read_public_channels`
+        permission for the team.
+
+        '
+      operationId: GetPostThread
+      parameters:
+      - description: ID of a post in the thread
+        in: path
+        name: post_id
+        required: true
+        schema:
+          type: string
+      - description: The number of posts per page
+        in: query
+        name: perPage
+        schema:
+          default: 0
+          type: integer
+      - description: The post_id to return the next page of posts from
+        in: query
+        name: fromPost
+        schema:
+          default: ''
+          type: string
+      - description: The create_at timestamp to return the next page of posts from
+        in: query
+        name: fromCreateAt
+        schema:
+          default: 0
+          type: integer
+      - description: The direction to return the posts. Either up or down.
+        in: query
+        name: direction
+        schema:
+          default: ''
+          type: string
+      - description: Whether to skip fetching threads or not
+        in: query
+        name: skipFetchThreads
+        schema:
+          default: false
+          type: boolean
+      - description: Whether the client uses CRT or not
+        in: query
+        name: collapsedThreads
+        schema:
+          default: false
+          type: boolean
+      - description: Whether to return the associated users as part of the response or not
+        in: query
+        name: collapsedThreadsExtended
+        schema:
+          default: false
+          type: boolean
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PostList'
+          description: Post list retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Get a thread
+      tags:
+      - posts
+  /api/v4/posts/{post_id}/unpin:
+    post:
+      description: 'Unpin a post to a channel it is in based from the provided post id string.
+
+        ##### Permissions
+
+        Must be authenticated and have the `read_channel` permission to the channel the post is in.
+
+        '
+      operationId: UnpinPost
+      parameters:
+      - description: Post GUID
+        in: path
+        name: post_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: Unpinned post successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Unpin a post to the channel
+      tags:
+      - posts
+  /api/v4/reactions:
+    post:
+      description: 'Create a reaction.
+
+        ##### Permissions
+
+        Must have `read_channel` permission for the channel the post is in.
+
+        '
+      operationId: SaveReaction
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Reaction'
+        description: The user's reaction with its post_id, user_id, and emoji_name fields set
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Reaction'
+          description: Reaction creation successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Create a reaction
+      tags:
+      - reactions
+  /api/v4/system/notices/view:
+    put:
+      description: 'Will mark the specified notices as ''viewed'' by the logged in user.
+
+        __Minimum server version__: 5.26
+
+        ##### Permissions
+
+        Must be logged in.
+
+        '
+      operationId: MarkNoticesViewed
+      requestBody:
+        content:
+          application/json:
+            schema:
+              items:
+                type: string
+              type: array
+        description: Array of notice IDs
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: Update successfull
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+      summary: Update notices as 'viewed'
+      tags:
+      - system
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          notices := []string{"id1","id2"}
+
+          resp := Client.MarkNoticesViewed(notices)
+
+          '
+  /api/v4/system/notices/{teamId}:
+    get:
+      description: 'Will return appropriate product notices for current user in the team specified by teamId parameter.
+
+        __Minimum server version__: 5.26
+
+        ##### Permissions
+
+        Must be logged in.
+
+        '
+      operationId: GetNotices
+      parameters:
+      - description: Version of the client (desktop/mobile/web) that issues the request
+        in: query
+        name: clientVersion
+        required: true
+        schema:
+          type: string
+      - description: Client locale
+        in: query
+        name: locale
+        required: false
+        schema:
+          type: string
+      - description: Client type (web/mobile-ios/mobile-android/desktop)
+        in: query
+        name: client
+        required: true
+        schema:
+          type: string
+      - description: ID of the team
+        in: path
+        name: teamId
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/Notice'
+                type: array
+          description: List notices retrieve successful
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+      summary: Get notices for logged in user in specified team
+      tags:
+      - system
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          notices, resp := Client.GetNotices(0, teamId, "mobile-android", "1.2.3", "enUS")
+
+          '
+  /api/v4/system/ping:
+    get:
+      description: "Check if the server is up and healthy based on the configuration setting `GoRoutineHealthThreshold`. If\
+        \ `GoRoutineHealthThreshold` and the number of goroutines on the server exceeds that threshold the server is considered\
+        \ unhealthy. If `GoRoutineHealthThreshold` is not set or the number of goroutines is below the threshold the server\
+        \ is considered healthy.\n__Minimum server version__: 3.10\nIf a \"device_id\" is passed in the query, it will test\
+        \ the Push Notification Proxy in order to discover whether the device is able to receive notifications. The response\
+        \ will have a \"CanReceiveNotifications\" property with one of the following values: - true: It can receive notifications\
+        \ - false: It cannot receive notifications - unknown: There has been an unknown error, and it is not certain whether\
+        \ it can\n  receive notifications.\n\n__Minimum server version__: 6.5\n##### Permissions\nNone.\n"
+      operationId: GetPing
+      parameters:
+      - description: Check the status of the database and file storage as well
+        in: query
+        name: get_server_status
+        required: false
+        schema:
+          type: boolean
+      - description: Check whether this device id can receive push notifications
+        in: query
+        name: device_id
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SystemStatusResponse'
+          description: Status of the system
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+      summary: Check system health
+      tags:
+      - system
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          // GetPing
+
+          status, resp := Client.GetPing()
+
+
+          // Get server status with database and storage checks
+
+          status, resp = Client.GetPingWithServerStatus()
+
+          '
+  /api/v4/system/support_packet:
+    get:
+      description: 'Download a zip file which contains helpful and useful information for troubleshooting your mattermost
+        instance.
+
+        __Minimum server version: 5.32__
+
+        ##### Permissions
+
+        Must have any of the system console read permissions.
+
+        ##### License
+
+        Requires either a E10 or E20 license.
+
+        '
+      operationId: GenerateSupportPacket
+      responses:
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Download a zip file which contains helpful and useful information for troubleshooting your mattermost instance.
+      tags:
+      - system
+  /api/v4/system/timezones:
+    get:
+      description: '__Minimum server version__: 3.10
+
+        ##### Permissions
+
+        Must be logged in.
+
+        '
+      operationId: GetSupportedTimezone
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  type: string
+                type: array
+          description: List of timezones retrieval successful
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+      summary: Retrieve a list of supported timezones
+      tags:
+      - system
+  /api/v4/teams:
+    get:
+      description: 'For regular users only returns open teams. Users with the "manage_system" permission will return teams
+        regardless of type. The result is based on query string parameters - page and per_page.
+
+        ##### Permissions
+
+        Must be authenticated. "manage_system" permission is required to show all teams.
+
+        '
+      operationId: GetAllTeams
+      parameters:
+      - description: The page to select.
+        in: query
+        name: page
+        schema:
+          default: 0
+          type: integer
+      - description: The number of teams per page.
+        in: query
+        name: per_page
+        schema:
+          default: 60
+          type: integer
+      - description: 'Appends a total count of returned teams inside the response object - ex: `{ "teams": [], "total_count"
+          : 0 }`.      '
+        in: query
+        name: include_total_count
+        schema:
+          default: false
+          type: boolean
+      - description: 'If set to true, teams which are part of a data retention policy will be excluded. The `sysconsole_read_compliance`
+          permission is required to use this parameter.
+
+          __Minimum server version__: 5.35'
+        in: query
+        name: exclude_policy_constrained
+        schema:
+          default: false
+          type: boolean
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/Team'
+                type: array
+          description: Team list retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+      summary: Get teams
+      tags:
+      - teams
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          teams, resp := Client.GetAllTeams("", 0, 100)
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$resp = $driver->getTeamModel()->getTeams([\n    \"page\" => 0,\n    \"per_page\" => 100,\n    \"include_total_count\"\
+          \ => false,\n]);\n\nif ($resp->getStatusCode() == 200) {\n    $teams = json_decode($resp->getBody());\n}\n"
+    post:
+      description: 'Create a new team on the system.
+
+        ##### Permissions
+
+        Must be authenticated and have the `create_team` permission.
+
+        '
+      operationId: CreateTeam
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                display_name:
+                  description: Non-unique UI name for the team
+                  type: string
+                name:
+                  description: Unique handler for a team, will be present in the team URL
+                  type: string
+                type:
+                  description: '`''O''` for open, `''I''` for invite only'
+                  type: string
+              required:
+              - name
+              - display_name
+              - type
+              type: object
+        description: Team that is to be created
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Team'
+          description: Team creation successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Create a team
+      tags:
+      - teams
+      x-code-samples:
+      - lang: Go
+        source: "import \"github.com/mattermost/mattermost-server/v5/model\"\n\nClient := model.NewAPIv4Client(\"https://your-mattermost-url.com\"\
+          )\nClient.Login(\"email@domain.com\", \"Password1\")\n\nnewTeam, err := Client.CreateTeam(&model.Team{\n  Name:\
+          \        \"teamName\",\n  DisplayName: \"TeamDisplayName\",\n  Type:        \"O\",\n})\n"
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$resp = $driver->getTeamModel()->createTeam([\n    \"name\" => \"teamName\",\n    \"display_name\" => \"TeamDisplayName\"\
+          ,\n    \"type\" => \"O\",\n]);\n\nif ($resp->getStatusCode() == 200) {\n    $newTeam = json_decode($resp->getBody());\n\
+          }\n"
+  /api/v4/teams/invite/{invite_id}:
+    get:
+      description: 'Get the `name`, `display_name`, `description` and `id` for a team from the invite id.
+
+
+        __Minimum server version__: 4.0
+
+
+        ##### Permissions
+
+        No authentication required.
+
+        '
+      operationId: GetTeamInviteInfo
+      parameters:
+      - description: Invite id for a team
+        in: path
+        name: invite_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  description:
+                    type: string
+                  display_name:
+                    type: string
+                  id:
+                    type: string
+                  name:
+                    type: string
+                type: object
+          description: Team invite info retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+      summary: Get invite info for a team
+      tags:
+      - teams
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+
+          inviteID := "zWEyrTZ7GZ22aBSfoX60iWryTY"
+
+
+          team, resp = Client.GetTeamInviteInfo(inviteID)
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$inviteID = \"zWEyrTZ7GZ22aBSfoX60iWryTY\";\n\n$resp = $driver->getTeamModel()->getInviteInfoForTeam($inviteID);\n\
+          \nif ($resp->getStatusCode() == 200) {\n    $team = json_decode($resp->getBody());\n}\n"
+  /api/v4/teams/invites/email:
+    delete:
+      description: 'Invalidate active email invitations that have not been accepted by the user.
+
+        ##### Permissions
+
+        Must have `sysconsole_write_authentication` permission.
+
+        '
+      operationId: InvalidateEmailInvites
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: Email invites successfully revoked
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Invalidate active email invitations
+      tags:
+      - teams
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          ok, resp := Client.InvalidateEmailInvites()
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$resp = $driver->getTeamModel()->invalidateActiveEmailInvitations();\n\nif ($resp->getStatusCode() == 200) {\n\
+          \    $ok = json_decode($resp->getBody())->status;\n}\n"
+  /api/v4/teams/members/invite:
+    post:
+      description: 'Using either an invite id or hash/data pair from an email invite link, add a user to a team.
+
+        ##### Permissions
+
+        Must be authenticated.
+
+        '
+      operationId: AddTeamMemberFromInvite
+      parameters:
+      - description: Token id from the invitation
+        in: query
+        name: token
+        required: true
+        schema:
+          type: string
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TeamMember'
+          description: Team member creation successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Add user to team from invite
+      tags:
+      - teams
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          tokenID := "qjda3stwafbgpqjaxej3k76sga"
+
+
+          tm, resp = Client.AddTeamMemberFromInvite(tokenID, "")
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$tokenID = \"qjda3stwafbgpqjaxej3k76sga\";\n\n$resp = $driver->getTeamModel()->addUserFromInvite([\n  \"token\"\
+          \ => $tokenID\n]);\n\nif ($resp->getStatusCode() == 200) {\n    $tm = json_decode($resp->getBody());\n}\n"
+  /api/v4/teams/name/{name}:
+    get:
+      description: 'Get a team based on provided name string
+
+        ##### Permissions
+
+        Must be authenticated, team type is open and have the `view_team` permission.
+
+        '
+      operationId: GetTeamByName
+      parameters:
+      - description: Team Name
+        in: path
+        name: name
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Team'
+          description: Team retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Get a team by name
+      tags:
+      - teams
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          team, resp := Client.GetTeamByName("teamName", "")
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$resp = $driver->getTeamModel()->getTeamByName(\"teamName\");\n\nif ($resp->getStatusCode() == 200) {\n    $team\
+          \ = json_decode($resp->getBody());\n}\n"
+  /api/v4/teams/name/{name}/exists:
+    get:
+      description: 'Check if the team exists based on a team name.
+
+        ##### Permissions
+
+        Must be authenticated.
+
+        '
+      operationId: TeamExists
+      parameters:
+      - description: Team Name
+        in: path
+        name: name
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TeamExists'
+          description: Team retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Check if team exists
+      tags:
+      - teams
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          exists, resp := Client.TeamExists("teamName", "")
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$resp = $driver->getTeamModel()->checkTeamExists(\"teamName\");\n\nif ($resp->getStatusCode() == 200) {\n    $exists\
+          \ = json_decode($resp->getBody())->exists;\n}\n"
+  /api/v4/teams/name/{team_name}/channels/name/{channel_name}:
+    get:
+      description: 'Gets a channel from the provided team name and channel name strings.
+
+        ##### Permissions
+
+        `read_channel` permission for the channel.
+
+        '
+      operationId: GetChannelByNameForTeamName
+      parameters:
+      - description: Team Name
+        in: path
+        name: team_name
+        required: true
+        schema:
+          type: string
+      - description: Channel Name
+        in: path
+        name: channel_name
+        required: true
+        schema:
+          type: string
+      - description: Defines if deleted channels should be returned or not (Mattermost Server 5.26.0+)
+        in: query
+        name: include_deleted
+        schema:
+          default: false
+          type: boolean
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Channel'
+          description: Channel retrieval successful
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Get a channel by name and team name
+      tags:
+      - channels
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          // GetChannelByNameForTeamName
+
+          channel, resp = Client.GetChannelByNameForTeamName(<CHANNEL NAME>, <TEAM NAME>, "")
+
+          '
+  /api/v4/teams/search:
+    post:
+      description: 'Search teams based on search term and options provided in the request body.
+
+
+        ##### Permissions
+
+        Logged in user only shows open teams
+
+        Logged in user with "manage_system" permission shows all teams
+
+        '
+      operationId: SearchTeams
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                allow_open_invite:
+                  description: 'Filters results to teams where `allow_open_invite` is set to true or false, excludes group
+                    constrained channels if this filter option is passed.
+
+                    If this filter option is not passed then the query will remain unchanged.
+
+                    __Minimum server version__: 5.28
+
+                    '
+                  type: boolean
+                exclude_policy_constrained:
+                  default: false
+                  description: 'If set to true, only teams which do not have a granular retention policy assigned to them
+                    will be returned. The `sysconsole_read_compliance_data_retention` permission is required to use this parameter.
+
+                    __Minimum server version__: 5.35
+
+                    '
+                  type: boolean
+                group_constrained:
+                  description: 'Filters results to teams where `group_constrained` is set to true or false, returns the union
+                    of results when used with `allow_open_invite`
+
+                    If the filter option is not passed then the query will remain unchanged.
+
+                    __Minimum server version__: 5.28
+
+                    '
+                  type: boolean
+                page:
+                  description: The page number to return, if paginated. If this parameter is not present with the `per_page`
+                    parameter then the results will be returned un-paged.
+                  type: string
+                per_page:
+                  description: The number of entries to return per page, if paginated. If this parameter is not present with
+                    the `page` parameter then the results will be returned un-paged.
+                  type: string
+                term:
+                  description: The search term to match against the name or display name of teams
+                  type: string
+              type: object
+        description: Search criteria
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  teams:
+                    description: The teams that matched the query.
+                    items:
+                      $ref: '#/components/schemas/Team'
+                    type: array
+                  total_count:
+                    description: The total number of results, regardless of page and per_page requested.
+                    type: number
+                type: object
+          description: Paginated teams response. (Note that the non-paginated response—returned if the request body does not
+            contain both `page` and `per_page` fields—is a simple array of teams.)
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Search teams
+      tags:
+      - teams
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          teams, resp := Client.SearchTeams(&model.TeamSearch{Term: "searchTerm"})
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$resp = $driver->getTeamModel()->searchTeams([\n  \"term\" => \"searchTerm\"\n]);\n\nif ($resp->getStatusCode()\
+          \ == 200) {\n    $teams = json_decode($resp->getBody())->teams;\n}\n"
+  /api/v4/teams/{team_id}:
+    delete:
+      description: 'Soft deletes a team, by marking the team as deleted in the database. Soft deleted teams will not be accessible
+        in the user interface.
+
+
+        Optionally use the permanent query parameter to hard delete the team for compliance reasons. As of server version
+        5.0, to use this feature `ServiceSettings.EnableAPITeamDeletion` must be set to `true` in the server''s configuration.
+
+        ##### Permissions
+
+        Must have the `manage_team` permission.
+
+        '
+      operationId: SoftDeleteTeam
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      - description: Permanently delete the team, to be used for compliance reasons only. As of server version 5.0, `ServiceSettings.EnableAPITeamDeletion`
+          must be set to `true` in the server's configuration.
+        in: query
+        name: permanent
+        required: false
+        schema:
+          default: false
+          type: boolean
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: Team deletion successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Delete a team
+      tags:
+      - teams
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          teamID := "4xp9fdt77pncbef59f4k1qe83o"
+
+
+          // Non-permanent deletion
+
+          ok, resp := Client.SoftDeleteTeam(&model.Team{Id: teamID})
+
+
+          // Permanent deletion
+
+          ok, resp := Client.PermanentDeleteTeam(&model.Team{Id: teamID})
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$teamID = \"4xp9fdt77pncbef59f4k1qe83o\";\n\n// Non-permanent deletion\n$resp = $driver->getTeamModel()->deleteTeam($teamID,\
+          \ [\n  \"permanent\" => false,\n]);\n\n// Permanent deletion\n$resp = $driver->getTeamModel()->deleteTeam($teamID,\
+          \ [\n  \"permanent\" => true,\n]);\n\nif ($resp->getStatusCode() == 200) {\n    $ok = json_decode($resp->getBody())->status;\n\
+          }\n"
+    get:
+      description: 'Get a team on the system.
+
+        ##### Permissions
+
+        Must be authenticated and have the `view_team` permission.
+
+        '
+      operationId: GetTeam
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Team'
+          description: Team retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Get a team
+      tags:
+      - teams
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          teamID := "4xp9fdt77pncbef59f4k1qe83o"
+
+
+          t, err := Client.GetTeam(teamID, "")
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$teamID = \"4xp9fdt77pncbef59f4k1qe83o\";\n\n$resp = $driver->getTeamModel()->getTeam($teamID);\n\nif ($resp->getStatusCode()\
+          \ == 200) {\n    $t = json_decode($resp->getBody());\n}\n"
+    put:
+      description: 'Update a team by providing the team object. The fields that can be updated are defined in the request
+        body, all other provided fields will be ignored.
+
+        ##### Permissions
+
+        Must have the `manage_team` permission.
+
+        '
+      operationId: UpdateTeam
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                allow_open_invite:
+                  type: string
+                allowed_domains:
+                  type: string
+                company_name:
+                  type: string
+                description:
+                  type: string
+                display_name:
+                  type: string
+                id:
+                  type: string
+                invite_id:
+                  type: string
+              required:
+              - id
+              - display_name
+              - description
+              - company_name
+              - allowed_domains
+              - invite_id
+              - allow_open_invite
+              type: object
+        description: Team to update
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Team'
+          description: Team update successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Update a team
+      tags:
+      - teams
+      x-code-samples:
+      - lang: Go
+        source: "import \"github.com/mattermost/mattermost-server/v5/model\"\n\nClient := model.NewAPIv4Client(\"https://your-mattermost-url.com\"\
+          )\nClient.Login(\"email@domain.com\", \"Password1\")\n\nteamID := \"4xp9fdt77pncbef59f4k1qe83o\"\ninviteID := \"\
+          qjda3stwafbgpqjaxej3k76sga\"\n\nuteam, resp := Client.UpdateTeam(&model.Team{\n  Id:              teamID,\n  DisplayName:\
+          \     \"displayName\",\n  Description:     \"description\",\n  CompanyName:     \"companyName\",\n  AllowedDomains:\
+          \  \"allowedDomains\",\n  InviteId:        inviteID,\n  AllowOpenInvite: false,\n})\n"
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$teamID = \"4xp9fdt77pncbef59f4k1qe83o\";\n$inviteID = \"qjda3stwafbgpqjaxej3k76sga\";\n\n$resp = $driver->getTeamModel()->updateTeam($teamID,\
+          \ [\n  \"id\" => $teamID,\n  \"display_name\" => \"displayName\",\n  \"description\" => \"description\",\n  \"company_name\"\
+          \ => \"companyName\",\n  \"allowed_domains\" => \"allowedDomains\",\n  \"invite_id\" => $inviteID,\n  \"allow_open_invite\"\
+          \ => false,\n]);\n\nif ($resp->getStatusCode() == 200) {\n    $uteam = json_decode($resp->getBody());\n}\n"
+  /api/v4/teams/{team_id}/channels:
+    get:
+      description: 'Get a page of public channels on a team based on query string parameters - page and per_page.
+
+        ##### Permissions
+
+        Must be authenticated and have the `list_team_channels` permission.
+
+        '
+      operationId: GetPublicChannelsForTeam
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      - description: The page to select.
+        in: query
+        name: page
+        schema:
+          default: 0
+          type: integer
+      - description: The number of public channels per page.
+        in: query
+        name: per_page
+        schema:
+          default: 60
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/Channel'
+                type: array
+          description: Channels retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Get public channels
+      tags:
+      - channels
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+          // GetPublicChannelsForTeam
+
+          channels, resp := Client.GetPublicChannelsForTeam(<TEAMID>, 0, 100, "")
+
+          '
+  /api/v4/teams/{team_id}/channels/autocomplete:
+    get:
+      description: 'Autocomplete public channels on a team based on the search term provided in the request URL.
+
+
+        __Minimum server version__: 4.7
+
+
+        ##### Permissions
+
+        Must have the `list_team_channels` permission.
+
+        '
+      operationId: AutocompleteChannelsForTeam
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      - description: Name or display name
+        in: query
+        name: name
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/Channel'
+                type: array
+          description: Channels autocomplete successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Autocomplete channels
+      tags:
+      - channels
+  /api/v4/teams/{team_id}/channels/deleted:
+    get:
+      description: 'Get a page of deleted channels on a team based on query string parameters - team_id, page and per_page.
+
+
+        __Minimum server version__: 3.10
+
+        '
+      operationId: GetDeletedChannelsForTeam
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      - description: The page to select.
+        in: query
+        name: page
+        schema:
+          default: 0
+          type: integer
+      - description: The number of public channels per page.
+        in: query
+        name: per_page
+        schema:
+          default: 60
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/Channel'
+                type: array
+          description: Channels retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Get deleted channels
+      tags:
+      - channels
+  /api/v4/teams/{team_id}/channels/ids:
+    post:
+      description: 'Get a list of public channels on a team by id.
+
+        ##### Permissions
+
+        `view_team` for the team the channels are on.
+
+        '
+      operationId: GetPublicChannelsByIdsForTeam
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              items:
+                type: string
+              type: array
+        description: List of channel ids
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/Channel'
+                type: array
+          description: Channel list retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Get a list of channels by ids
+      tags:
+      - channels
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          channelIds := []string{<ID OF CHANNEL1>, <ID OF CHANNEL2>, ...}
+
+
+          // GetPublicChannelsByIdsForTeam
+
+          channels, resp := Client.GetPublicChannelsByIdsForTeam(<TEAMID>, channelIds)
+
+          '
+  /api/v4/teams/{team_id}/channels/name/{channel_name}:
+    get:
+      description: 'Gets channel from the provided team id and channel name strings.
+
+        ##### Permissions
+
+        `read_channel` permission for the channel.
+
+        '
+      operationId: GetChannelByName
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      - description: Channel Name
+        in: path
+        name: channel_name
+        required: true
+        schema:
+          type: string
+      - description: Defines if deleted channels should be returned or not (Mattermost Server 5.26.0+)
+        in: query
+        name: include_deleted
+        schema:
+          default: false
+          type: boolean
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Channel'
+          description: Channel retrieval successful
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Get a channel by name
+      tags:
+      - channels
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          // GetChannelByName
+
+          channel, resp := Client.GetChannelByName(<CHANNEL NAME>, <TEAMID>, "")
+
+          '
+  /api/v4/teams/{team_id}/channels/private:
+    get:
+      description: 'Get a page of private channels on a team based on query string
+
+        parameters - team_id, page and per_page.
+
+
+        __Minimum server version__: 5.26
+
+
+        ##### Permissions
+
+        Must have `manage_system` permission.
+
+        '
+      operationId: GetPrivateChannelsForTeam
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      - description: The page to select.
+        in: query
+        name: page
+        schema:
+          default: 0
+          type: integer
+      - description: The number of private channels per page.
+        in: query
+        name: per_page
+        schema:
+          default: 60
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/Channel'
+                type: array
+          description: Channels retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Get private channels
+      tags:
+      - channels
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+          // GetPrivateChannelsForTeam
+
+          channels, resp := Client.GetPrivateChannelsForTeam(<TEAMID>, 0, 100, "")
+
+          '
+  /api/v4/teams/{team_id}/channels/search:
+    post:
+      description: 'Search public channels on a team based on the search term provided in the request body.
+
+        ##### Permissions
+
+        Must have the `list_team_channels` permission.
+
+
+        In server version 5.16 and later, a user without the `list_team_channels` permission will be able to use this endpoint,
+        with the search results limited to the channels that the user is a member of.
+
+        '
+      operationId: SearchChannels
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                term:
+                  description: The search term to match against the name or display name of channels
+                  type: string
+              required:
+              - term
+              type: object
+        description: Search criteria
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/Channel'
+                type: array
+          description: Channels search successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Search channels
+      tags:
+      - channels
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          search := &model.ChannelSearch{Term: <CHANNEL DISPLAYNAME>}
+
+
+          // SearchChannels
+
+          channels, resp := Client.SearchChannels(<TEAMID>, search)
+
+          '
+  /api/v4/teams/{team_id}/channels/search_archived:
+    post:
+      description: 'Search archived channels on a team based on the search term provided in the request body.
+
+
+        __Minimum server version__: 5.18
+
+
+        ##### Permissions
+
+        Must have the `list_team_channels` permission.
+
+
+        In server version 5.18 and later, a user without the `list_team_channels` permission will be able to use this endpoint,
+        with the search results limited to the channels that the user is a member of.
+
+        '
+      operationId: SearchArchivedChannels
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                term:
+                  description: The search term to match against the name or display name of archived channels
+                  type: string
+              required:
+              - term
+              type: object
+        description: Search criteria
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/Channel'
+                type: array
+          description: Channels search successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Search archived channels
+      tags:
+      - channels
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          search := &model.ChannelSearch{Term: <CHANNEL DISPLAYNAME>}
+
+
+          // SearchChannels
+
+          channels, resp := Client.SearchArchivedChannels(<TEAMID>, search)
+
+          '
+  /api/v4/teams/{team_id}/channels/search_autocomplete:
+    get:
+      description: 'Autocomplete your channels on a team based on the search term provided in the request URL.
+
+
+        __Minimum server version__: 5.4
+
+
+        ##### Permissions
+
+        Must have the `list_team_channels` permission.
+
+        '
+      operationId: AutocompleteChannelsForTeamForSearch
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      - description: Name or display name
+        in: query
+        name: name
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/Channel'
+                type: array
+          description: Channels autocomplete successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Autocomplete channels for search
+      tags:
+      - channels
+  /api/v4/teams/{team_id}/commands/autocomplete:
+    get:
+      description: 'List autocomplete commands in the team.
+
+        ##### Permissions
+
+        `view_team` for the team.
+
+        '
+      operationId: ListAutocompleteCommands
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/Command'
+                type: array
+          description: Autocomplete commands retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: List autocomplete commands
+      tags:
+      - commands
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          // ListAutocompleteCommands
+
+          listCommands, resp := Client.ListAutocompleteCommands(<TEAMID>)
+
+          '
+  /api/v4/teams/{team_id}/files/search:
+    post:
+      description: 'Search for files in a team based on file name, extention and file content (if file content extraction
+        is enabled and supported for the files).
+
+        __Minimum server version__: 5.34
+
+        ##### Permissions
+
+        Must be authenticated and have the `view_team` permission.
+
+        '
+      operationId: SearchFiles
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              properties:
+                include_deleted_channels:
+                  description: Set to true if deleted channels should be included in the search. (archived channels)
+                  type: boolean
+                is_or_search:
+                  description: Set to true if an Or search should be performed vs an And search.
+                  type: boolean
+                page:
+                  default: 0
+                  description: The page to select. (Only works with Elasticsearch)
+                  type: integer
+                per_page:
+                  default: 60
+                  description: The number of posts per page. (Only works with Elasticsearch)
+                  type: integer
+                terms:
+                  description: The search terms as inputed by the user. To search for files from a user include `from:someusername`,
+                    using a user's username. To search in a specific channel include `in:somechannel`, using the channel name
+                    (not the display name). To search for specific extensions included `ext:extension`.
+                  type: string
+                time_zone_offset:
+                  default: 0
+                  description: Offset from UTC of user timezone for date searches.
+                  type: integer
+              required:
+              - terms
+              - is_or_search
+              type: object
+        description: The search terms and logic to use in the search.
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FileInfoList'
+          description: Files list retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Search files in a team
+      tags:
+      - teams
+      - files
+      - search
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+          teamID := "zWEyrTZ7GZ22aBSfoX60iWryTY"
+
+          fileInfoList, resp := Client.SearchFiles(teamID, "filename", false)
+
+          '
+      - lang: curl
+        source: "curl -X POST \\\n  https://your-mattermost-url.com/api/v4/teams/zWEyrTZ7GZ22aBSfoX60iWryTY/files/search \\\
+          \n  -H 'Authorization: Bearer frn8fu5rtpyc5m4xy6q3oj4yur' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\"\
+          terms\": \"filename\", \"is_or_search\": false}'\n"
+  /api/v4/teams/{team_id}/groups:
+    get:
+      description: 'Retrieve the list of groups associated with a given team.
+
+
+        __Minimum server version__: 5.11
+
+        '
+      operationId: GetGroupsByTeam
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      - description: The page to select.
+        in: query
+        name: page
+        schema:
+          default: 0
+          type: integer
+      - description: The number of groups per page.
+        in: query
+        name: per_page
+        schema:
+          default: 60
+          type: integer
+      - description: Boolean which filters in the group entries with the `allow_reference` attribute set.
+        in: query
+        name: filter_allow_reference
+        schema:
+          default: false
+          type: boolean
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/Group'
+                type: array
+          description: Group list retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+      summary: Get team groups
+      tags:
+      - groups
+  /api/v4/teams/{team_id}/groups_by_channels:
+    get:
+      description: 'Retrieve the set of groups associated with the channels in the given team grouped by channel.
+
+
+        ##### Permissions
+
+        Must have `manage_system` permission or can access only for current user
+
+
+        __Minimum server version__: 5.11
+
+        '
+      operationId: GetGroupsAssociatedToChannelsByTeam
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      - description: The page to select.
+        in: query
+        name: page
+        schema:
+          default: 0
+          type: integer
+      - description: The number of groups per page.
+        in: query
+        name: per_page
+        schema:
+          default: 60
+          type: integer
+      - description: Boolean which filters in the group entries with the `allow_reference` attribute set.
+        in: query
+        name: filter_allow_reference
+        schema:
+          default: false
+          type: boolean
+      - description: Boolean to determine whether the pagination should be applied or not
+        in: query
+        name: paginate
+        schema:
+          default: false
+          type: boolean
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/GroupsAssociatedToChannels'
+                type: object
+          description: Group list retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+      summary: Get team groups by channels
+      tags:
+      - groups
+  /api/v4/teams/{team_id}/image:
+    delete:
+      description: 'Remove the team icon for the team.
+
+
+        __Minimum server version__: 4.10
+
+
+        ##### Permissions
+
+        Must be authenticated and have the `manage_team` permission.
+
+        '
+      operationId: RemoveTeamIcon
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: Team icon successfully remove
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+      summary: Remove the team icon
+      tags:
+      - teams
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          teamID := "zWEyrTZ7GZ22aBSfoX60iWryTY"
+
+
+          ok, resp = Client.RemoveTeamIcon(teamID)
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$teamID = \"zWEyrTZ7GZ22aBSfoX60iWryTY\";\n\n$resp = $driver->getTeamModel()->removeTeamIcon($teamID);\n\nif ($resp->getStatusCode()\
+          \ == 200) {\n    $ok = json_decode($resp->getBody())->status;\n}\n"
+    get:
+      description: 'Get the team icon of the team.
+
+
+        __Minimum server version__: 4.9
+
+
+        ##### Permissions
+
+        User must be authenticated. In addition, team must be open or the user must have the `view_team` permission.
+
+        '
+      operationId: GetTeamIcon
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Team icon retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+      summary: Get the team icon
+      tags:
+      - teams
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          teamID := "zWEyrTZ7GZ22aBSfoX60iWryTY"
+
+
+          icon, resp = Client.GetTeamIcon(teamID, "")
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$teamID = \"zWEyrTZ7GZ22aBSfoX60iWryTY\";\n\n$resp = $driver->getTeamModel()->getTeamIcon($teamID);\n\nif ($resp->getStatusCode()\
+          \ == 200) {\n    $icon = json_decode($resp->getBody());\n}\n"
+    post:
+      description: 'Sets the team icon for the team.
+
+
+        __Minimum server version__: 4.9
+
+
+        ##### Permissions
+
+        Must be authenticated and have the `manage_team` permission.
+
+        '
+      operationId: SetTeamIcon
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              properties:
+                image:
+                  description: The image to be uploaded
+                  format: binary
+                  type: string
+              required:
+              - image
+              type: object
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: Team icon successfully set
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+      summary: Sets the team icon
+      tags:
+      - teams
+      x-code-samples:
+      - lang: Go
+        source: "import (\n  \"io/ioutil\"\n  \"log\"\n\n  \"github.com/mattermost/mattermost-server/v5/model\"\n)\n\nClient\
+          \ := model.NewAPIv4Client(\"https://your-mattermost-url.com\")\nClient.Login(\"email@domain.com\", \"Password1\"\
+          )\n\ndata, err := ioutil.ReadFile(\"icon.png\")\nif err != nil {\n  log.Fatal(err)\n}\n\nteamID := \"zWEyrTZ7GZ22aBSfoX60iWryTY\"\
+          \n\nok, resp := Client.SetTeamIcon(teamID, data)\n"
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$teamID = \"zWEyrTZ7GZ22aBSfoX60iWryTY\";\n$resource = fopen(\"icon.png\", 'rb');\n\nif ($resource === false)\
+          \ {\n  throw new \\Exeption(\"Failure.\");\n}\n\n$data = new \\GuzzleHttp\\Psr7\\Stream($resource);\n\n$resp = $driver->getTeamModel()->setTeamIcon($teamID,\
+          \ [\n  \"image\" => $data,\n]);\n\nfclose($resource);\n\nif ($resp->getStatusCode() == 200) {\n    $ok = json_decode($resp->getBody())->status;\n\
+          }\n"
+  /api/v4/teams/{team_id}/import:
+    post:
+      description: 'Import a team into a existing team. Import users, channels, posts, hooks.
+
+        ##### Permissions
+
+        Must have `permission_import_team` permission.
+
+        '
+      operationId: ImportTeam
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              properties:
+                file:
+                  description: A file to be uploaded in zip format.
+                  format: binary
+                  type: string
+                filesize:
+                  description: The size of the zip file to be imported.
+                  type: integer
+                importFrom:
+                  description: String that defines from which application the team was exported to be imported into Mattermost.
+                  type: string
+              required:
+              - file
+              - filesize
+              - importFrom
+              type: object
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  results:
+                    type: string
+                type: object
+          description: JSON object containing a base64 encoded text file of the import logs in its `results` property.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Import a Team from other application
+      tags:
+      - teams
+      x-code-samples:
+      - lang: Go
+        source: "import (\n  \"encoding/binary\"\n  \"io/ioutil\"\n  \"log\"\n\n  \"github.com/mattermost/mattermost-server/v5/model\"\
+          \n)\n\nClient := model.NewAPIv4Client(\"https://your-mattermost-url.com\")\nClient.Login(\"email@domain.com\", \"\
+          Password1\")\n\ndata, err = ioutil.ReadFile(\"to_import.zip\")\nif err != nil && len(data) == 0 {\n  log.Fatal(\"\
+          Error while reading file.\")\n}\n\nteamID := \"zWEyrTZ7GZ22aBSfoX60iWryTY\"\n\nfileResp, resp := Client.ImportTeam(data,\
+          \ binary.Size(data), \"slack\", \"to_import.zip\", teamID)\n"
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$teamID = \"zWEyrTZ7GZ22aBSfoX60iWryTY\";\n$resource = fopen(\"to_import.zip\", 'rb');\n\nif ($resource === false)\
+          \ {\n  throw new \\Exeption(\"Error while reading file.\");\n}\n\n$data = new \\GuzzleHttp\\Psr7\\Stream($resource);\n\
+          \n$resp = $driver->getTeamModel()->importTeamFromOtherApplication($teamID, [\n  \"file\" => $data,\n  \"filesize\"\
+          \ => $data->getSize(),\n  \"importFrom\" => \"slack\",\n]);\n\nfclose($resource);\n\nif ($resp->getStatusCode()\
+          \ == 200) {\n    $fileResp = json_decode($resp->getBody())->results;\n}\n"
+  /api/v4/teams/{team_id}/invite-guests/email:
+    post:
+      description: 'Invite guests to existing team channels usign the user''s email.
+
+
+        The number of emails that can be sent is rate limited to 20 per hour with a burst of 20 emails. If the rate limit
+        exceeds, the error message contains details on when to retry and when the timer will be reset.
+
+
+        __Minimum server version__: 5.16
+
+
+        ##### Permissions
+
+        Must have `invite_guest` permission for the team.
+
+        '
+      operationId: InviteGuestsToTeam
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                channels:
+                  description: List of channel ids
+                  items:
+                    type: string
+                  type: array
+                emails:
+                  description: List of emails
+                  items:
+                    type: string
+                  type: array
+                message:
+                  description: Message to include in the invite
+                  type: string
+              required:
+              - emails
+              - channels
+              type: object
+        description: Guests invite information
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: Guests invite successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '413':
+          $ref: '#/components/responses/TooLarge'
+      summary: Invite guests to the team by email
+      tags:
+      - teams
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          teamID := "zWEyrTZ7GZ22aBSfoX60iWryTY"
+
+          channel1ID := "wu6wyxm9spgwtjaycjrcihnqtr"
+
+          channel2ID := "ymzsgjw1tprniqtzyb7g3cmuuc"
+
+
+          ok, resp := Client.InviteGuestsToTeam(teamID, []string{"test@domain.com", "test2@domain.com"}, []string{channel1ID,
+          channel2ID}, "Please join to our mattermost team to keep working in the project")
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$teamID = \"zWEyrTZ7GZ22aBSfoX60iWryTY\";\n\n$channel1ID = \"wu6wyxm9spgwtjaycjrcihnqtr\";\n$channel2ID = \"ymzsgjw1tprniqtzyb7g3cmuuc\"\
+          ;\n\n$resp = $driver->getTeamModel()->inviteGuestsByEmail($teamID, [\n  \"emails\" => [\"test@domain.com\", \"test2@domain.com\"\
+          ],\n  \"channels\" => [$channel1ID, $channel2ID],\n  \"message\" => \"Please join to our mattermost team to keep\
+          \ working in the project\",\n]);\n\nif ($resp->getStatusCode() == 200) {\n    $ok = json_decode($resp->getBody())->status;\n\
+          }\n"
+  /api/v4/teams/{team_id}/invite/email:
+    post:
+      description: 'Invite users to the existing team using the user''s email.
+
+
+        The number of emails that can be sent is rate limited to 20 per hour with a burst of 20 emails. If the rate limit
+        exceeds, the error message contains details on when to retry and when the timer will be reset.
+
+        ##### Permissions
+
+        Must have `invite_user` and `add_user_to_team` permissions for the team.
+
+        '
+      operationId: InviteUsersToTeam
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              items:
+                type: string
+              type: array
+        description: List of user's email
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: Users invite successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '413':
+          $ref: '#/components/responses/TooLarge'
+      summary: Invite users to the team by email
+      tags:
+      - teams
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          teamID := "zWEyrTZ7GZ22aBSfoX60iWryTY"
+
+
+          ok, resp := Client.InviteUsersToTeam(teamID, []string{"test@domain.com", "test2@domain.com"})
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$teamID = \"zWEyrTZ7GZ22aBSfoX60iWryTY\";\n\n$resp = $driver->getTeamModel()->inviteUsersByEmail($teamID, [\n\
+          \  \"test@domain.com\",\n  \"test2@domain.com\",\n]);\n\nif ($resp->getStatusCode() == 200) {\n    $ok = json_decode($resp->getBody())->status;\n\
+          }\n"
+  /api/v4/teams/{team_id}/members:
+    get:
+      description: 'Get a page team members list based on query string parameters - team id, page and per page.
+
+        ##### Permissions
+
+        Must be authenticated and have the `view_team` permission.
+
+        '
+      operationId: GetTeamMembers
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      - description: The page to select.
+        in: query
+        name: page
+        schema:
+          default: 0
+          type: integer
+      - description: The number of users per page.
+        in: query
+        name: per_page
+        schema:
+          default: 60
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/TeamMember'
+                type: array
+          description: Team members retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Get team members
+      tags:
+      - teams
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          teamID := "4xp9fdt77pncbef59f4k1qe83o"
+
+
+          members, resp := Client.GetTeamMembers(teamID, 0, 100, "")
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$teamID = \"4xp9fdt77pncbef59f4k1qe83o\";\n\n$resp = $driver->getTeamModel()->getTeamMembers($teamID, [\n  \"\
+          page\" => 0,\n  \"per_page\" => 100,\n]);\n\nif ($resp->getStatusCode() == 200) {\n    $members = json_decode($resp->getBody());\n\
+          }\n"
+    post:
+      description: 'Add user to the team by user_id.
+
+        ##### Permissions
+
+        Must be authenticated and team be open to add self. For adding another user, authenticated user must have the `add_user_to_team`
+        permission.
+
+        '
+      operationId: AddTeamMember
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                team_id:
+                  type: string
+                user_id:
+                  type: string
+              type: object
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TeamMember'
+          description: Team member creation successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Add user to team
+      tags:
+      - teams
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          teamID := "4xp9fdt77pncbef59f4k1qe83o"
+
+          userID := "qjda3stwafbgpqjaxej3k76sga"
+
+
+          teamMember, resp := Client.AddTeamMember(teamID, userID)
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$teamID = \"4xp9fdt77pncbef59f4k1qe83o\";\n$userID = \"qjda3stwafbgpqjaxej3k76sga\";\n\n$resp = $driver->getTeamModel()->addUser($teamID,\
+          \ [\n  \"user_id\" => $userID,\n  \"team_id\" => $teamID,\n]);\n\nif ($resp->getStatusCode() == 200) {\n    $teamMember\
+          \ = json_decode($resp->getBody());\n}\n"
+  /api/v4/teams/{team_id}/members/batch:
+    post:
+      description: 'Add a number of users to the team by user_id.
+
+        ##### Permissions
+
+        Must be authenticated. Authenticated user must have the `add_user_to_team` permission.
+
+        '
+      operationId: AddTeamMembers
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      - description: 'Instead of aborting the operation if a user cannot be added, return an arrray that will contain both
+          the success and added members and the ones with error, in form of `[{"member": {...}, "user_id", "...", "error":
+          {...}}]`'
+        in: query
+        name: graceful
+        required: false
+        schema:
+          type: boolean
+      requestBody:
+        content:
+          application/json:
+            schema:
+              items:
+                $ref: '#/components/schemas/TeamMember'
+              type: array
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/TeamMember'
+                type: array
+          description: Team members created successfully.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Add multiple users to team
+      tags:
+      - teams
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          teamID := "IJyUQLwh1CO9ahbzaQwWwc0ZnV"
+
+
+          userID := "zWEyrTZ7GZ22aBSfoX60iWryTY"
+
+          userID2 := "NqCSr5HMDZjrWS74IEmedvlOYf"
+
+
+          tm, resp := Client.AddTeamMembers(teamID, []string{userID, userID2})
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$teamID = \"IJyUQLwh1CO9ahbzaQwWwc0ZnV\";\n\n$userID = \"zWEyrTZ7GZ22aBSfoX60iWryTY\";\n$userID2 = \"NqCSr5HMDZjrWS74IEmedvlOYf\"\
+          ;\n\n$resp = $driver->getTeamModel()->addMultipleUsers($teamID, [\n  [\n    \"user_id\" => $userID,\n  ],\n  [\n\
+          \    \"user_id\" => $userID2,\n  ],\n]);\n\nif ($resp->getStatusCode() == 200) {\n    $tm = json_decode($resp->getBody());\n\
+          }\n"
+  /api/v4/teams/{team_id}/members/ids:
+    post:
+      description: 'Get a list of team members based on a provided array of user ids.
+
+        ##### Permissions
+
+        Must have `view_team` permission for the team.
+
+        '
+      operationId: GetTeamMembersByIds
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              items:
+                type: string
+              type: array
+        description: List of user ids
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/TeamMember'
+                type: array
+          description: Team members retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Get team members by ids
+      tags:
+      - teams
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          teamID := zWEyrTZ7GZ22aBSfoX60iWryTY
+
+
+          userID := "NqCSr5HMDZjrWS74IEmedvlOYf"
+
+          userID2 := "UAFalLvtKwNKABAnmwR7uGB5md"
+
+
+          tm, resp := Client.GetTeamMembersByIds(teamID, []string{userID, userID2})
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$teamID = \"zWEyrTZ7GZ22aBSfoX60iWryTY\";\n\n$userID = \"NqCSr5HMDZjrWS74IEmedvlOYf\";\n$userID2 = \"UAFalLvtKwNKABAnmwR7uGB5md\"\
+          ;\n\n$resp = $driver->getTeamModel()->getTeamMembersByIds($teamID, [\n  $userID,\n  $userID2,\n]);\n\nif ($resp->getStatusCode()\
+          \ == 200) {\n    $tm = json_decode($resp->getBody());\n}\n"
+  /api/v4/teams/{team_id}/members/{user_id}:
+    delete:
+      description: 'Delete the team member object for a user, effectively removing them from a team.
+
+        ##### Permissions
+
+        Must be logged in as the user or have the `remove_user_from_team` permission.
+
+        '
+      operationId: RemoveTeamMember
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: Team member deletion successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Remove user from team
+      tags:
+      - teams
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          teamID := "zWEyrTZ7GZ22aBSfoX60iWryTY"
+
+          userID := "NqCSr5HMDZjrWS74IEmedvlOYf"
+
+
+          ok, resp = Client.RemoveTeamMember(teamID, userID)
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$teamID = \"zWEyrTZ7GZ22aBSfoX60iWryTY\";\n$userID = \"NqCSr5HMDZjrWS74IEmedvlOYf\";\n\n$resp = $driver->getTeamModel()->removeUser($teamID,\
+          \ $userID);\n\nif ($resp->getStatusCode() == 200) {\n    $ok = json_decode($resp->getBody())->status;\n}\n"
+    get:
+      description: 'Get a team member on the system.
+
+        ##### Permissions
+
+        Must be authenticated and have the `view_team` permission.
+
+        '
+      operationId: GetTeamMember
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TeamMember'
+          description: Team member retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Get a team member
+      tags:
+      - teams
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          teamID := "zWEyrTZ7GZ22aBSfoX60iWryTY"
+
+          userID := "NqCSr5HMDZjrWS74IEmedvlOYf"
+
+
+          teamMember, resp = Client.GetTeamMember(teamID, userID, "")
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$teamID = \"zWEyrTZ7GZ22aBSfoX60iWryTY\";\n$userID = \"NqCSr5HMDZjrWS74IEmedvlOYf\";\n\n$resp = $driver->getTeamModel()->getTeamMember($teamID,\
+          \ $userID);\n\nif ($resp->getStatusCode() == 200) {\n    $teamMember = json_decode($resp->getBody());\n}\n"
+  /api/v4/teams/{team_id}/members/{user_id}/roles:
+    put:
+      description: 'Update a team member roles. Valid team roles are "team_user", "team_admin" or both of them. Overwrites
+        any previously assigned team roles.
+
+        ##### Permissions
+
+        Must be authenticated and have the `manage_team_roles` permission.
+
+        '
+      operationId: UpdateTeamMemberRoles
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                roles:
+                  type: string
+              required:
+              - roles
+              type: object
+        description: Space-delimited team roles to assign to the user
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: Team member roles update successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Update a team member roles
+      tags:
+      - teams
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          teamID := "zWEyrTZ7GZ22aBSfoX60iWryTY"
+
+          userID := "NqCSr5HMDZjrWS74IEmedvlOYf"
+
+
+          ok, resp := Client.UpdateTeamMemberRoles(teamID, userID, "team_user team_admin")
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$teamID = \"zWEyrTZ7GZ22aBSfoX60iWryTY\";\n$userID = \"NqCSr5HMDZjrWS74IEmedvlOYf\";\n\n$resp = $driver->getTeamModel()->updateTeamMemberRoles($teamID,\
+          \ $userID, [\n  \"roles\" => \"team_user team_admin\",\n]);\n\nif ($resp->getStatusCode() == 200) {\n    $ok = json_decode($resp->getBody())->status;\n\
+          }\n"
+  /api/v4/teams/{team_id}/members/{user_id}/schemeRoles:
+    put:
+      description: 'Update a team member''s scheme_admin/scheme_user properties. Typically this should either be `scheme_admin=false,
+        scheme_user=true` for ordinary team member, or `scheme_admin=true, scheme_user=true` for a team admin.
+
+
+        __Minimum server version__: 5.0
+
+
+        ##### Permissions
+
+        Must be authenticated and have the `manage_team_roles` permission.
+
+        '
+      operationId: UpdateTeamMemberSchemeRoles
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                scheme_admin:
+                  type: boolean
+                scheme_user:
+                  type: boolean
+              required:
+              - scheme_admin
+              - scheme_user
+              type: object
+        description: Scheme properties.
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: Team member's scheme-derived roles updated successfully.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Update the scheme-derived roles of a team member.
+      tags:
+      - teams
+      x-code-samples:
+      - lang: Go
+        source: "import \"github.com/mattermost/mattermost-server/v5/model\"\n\nClient := model.NewAPIv4Client(\"https://your-mattermost-url.com\"\
+          )\nClient.Login(\"email@domain.com\", \"Password1\")\n\nteamID := \"zWEyrTZ7GZ22aBSfoX60iWryTY\"\nuserID := \"NqCSr5HMDZjrWS74IEmedvlOYf\"\
+          \n\nok, resp := Client.UpdateTeamMemberSchemeRoles(teamID, userID, &model.SchemeRoles{\n  SchemeAdmin: true,\n \
+          \ SchemeUser:  true,\n})\n"
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$teamID = \"zWEyrTZ7GZ22aBSfoX60iWryTY\";\n$userID = \"NqCSr5HMDZjrWS74IEmedvlOYf\";\n\n$resp = $driver->getTeamModel()->updateSchemeDerivedRolesOfMember($teamID,\
+          \ $userID, [\n  \"scheme_admin\" => true,\n  \"scheme_user\" => true,\n]);\n\nif ($resp->getStatusCode() == 200)\
+          \ {\n    $ok = json_decode($resp->getBody())->status;\n}\n"
+  /api/v4/teams/{team_id}/members_minus_group_members:
+    get:
+      description: 'Get the set of users who are members of the team minus the set of users who are members of the given groups.
+
+        Each user object contains an array of group objects representing the group memberships for that user.
+
+        Each user object contains the boolean fields `scheme_guest`, `scheme_user`, and `scheme_admin` representing the roles
+        that user has for the given team.
+
+
+        ##### Permissions
+
+        Must have `manage_system` permission.
+
+
+        __Minimum server version__: 5.14
+
+        '
+      operationId: TeamMembersMinusGroupMembers
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      - description: A comma-separated list of group ids.
+        in: query
+        name: group_ids
+        required: true
+        schema:
+          default: ''
+          type: string
+      - description: The page to select.
+        in: query
+        name: page
+        schema:
+          default: 0
+          type: integer
+      - description: The number of users per page.
+        in: query
+        name: per_page
+        schema:
+          default: 0
+          type: integer
+      responses:
+        '200':
+          description: Successfully returns users specified by the pagination, and the total_count.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Team members minus group members.
+      tags:
+      - teams
+      x-code-samples:
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$teamID = \"fcnst115y3y7xmzzp5uq34u8ce\";\n\n$groupID = \"eoezijg8zffgjmch8icy5bjd1e\";\n$groupID2 = \"ugaw6wjc3tfxpcr1eq5u5k8dhe\"\
+          ;\n\n$resp = $driver->getTeamModel()->getTeamMembersMinusGroupMembers($teamID, [\n  \"group_ids\" => [$groupID,\
+          \ $groupID2],\n  \"page\" => 0,\n  \"per_page\" => 100,\n]);\n\nif ($resp->getStatusCode() == 200) {\n    $members\
+          \ = json_decode($resp->getBody());\n}\n"
+      - lang: curl
+        source: "curl 'http://your-mattermost-url.com/api/v4/teams/fcnst115y3y7xmzzp5uq34u8ce/members_minus_group_members?group_ids=eoezijg8zffgjmch8icy5bjd1e,ugaw6wjc3tfxpcr1eq5u5k8dhe&page=0&per_page=100'\
+          \ \\\n    -H 'Authorization: Bearer mq8rrfxpdfyafbnw3qfmhwkx6c' \\\n    -H 'Content-Type: application/json' \\\n\
+          \    -H 'X-Requested-With: XMLHttpRequest'\n"
+  /api/v4/teams/{team_id}/patch:
+    put:
+      description: 'Partially update a team by providing only the fields you want to update. Omitted fields will not be updated.
+        The fields that can be updated are defined in the request body, all other provided fields will be ignored.
+
+        ##### Permissions
+
+        Must have the `manage_team` permission.
+
+        '
+      operationId: PatchTeam
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                allow_open_invite:
+                  type: boolean
+                company_name:
+                  type: string
+                description:
+                  type: string
+                display_name:
+                  type: string
+                invite_id:
+                  type: string
+              type: object
+        description: Team object that is to be updated
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Team'
+          description: team patch successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Patch a team
+      tags:
+      - teams
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          patch := &model.TeamPatch{}
+
+          patch.DisplayName = model.NewString("Other name")
+
+          patch.Description = model.NewString("Other description")
+
+          patch.CompanyName = model.NewString("Other company name")
+
+          patch.AllowOpenInvite = model.NewBool(true)
+
+
+          teamID := "4xp9fdt77pncbef59f4k1qe83o"
+
+
+          team, resp := Client.PatchTeam(teamID, patch)
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$teamID = \"4xp9fdt77pncbef59f4k1qe83o\";\n\n$resp = $driver->getTeamModel()->patchTeam($teamID, [\n  \"display_name\"\
+          \ => \"Other name\",\n  \"description\" => \"Other description\",\n  \"company_name\" => \"Other company name\"\
+          ,\n  \"allow_open_invite\" => true,\n]);\n\nif ($resp->getStatusCode() == 200) {\n    $team = json_decode($resp->getBody());\n\
+          }\n"
+  /api/v4/teams/{team_id}/posts/search:
+    post:
+      description: 'Search posts in the team and from the provided terms string.
+
+        ##### Permissions
+
+        Must be authenticated and have the `view_team` permission.
+
+        '
+      operationId: SearchPosts
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                include_deleted_channels:
+                  description: Set to true if deleted channels should be included in the search. (archived channels)
+                  type: boolean
+                is_or_search:
+                  description: Set to true if an Or search should be performed vs an And search.
+                  type: boolean
+                page:
+                  default: 0
+                  description: The page to select. (Only works with Elasticsearch)
+                  type: integer
+                per_page:
+                  default: 60
+                  description: The number of posts per page. (Only works with Elasticsearch)
+                  type: integer
+                terms:
+                  description: The search terms as inputed by the user. To search for posts from a user include `from:someusername`,
+                    using a user's username. To search in a specific channel include `in:somechannel`, using the channel name
+                    (not the display name).
+                  type: string
+                time_zone_offset:
+                  default: 0
+                  description: Offset from UTC of user timezone for date searches.
+                  type: integer
+              required:
+              - terms
+              - is_or_search
+              type: object
+        description: The search terms and logic to use in the search.
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PostListWithSearchMatches'
+          description: Post list retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Search for team posts
+      tags:
+      - posts
+  /api/v4/teams/{team_id}/privacy:
+    put:
+      description: 'Updates team''s privacy allowing changing a team from Public (open) to Private (invitation only) and back.
+
+
+        __Minimum server version__: 5.24
+
+
+        ##### Permissions
+
+        `manage_team` permission for the team of the team.
+
+        '
+      operationId: UpdateTeamPrivacy
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                privacy:
+                  description: 'Team privacy setting: ''O'' for a public (open) team, ''I'' for a private (invitation only)
+                    team'
+                  type: string
+              required:
+              - privacy
+              type: object
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Team'
+          description: Team conversion successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Update teams's privacy
+      tags:
+      - teams
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          // Update team''s privacy to Public
+
+          updatedTeam, resp := Client.UpdateTeamPrivacy(<TEAMID>, model.TEAM_OPEN)
+
+
+          // Update team''s privacy to Private
+
+          updatedTeam, resp := Client.UpdateTeamPrivacy(<TEAMID>, model.TEAM_INVITE)
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n// Update team's privacy to Public\n$resp = $driver->getTeamModel()->updateTeamPrivacy(<TEAMID>, [\n  \"privacy\"\
+          \ => \"0\",\n]);\n\n// Update team's privacy to Private\n$resp = $driver->getTeamModel()->updateTeamPrivacy(<TEAMID>,\
+          \ [\n  \"privacy\" => \"1\",\n]);\n\nif ($resp->getStatusCode() == 200) {\n    $updatedTeam = json_decode($resp->getBody());\n\
+          }\n"
+  /api/v4/teams/{team_id}/regenerate_invite_id:
+    post:
+      description: 'Regenerates the invite ID used in invite links of a team
+
+        ##### Permissions
+
+        Must be authenticated and have the `manage_team` permission.
+
+        '
+      operationId: RegenerateTeamInviteId
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Team'
+          description: Team Invite ID regenerated
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Regenerate the Invite ID from a Team
+      tags:
+      - teams
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          teamID := "zWEyrTZ7GZ22aBSfoX60iWryTY"
+
+
+          team, resp := Client.RegenerateTeamInviteId(teamID)
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$teamID = \"zWEyrTZ7GZ22aBSfoX60iWryTY\";\n\n$resp = $driver->getTeamModel()->regenerateInviteID($teamID);\n\n\
+          if ($resp->getStatusCode() == 200) {\n    $team = json_decode($resp->getBody());\n}\n"
+  /api/v4/teams/{team_id}/restore:
+    post:
+      description: 'Restore a team that was previously soft deleted.
+
+
+        __Minimum server version__: 5.24
+
+
+        ##### Permissions
+
+        Must have the `manage_team` permission.
+
+        '
+      operationId: RestoreTeam
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Team'
+          description: Team restore successful
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Restore a team
+      tags:
+      - teams
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+          teamID := "4xp9fdt77pncbef59f4k1qe83o"
+
+          team, resp := Client.RestoreTeam(teamID)
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$teamID = \"4xp9fdt77pncbef59f4k1qe83o\";\n\n$resp = $driver->getTeamModel()->restoreTeam($teamID);\n\nif ($resp->getStatusCode()\
+          \ == 200) {\n    $team = json_decode($resp->getBody());\n}\n"
+  /api/v4/teams/{team_id}/scheme:
+    put:
+      description: 'Set a team''s scheme, more specifically sets the scheme_id value of a team record.
+
+
+        ##### Permissions
+
+        Must have `manage_system` permission.
+
+
+        __Minimum server version__: 5.0
+
+        '
+      operationId: UpdateTeamScheme
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                scheme_id:
+                  description: The ID of the scheme.
+                  type: string
+              required:
+              - scheme_id
+              type: object
+        description: Scheme GUID
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: Update team scheme successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+      summary: Set a team's scheme
+      tags:
+      - teams
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          teamID := "4xp9fdt77pncbef59f4k1qe83o"
+
+          schemeID := "qjda3stwafbgpqjaxej3k76sga"
+
+
+          ok, resp := UpdateTeamScheme(teamID, schemeID)
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$teamID = \"4xp9fdt77pncbef59f4k1qe83o\";\n$schemeID = \"qjda3stwafbgpqjaxej3k76sga\";\n\n$resp = $driver->getTeamModel()->setTeamScheme($teamID,\
+          \ [\n  \"scheme_id\" => $schemeID,\n]);\n\nif ($resp->getStatusCode() == 200) {\n    $ok = json_decode($resp->getBody())->status;\n\
+          }\n"
+      - lang: curl
+        source: "curl -X PUT \\\n  https://your-mattermost-url.com/api/v4/teams/4xp9fdt77pncbef59f4k1qe83o/scheme \\\n  -H\
+          \ 'Authorization: Bearer frn8fu5rtpyc5m4xy6q3oj4yur' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\"scheme_id\"\
+          : \"qjda3stwafbgpqjaxej3k76sga\"}'\n"
+  /api/v4/teams/{team_id}/stats:
+    get:
+      description: 'Get a team stats on the system.
+
+        ##### Permissions
+
+        Must be authenticated and have the `view_team` permission.
+
+        '
+      operationId: GetTeamStats
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TeamStats'
+          description: Team stats retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Get a team stats
+      tags:
+      - teams
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          teamID := "zWEyrTZ7GZ22aBSfoX60iWryTY"
+
+
+          stats, resp := Client.GetTeamStats(teamID, "")
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$teamID = \"zWEyrTZ7GZ22aBSfoX60iWryTY\";\n\n$resp = $driver->getTeamModel()->getTeamStats($teamID);\n\nif ($resp->getStatusCode()\
+          \ == 200) {\n    $stats = json_decode($resp->getBody());\n}\n"
+  /api/v4/teams/{team_id}/top/channels:
+    get:
+      description: 'Get a list of the top public and private channels (the user is a member of) for a given team.
+
+        ##### Permissions
+
+        Must have `view_team` permission for the team.
+
+        '
+      operationId: GetTopChannelsForTeam
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      - description: 'Time range can be "today", "7_day", or "28_day".
+
+          - `today`: channels with posts on the current day.
+
+          - `7_day`: channels with posts in the last 7 days.
+
+          - `28_day`: channels with posts in the last 28 days.
+
+          '
+        in: query
+        name: time_range
+        required: true
+        schema:
+          type: string
+      - description: The page to select.
+        in: query
+        name: page
+        schema:
+          default: 0
+          type: integer
+      - description: The number of items per page, up to a maximum of 200.
+        in: query
+        name: per_page
+        schema:
+          default: 60
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TopChannelList'
+                type: object
+          description: Top channels retrieved successfully.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Get a list of the top channels for a team.
+      tags:
+      - insights
+  /api/v4/teams/{team_id}/top/reactions:
+    get:
+      description: 'Get a list of the top reactions across all public and private channels (the user is a member of) for a
+        given team.
+
+        ##### Permissions
+
+        Must have `view_team` permission for the team.
+
+        '
+      operationId: GetTopReactionsForTeam
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      - description: 'Time range can be "today", "7_day", or "28_day".
+
+          - `today`: reactions posted on the current day.
+
+          - `7_day`: reactions posted in the last 7 days.
+
+          - `28_day`: reactions posted in the last 28 days.
+
+          '
+        in: query
+        name: time_range
+        required: true
+        schema:
+          type: string
+      - description: The page to select.
+        in: query
+        name: page
+        schema:
+          default: 0
+          type: integer
+      - description: The number of items per page, up to a maximum of 200.
+        in: query
+        name: per_page
+        schema:
+          default: 60
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TopReactionList'
+                type: object
+          description: Top reactions retrieved successfully.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Get a list of the top reactions for a team.
+      tags:
+      - insights
+  /api/v4/teams/{team_id}/top/team_members:
+    get:
+      description: 'Get a list of all of the new team members that have joined the given team during the given time period.
+
+        ##### Permissions
+
+        Must have `view_team` permission for the team.
+
+        '
+      operationId: GetNewTeamMembers
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      - description: 'Time range can be "today", "7_day", or "28_day".
+
+          - `today`: team members who joined during the current day.
+
+          - `7_day`: team members who joined in the last 7 days.
+
+          - `28_day`: team members who joined in the last 28 days.
+
+          '
+        in: query
+        name: time_range
+        required: true
+        schema:
+          type: string
+      - description: The page to select.
+        in: query
+        name: page
+        schema:
+          default: 0
+          type: integer
+      - description: The number of items per page.
+        in: query
+        name: per_page
+        schema:
+          default: 60
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NewTeamMembersList'
+                type: object
+          description: New team members retrieved successfully.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Get a list of new team members.
+      tags:
+      - insights
+  /api/v4/teams/{team_id}/top/threads:
+    get:
+      description: 'Get a list of the top threads from public and private channels (the user is a member of) for a given team.
+
+        ##### Permissions
+
+        Must have `view_team` permission for the team.
+
+        '
+      operationId: GetTopThreadsForTeam
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      - description: 'Time range can be "today", "7_day", or "28_day".
+
+          - `today`: threads with activity on the current day.
+
+          - `7_day`: threads with activity in the last 7 days.
+
+          - `28_day`: threads with activity in the last 28 days.
+
+          '
+        in: query
+        name: time_range
+        required: true
+        schema:
+          type: string
+      - description: The page to select.
+        in: query
+        name: page
+        schema:
+          default: 0
+          type: integer
+      - description: The number of items per page, up to a maximum of 200.
+        in: query
+        name: per_page
+        schema:
+          default: 60
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TopThreadList'
+                type: object
+          description: Top threads retrieved successfully.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Get a list of the top threads for a team.
+      tags:
+      - insights
+  /api/v4/users:
+    delete:
+      description: 'Permanently deletes all users and all their related information, including posts.
+
+
+        __Minimum server version__: 5.26.0
+
+
+        __Local mode only__: This endpoint is only available through [local mode](https://docs.mattermost.com/administration/mmctl-cli-tool.html#local-mode).
+
+        '
+      operationId: PermanentDeleteAllUsers
+      responses:
+        '200':
+          description: Delete request was successful
+      summary: Permanent delete all users
+      tags:
+      - users
+      x-code-samples:
+      - lang: Go
+        source: "import (\n    \"net\"\n    \"net/http\"\n\n    \"github.com/mattermost/mattermost-server/v5/model\"\n)\n\n\
+          tr := &http.Transport{\n    Dial: func(network, addr string) (net.Conn, error) {\n        return net.Dial(\"unix\"\
+          , socketPath)\n    },\n}\n\nClient := model.NewAPIv4Client(\"http://_\")\nClient.HttpClient = &http.Client{Transport:\
+          \ tr}\n\nok, resp := Client.PermanentDeleteAllUsers()\n"
+    get:
+      description: 'Get a page of a list of users. Based on query string parameters, select users from a team, channel, or
+        select users not in a specific channel.
+
+
+        Since server version 4.0, some basic sorting is available using the `sort` query parameter. Sorting is currently only
+        supported when selecting users on a team.
+
+        ##### Permissions
+
+        Requires an active session and (if specified) membership to the channel or team being selected from.
+
+        '
+      operationId: GetUsers
+      parameters:
+      - description: The page to select.
+        in: query
+        name: page
+        schema:
+          default: 0
+          type: integer
+      - description: The number of users per page. There is a maximum limit of 200 users per page.
+        in: query
+        name: per_page
+        schema:
+          default: 60
+          type: integer
+      - description: The ID of the team to get users for.
+        in: query
+        name: in_team
+        schema:
+          type: string
+      - description: The ID of the team to exclude users for. Must not be used with "in_team" query parameter.
+        in: query
+        name: not_in_team
+        schema:
+          type: string
+      - description: The ID of the channel to get users for.
+        in: query
+        name: in_channel
+        schema:
+          type: string
+      - description: The ID of the channel to exclude users for. Must be used with "in_channel" query parameter.
+        in: query
+        name: not_in_channel
+        schema:
+          type: string
+      - description: The ID of the group to get users for. Must have `manage_system` permission.
+        in: query
+        name: in_group
+        schema:
+          type: string
+      - description: When used with `not_in_channel` or `not_in_team`, returns only the users that are allowed to join the
+          channel or team based on its group constrains.
+        in: query
+        name: group_constrained
+        schema:
+          type: boolean
+      - description: Whether or not to list users that are not on any team. This option takes precendence over `in_team`,
+          `in_channel`, and `not_in_channel`.
+        in: query
+        name: without_team
+        schema:
+          type: boolean
+      - description: Whether or not to list only users that are active. This option cannot be used along with the `inactive`
+          option.
+        in: query
+        name: active
+        schema:
+          type: boolean
+      - description: Whether or not to list only users that are deactivated. This option cannot be used along with the `active`
+          option.
+        in: query
+        name: inactive
+        schema:
+          type: boolean
+      - description: Returns users that have this role.
+        in: query
+        name: role
+        schema:
+          type: string
+      - description: 'Sort is only available in conjunction with certain options below. The paging parameter is also always
+          available.
+
+
+          ##### `in_team`
+
+          Can be "", "last_activity_at" or "create_at".
+
+          When left blank, sorting is done by username.
+
+          __Minimum server version__: 4.0
+
+          ##### `in_channel`
+
+          Can be "", "status".
+
+          When left blank, sorting is done by username. `status` will sort by User''s current status (Online, Away, DND, Offline),
+          then by Username.
+
+          __Minimum server version__: 4.7
+
+          ##### `in_group`
+
+          Can be "", "display_name".
+
+          When left blank, sorting is done by username. `display_name` will sort alphabetically by user''s display name.
+
+          __Minimum server version__: 7.7
+
+          '
+        in: query
+        name: sort
+        schema:
+          type: string
+      - description: 'Comma separated string used to filter users based on any of the specified system roles
+
+
+          Example: `?roles=system_admin,system_user` will return users that are either system admins or system users
+
+
+          __Minimum server version__: 5.26
+
+          '
+        in: query
+        name: roles
+        schema:
+          type: string
+      - description: 'Comma separated string used to filter users based on any of the specified channel roles, can only be
+          used in conjunction with `in_channel`
+
+
+          Example: `?in_channel=4eb6axxw7fg3je5iyasnfudc5y&channel_roles=channel_user` will return users that are only channel
+          users and not admins or guests
+
+
+          __Minimum server version__: 5.26
+
+          '
+        in: query
+        name: channel_roles
+        schema:
+          type: string
+      - description: 'Comma separated string used to filter users based on any of the specified team roles, can only be used
+          in conjunction with `in_team`
+
+
+          Example: `?in_team=4eb6axxw7fg3je5iyasnfudc5y&team_roles=team_user` will return users that are only team users and
+          not admins or guests
+
+
+          __Minimum server version__: 5.26
+
+          '
+        in: query
+        name: team_roles
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/User'
+                type: array
+          description: User page retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Get users
+      tags:
+      - users
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+
+          // page, perPage, etag
+
+          users := Client.GetUsers(0, 60, "")
+
+          users = Client.GetUsersInChannel("channelid", 0, 60, "")
+
+          users = Client.GetUsersNotInChannel("teamid", "channelid", 0, 60, "")
+
+          users = Client.GetUsersInTeam("teamid", 0, 60, "")
+
+          users = Client.GetUsersNotInTeam("teamid", 0, 60, "")
+
+          users = Client.GetUsersWithoutTeam(0, 60, "")
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n//get users\n$resp = $driver->getUserModel()->getUsers([\n    \"page\" => 0,\n    \"per_page\" => 60,\n]);\n\n\
+          //get users in channel\n$resp = $driver->getUserModel()->getUsers([\n    \"in_channel\" => \"channelid\",\n    \"\
+          page\" => 0,\n    \"per_page\" => 60,\n]);\n\n//get users not in channel\n$resp = $driver->getUserModel()->getUsers([\n\
+          \    \"in_team\" => \"teamid\",\n    \"not_in_channel\" => \"channelid\",\n    \"page\" => 0,\n    \"per_page\"\
+          \ => 60,\n]);\n\n//get users in team\n$resp = $driver->getUserModel()->getUsers([\n    \"in_team\" => \"teamid\"\
+          ,\n    \"page\" => 0,\n    \"per_page\" => 60,\n]);\n\n//get users not in team\n$resp = $driver->getUserModel()->getUsers([\n\
+          \    \"not_in_team\" => \"teamid\",\n    \"page\" => 0,\n    \"per_page\" => 60,\n]);\n\n//get users without team\n\
+          $resp = $driver->getUserModel()->getUsers([\n    \"without_team\" => true,\n    \"page\" => 0,\n    \"per_page\"\
+          \ => 60,\n]);\n\nif ($resp->getStatusCode() == 200) {\n    $users = json_decode($resp->getBody());\n}\n"
+    post:
+      description: 'Create a new user on the system. Password is required for email login. For other authentication types
+        such as LDAP or SAML, auth_data and auth_service fields are required.
+
+        ##### Permissions
+
+        No permission required for creating email/username accounts on an open server. Auth Token is required for other authentication
+        types such as LDAP or SAML.
+
+        '
+      operationId: CreateUser
+      parameters:
+      - description: Token id from an email invitation
+        in: query
+        name: t
+        required: false
+        schema:
+          type: string
+      - description: Token id from an invitation link
+        in: query
+        name: iid
+        required: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                auth_data:
+                  description: Service-specific authentication data, such as email address.
+                  type: string
+                auth_service:
+                  description: The authentication service, one of "email", "gitlab", "ldap", "saml", "office365", "google",
+                    and "".
+                  type: string
+                email:
+                  type: string
+                first_name:
+                  type: string
+                last_name:
+                  type: string
+                locale:
+                  type: string
+                nickname:
+                  type: string
+                notify_props:
+                  $ref: '#/components/schemas/UserNotifyProps'
+                password:
+                  description: The password used for email authentication.
+                  type: string
+                props:
+                  type: object
+                username:
+                  type: string
+              required:
+              - email
+              - username
+              type: object
+        description: User object to be created
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+          description: User creation successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Create a user
+      tags:
+      - users
+      x-code-samples:
+      - lang: Go
+        source: "import \"github.com/mattermost/mattermost-server/v5/model\"\n\nClient := model.NewAPIv4Client(\"https://your-mattermost-url.com\"\
+          )\n\nuser := &model.User{\n    Username: \"username\",\n    Email: \"email@domain.com\",\n    Password: \"Password1\"\
+          ,\n}\n\ncreatedUser, response := Client.CreateUser(user)\n"
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$resp = $driver->getUserModel()->createUser([\n    \"username\" => \"username\",\n    \"email\" => \"email@domain.com\"\
+          ,\n    \"password\" => \"Password1\"\n]);\n\nif ($resp->getStatusCode() == 200) {\n    $createdUser = json_decode($resp->getBody());\n\
+          }\n"
+  /api/v4/users/autocomplete:
+    get:
+      description: 'Get a list of users for the purpose of autocompleting based on the provided search term. Specify a combination
+        of `team_id` and `channel_id` to filter results further.
+
+        ##### Permissions
+
+        Requires an active session and `view_team` and `read_channel` on any teams or channels used to filter the results
+        further.
+
+        '
+      operationId: AutocompleteUsers
+      parameters:
+      - description: Team ID
+        in: query
+        name: team_id
+        schema:
+          type: string
+      - description: Channel ID
+        in: query
+        name: channel_id
+        schema:
+          type: string
+      - description: Username, nickname first name or last name
+        in: query
+        name: name
+        required: true
+        schema:
+          type: string
+      - description: 'The maximum number of users to return in each subresult
+
+
+          __Available as of server version 5.6. Defaults to `100` if not provided or on an earlier server version.__
+
+          '
+        in: query
+        name: limit
+        schema:
+          default: 100
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserAutocomplete'
+          description: User autocomplete successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Autocomplete users
+      tags:
+      - users
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          teamID := "4xp9fdt77pncbef59f4k1qe83o"
+
+          channelID := "Ej3SKOHlWIKAblkUTK5Xvkj2cm"
+
+          username := "testUsername"
+
+
+          users, resp := Client.AutocompleteUsersInChannel(teamID, channelID, username, 100, "")
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n     ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$teamID = \"4xp9fdt77pncbef59f4k1qe83o\";\n$channelID = \"Ej3SKOHlWIKAblkUTK5Xvkj2cm\";\n$username = \"testUsername\"\
+          ;\n\n$resp = $driver->getUserModel()->autocompleteUsers([\n    \"team_id\" => $teamID,\n    \"channel_id\" => $channelID,\n\
+          \    \"name\" => $username,\n    \"limit\" => 100,\n]);\n\nif ($resp->getStatusCode() == 200) {\n    $users = json_decode($resp->getBody());\n\
+          }\n"
+  /api/v4/users/email/verify:
+    post:
+      description: 'Verify the email used by a user to sign-up their account with.
+
+        ##### Permissions
+
+        No permissions required.
+
+        '
+      operationId: VerifyUserEmail
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                token:
+                  description: The token given to validate the email
+                  type: string
+              required:
+              - token
+              type: object
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: User email verification successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+      summary: Verify user email
+      tags:
+      - users
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+
+          token := "zWEyrTZ7GZ22aBSfoX60iWryTY"
+
+
+          ok, resp := Client.VerifyUserEmail(token)
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n      ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$token = \"zWEyrTZ7GZ22aBSfoX60iWryTY\";\n\n$resp = $driver->getUserModel()->verifyUserEmail([\n    \"token\"\
+          \ => $token,\n]);\n\nif ($resp->getStatusCode() == 200) {\n   $ok = json_decode($resp->getBody())->status;\n}\n"
+  /api/v4/users/email/verify/send:
+    post:
+      description: 'Send an email with a verification link to a user that has an email matching the one in the request body.
+        This endpoint will return success even if the email does not match any users on the system.
+
+        ##### Permissions
+
+        No permissions required.
+
+        '
+      operationId: SendVerificationEmail
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                email:
+                  description: Email of a user
+                  type: string
+              required:
+              - email
+              type: object
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: Email send successful if email exists
+        '400':
+          $ref: '#/components/responses/BadRequest'
+      summary: Send verification email
+      tags:
+      - users
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+
+          email := "test@domain.com"
+
+
+          pass, resp := Client.SendVerificationEmail(email)
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n      ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$email = \"test@domain.com\";\n\n$resp = $driver->getUserModel()->sendVerificationEmail([\n    \"email\" => $email,\n\
+          ]);\n\nif ($resp->getStatusCode() == 200) {\n   $pass = json_decode($resp->getBody())->status;\n}\n"
+  /api/v4/users/email/{email}:
+    get:
+      description: 'Get a user object by providing a user email. Sensitive information will be sanitized out.
+
+        ##### Permissions
+
+        Requires an active session and for the current session to be able to view another user''s email based on the server''s
+        privacy settings.
+
+        '
+      operationId: GetUserByEmail
+      parameters:
+      - description: User Email
+        in: path
+        name: email
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+          description: User retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Get a user by email
+      tags:
+      - users
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          email := "test@domain.com"
+
+
+          user, resp := Client.GetUserByEmail(email, "")
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n      ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$email = \"test@domain.com\";\n\n$resp = $driver->getUserModel()->getUserByEmail($email);\n\nif ($resp->getStatusCode()\
+          \ == 200) {\n   $user = json_decode($resp->getBody());\n}\n"
+  /api/v4/users/group_channels:
+    post:
+      description: 'Get an object containing a key per group channel id in the
+
+        query and its value as a list of users members of that group
+
+        channel.
+
+
+        The user must be a member of the group ids in the query, or
+
+        they will be omitted from the response.
+
+        ##### Permissions
+
+        Requires an active session but no other permissions.
+
+
+        __Minimum server version__: 5.14
+
+        '
+      operationId: GetUsersByGroupChannelIds
+      requestBody:
+        content:
+          application/json:
+            schema:
+              items:
+                type: string
+              type: array
+        description: List of group channel ids
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  <CHANNEL_ID>:
+                    items:
+                      $ref: '#/components/schemas/User'
+                    type: array
+                type: object
+          description: User list retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+      summary: Get users by group channels ids
+      tags:
+      - users
+  /api/v4/users/ids:
+    post:
+      description: 'Get a list of users based on a provided list of user ids.
+
+        ##### Permissions
+
+        Requires an active session but no other permissions.
+
+        '
+      operationId: GetUsersByIds
+      parameters:
+      - description: 'Only return users that have been modified since the given Unix timestamp (in milliseconds).
+
+
+          __Minimum server version__: 5.14
+
+          '
+        in: query
+        name: since
+        schema:
+          type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              items:
+                type: string
+              type: array
+        description: List of user ids
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/User'
+                type: array
+          description: User list retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+      summary: Get users by ids
+      tags:
+      - users
+  /api/v4/users/known:
+    get:
+      description: 'Get the list of user IDs of users with any direct relationship with a
+
+        user. That means any user sharing any channel, including direct and
+
+        group channels.
+
+        ##### Permissions
+
+        Must be authenticated.
+
+
+        __Minimum server version__: 5.23
+
+        '
+      operationId: GetKnownUsers
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KnownUsers'
+                type: array
+          description: Known users' IDs retrieval successful
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+      summary: Get user IDs of known users
+      tags:
+      - users
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          userIds, resp := Client.GetKnownUsers()
+
+          '
+  /api/v4/users/login:
+    post:
+      description: '##### Permissions
+
+        No permission required
+
+        '
+      operationId: Login
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                device_id:
+                  type: string
+                id:
+                  type: string
+                ldap_only:
+                  type: boolean
+                login_id:
+                  type: string
+                password:
+                  description: The password used for email authentication.
+                  type: string
+                token:
+                  type: string
+              type: object
+        description: User authentication object
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+          description: User login successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Login to Mattermost server
+      tags:
+      - users
+  /api/v4/users/login/cws:
+    post:
+      description: 'CWS stands for Customer Web Server which is the cloud service used to manage cloud instances.
+
+        ##### Permissions
+
+        A Cloud license is required
+
+        '
+      operationId: LoginByCwsToken
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                cws_token:
+                  type: string
+                login_id:
+                  type: string
+              type: object
+        description: User authentication object
+        required: true
+      responses:
+        '302':
+          description: Login successful, it'll redirect to login page to perform the autologin
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Auto-Login to Mattermost server using CWS token
+      tags:
+      - users
+  /api/v4/users/login/switch:
+    post:
+      description: 'Switch a user''s login method from using email to OAuth2/SAML/LDAP or back to email. When switching to
+        OAuth2/SAML, account switching is not complete until the user follows the returned link and completes any steps on
+        the OAuth2/SAML service provider.
+
+
+        To switch from email to OAuth2/SAML, specify `current_service`, `new_service`, `email` and `password`.
+
+
+        To switch from OAuth2/SAML to email, specify `current_service`, `new_service`, `email` and `new_password`.
+
+
+        To switch from email to LDAP/AD, specify `current_service`, `new_service`, `email`, `password`, `ldap_ip` and `new_password`
+        (this is the user''s LDAP password).
+
+
+        To switch from LDAP/AD to email, specify `current_service`, `new_service`, `ldap_ip`, `password` (this is the user''s
+        LDAP password), `email`  and `new_password`.
+
+
+        Additionally, specify `mfa_code` when trying to switch an account on LDAP/AD or email that has MFA activated.
+
+
+        ##### Permissions
+
+        No current authentication required except when switching from OAuth2/SAML to email.
+
+        '
+      operationId: SwitchAccountType
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                current_service:
+                  description: The service the user currently uses to login
+                  type: string
+                email:
+                  description: The email of the user
+                  type: string
+                ldap_id:
+                  description: The LDAP/AD id of the user
+                  type: string
+                mfa_code:
+                  description: The MFA code of the current service
+                  type: string
+                new_service:
+                  description: The service the user will use to login
+                  type: string
+                password:
+                  description: The password used with the current service
+                  type: string
+              required:
+              - current_service
+              - new_service
+              type: object
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  follow_link:
+                    description: The link for the user to follow to login or to complete the account switching when the current
+                      service is OAuth2/SAML
+                    type: string
+                type: object
+          description: Login method switch or request successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+      summary: Switch login method
+      tags:
+      - users
+      x-code-samples:
+      - lang: Go
+        source: "import \"github.com/mattermost/mattermost-server/v5/model\"\n\nClient := model.NewAPIv4Client(\"https://your-mattermost-url.com\"\
+          )\n\ncurrentService := \"email\"\nnewService := \"gitlab\"\nemail := \"test@domain.com\"\npassword := \"awesomePassword\"\
+          \nmfaCode := \"adWv1qPZmHdtxk7Lmqh6RtxWxS\"\nldapLoginID := \"RdDjEDlkWgt7ndjyVLwWGvnX8c\"\n\n\nlink, resp := Client.SwitchAccountType(&model.SwitchRequest{\n\
+          \  CurrentService: currentService,\n  NewService:     newService,\n  Email:          email,\n  Password:       password,\n\
+          \  MfaCode:        mfaCode,\n  LdapLoginId:    ldapLoginID,\n})\n"
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n      ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$currentService = \"email\";\n$newService = \"gitlab\";\n$email = \"test@domain.com\";\n$password = \"awesomePassword\"\
+          ;\n$mfaCode = \"adWv1qPZmHdtxk7Lmqh6RtxWxS\";\n$ldapLoginID = \"RdDjEDlkWgt7ndjyVLwWGvnX8c\";\n\n$resp = $driver->getUserModel()->switchLoginMethod([\n\
+          \    \"current_service\" => $currentService,\n    \"new_service\" => $newService,\n    \"email\" => $email,\n  \
+          \  \"password\" => $password,\n    \"mfa_code\" => $mfaCode,\n    \"ldap_id\" => $ldapLoginID,\n]);\n\nif ($resp->getStatusCode()\
+          \ == 200) {\n   $link = json_decode($resp->getBody())->follow_link;\n}\n"
+  /api/v4/users/logout:
+    post:
+      description: '##### Permissions
+
+        An active session is required
+
+        '
+      operationId: Logout
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: User logout successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Logout from the Mattermost server
+      tags:
+      - users
+  /api/v4/users/me/top/channels:
+    get:
+      description: 'Get a list of the top public and private channels (the user is a member of) for a given user.
+
+        ##### Permissions
+
+        Must be logged in as the user.
+
+        '
+      operationId: GetTopChannelsForUser
+      parameters:
+      - description: 'Time range can be "today", "7_day", or "28_day".
+
+          - `today`: channels with posts on the current day.
+
+          - `7_day`: channels with posts in the last 7 days.
+
+          - `28_day`: channels with posts in the last 28 days.
+
+          '
+        in: query
+        name: time_range
+        required: true
+        schema:
+          type: string
+      - description: The page to select.
+        in: query
+        name: page
+        schema:
+          default: 0
+          type: integer
+      - description: The number of items per page, up to a maximum of 200.
+        in: query
+        name: per_page
+        schema:
+          default: 60
+          type: integer
+      - description: 'Team ID will scope the response to a given team.
+
+          ##### Permissions
+
+          Must have `view_team` permission for the team.
+
+          '
+        in: query
+        name: team_id
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TopChannelList'
+                type: object
+          description: Top channels retrieved successfully.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Get a list of the top channels for a user.
+      tags:
+      - insights
+  /api/v4/users/me/top/dms:
+    get:
+      description: 'Get a list of the top dms for a given user.
+
+        ##### Permissions
+
+        Must be logged in as the user.
+
+        '
+      operationId: GetTopDMsForUser
+      parameters:
+      - description: 'Time range can be "today", "7_day", or "28_day".
+
+          - `today`: threads with activity on the current day.
+
+          - `7_day`: threads with activity in the last 7 days.
+
+          - `28_day`: threads with activity in the last 28 days.
+
+          '
+        in: query
+        name: time_range
+        required: true
+        schema:
+          type: string
+      - description: The page to select.
+        in: query
+        name: page
+        schema:
+          default: 0
+          type: integer
+      - description: The number of items per page, up to a maximum of 200.
+        in: query
+        name: per_page
+        schema:
+          default: 60
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TopDMList'
+                type: object
+          description: Top dms retrieved successfully.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Get a list of the top dms for a user.
+      tags:
+      - insights
+  /api/v4/users/me/top/reactions:
+    get:
+      description: 'Get a list of the top reactions across all public and private channels (the user is a member of) for a
+        given user.
+
+        If no `team_id` is provided, this will also include reactions posted by the given user in direct and group messages.
+
+        ##### Permissions
+
+        Must be logged in as the user.
+
+        '
+      operationId: GetTopReactionsForUser
+      parameters:
+      - description: 'Time range can be "today", "7_day", or "28_day".
+
+          - `today`: reactions posted on the current day.
+
+          - `7_day`: reactions posted in the last 7 days.
+
+          - `28_day`: reactions posted in the last 28 days.
+
+          '
+        in: query
+        name: time_range
+        required: true
+        schema:
+          type: string
+      - description: The page to select.
+        in: query
+        name: page
+        schema:
+          default: 0
+          type: integer
+      - description: The number of items per page, up to a maximum of 200.
+        in: query
+        name: per_page
+        schema:
+          default: 60
+          type: integer
+      - description: 'Team ID will scope the response to a given team and exclude direct and group messages.
+
+          ##### Permissions
+
+          Must have `view_team` permission for the team.
+
+          '
+        in: query
+        name: team_id
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TopReactionList'
+                type: object
+          description: Top reactions retrieved successfully.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Get a list of the top reactions for a user.
+      tags:
+      - insights
+  /api/v4/users/me/top/threads:
+    get:
+      description: 'Get a list of the top threads from public and private channels (the user is a member of and participating
+        in the thread) for a given user.
+
+        ##### Permissions
+
+        Must be logged in as the user.
+
+        '
+      operationId: GetTopThreadsForUser
+      parameters:
+      - description: 'Time range can be "today", "7_day", or "28_day".
+
+          - `today`: threads with activity on the current day.
+
+          - `7_day`: threads with activity in the last 7 days.
+
+          - `28_day`: threads with activity in the last 28 days.
+
+          '
+        in: query
+        name: time_range
+        required: true
+        schema:
+          type: string
+      - description: The page to select.
+        in: query
+        name: page
+        schema:
+          default: 0
+          type: integer
+      - description: The number of items per page, up to a maximum of 200.
+        in: query
+        name: per_page
+        schema:
+          default: 60
+          type: integer
+      - description: 'Team ID will scope the response to a given team.
+
+          ##### Permissions
+
+          Must have `view_team` permission for the team.
+
+          '
+        in: query
+        name: team_id
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TopThreadList'
+                type: object
+          description: Top threads retrieved successfully.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Get a list of the top threads for a user.
+      tags:
+      - insights
+  /api/v4/users/mfa:
+    post:
+      description: 'Check if a user has multi-factor authentication active on their account by providing a login id. Used
+        to check whether an MFA code needs to be provided when logging in.
+
+        ##### Permissions
+
+        No permission required.
+
+        '
+      operationId: CheckUserMfa
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                login_id:
+                  description: The email or username used to login
+                  type: string
+              required:
+              - login_id
+              type: object
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  mfa_required:
+                    description: Value will `true` if MFA is active, `false` otherwise
+                    type: boolean
+                type: object
+          description: MFA check successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+      summary: Check MFA
+      tags:
+      - users
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+
+          loginID := "test@domain.com"
+
+
+          required, resp := Client.CheckUserMfa(loginID)
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$loginID = \"test@domain.com\";\n\n$resp = $driver->getUserModel()->checkMfa([\n    \"login_id\" => $loginID,\n\
+          ]);\n\nif ($resp->getStatusCode() == 200) {\n   $required = json_decode($resp->getBody())->mfa_required;\n}\n"
+  /api/v4/users/migrate_auth/ldap:
+    post:
+      description: 'Migrates accounts from one authentication provider to another. For example, you can upgrade your authentication
+        provider from email to LDAP.
+
+        __Minimum server version__: 5.28
+
+        ##### Permissions
+
+        Must have `manage_system` permission.
+
+        '
+      operationId: MigrateAuthToLdap
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                force:
+                  type: boolean
+                from:
+                  description: The current authentication type for the matched users.
+                  type: string
+                match_field:
+                  description: Foreign user field name to match.
+                  type: string
+              required:
+              - from
+              - match_field
+              - force
+              type: object
+      responses:
+        '200':
+          description: Successfully migrated authentication type to LDAP.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+      summary: Migrate user accounts authentication type to LDAP.
+      tags:
+      - users
+      - migrate
+      - authentication
+      - LDAP
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("sysadmin@domain.com", "Password1")
+
+
+          ok, response := Client.MigrateAuthToLdap(fromAuthService, matchField, force)
+
+          '
+  /api/v4/users/migrate_auth/saml:
+    post:
+      description: 'Migrates accounts from one authentication provider to another. For example, you can upgrade your authentication
+        provider from email to SAML.
+
+        __Minimum server version__: 5.28
+
+        ##### Permissions
+
+        Must have `manage_system` permission.
+
+        '
+      operationId: MigrateAuthToSaml
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                auto:
+                  type: boolean
+                from:
+                  description: The current authentication type for the matched users.
+                  type: string
+                matches:
+                  description: Users map.
+                  type: object
+              required:
+              - from
+              - matches
+              - auto
+              type: object
+      responses:
+        '200':
+          description: Successfully migrated authentication type to LDAP.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+      summary: Migrate user accounts authentication type to SAML.
+      tags:
+      - users
+      - migrate
+      - authentication
+      - SAML
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("sysadmin@domain.com", "Password1")
+
+
+          ok, response := Client.MigrateAuthToSaml(fromAuthService, usersMap, auto)
+
+          '
+  /api/v4/users/password/reset:
+    post:
+      description: 'Update the password for a user using a one-use, timed recovery code tied to the user''s account. Only
+        works for non-SSO users.
+
+        ##### Permissions
+
+        No permissions required.
+
+        '
+      operationId: ResetPassword
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                code:
+                  description: The recovery code
+                  type: string
+                new_password:
+                  description: The new password for the user
+                  type: string
+              required:
+              - code
+              - new_password
+              type: object
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: User password update successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Reset password
+      tags:
+      - users
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          code := "4xp9fdt77pncbef59f4k1qe83o"
+
+          newPassword := "awesomePassword"
+
+
+          success, resp = Client.ResetPassword(code, newPassword)
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n      ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$code = \"4xp9fdt77pncbef59f4k1qe83o\";\n$newPassword = \"awesomePassword\";\n\n$resp = $driver->getUserModel()->resetPassword([\n\
+          \    \"code\" => $code,\n    \"newPassword\" => $newPassword,\n]);\n\nif ($resp->getStatusCode() == 200) {\n   $success\
+          \ = json_decode($resp->getBody())->status;\n}\n"
+  /api/v4/users/password/reset/send:
+    post:
+      description: 'Send an email containing a link for resetting the user''s password. The link will contain a one-use, timed
+        recovery code tied to the user''s account. Only works for non-SSO users.
+
+        ##### Permissions
+
+        No permissions required.
+
+        '
+      operationId: SendPasswordResetEmail
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                email:
+                  description: The email of the user
+                  type: string
+              required:
+              - email
+              type: object
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: Email sent if account exists
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Send password reset email
+      tags:
+      - users
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+
+          email := "test@domain.com"
+
+
+          pass, resp := Client.SendVerificationEmail(email)
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n      ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$email = \"test@domain.com\";\n\n$resp = $driver->getUserModel()->sendPasswordResetEmail([\n    \"email\" => $email,\n\
+          ]);\n\nif ($resp->getStatusCode() == 200) {\n   $pass = json_decode($resp->getBody())->status;\n}\n"
+  /api/v4/users/search:
+    post:
+      description: 'Get a list of users based on search criteria provided in the request body. Searches are typically done
+        against username, full name, nickname and email unless otherwise configured by the server.
+
+        ##### Permissions
+
+        Requires an active session and `read_channel` and/or `view_team` permissions for any channels or teams specified in
+        the request body.
+
+        '
+      operationId: SearchUsers
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                allow_inactive:
+                  description: When `true`, include deactivated users in the results
+                  type: boolean
+                group_constrained:
+                  description: When used with `not_in_channel_id` or `not_in_team_id`, returns only the users that are allowed
+                    to join the channel or team based on its group constrains.
+                  type: boolean
+                in_channel_id:
+                  description: If provided, only search users in this channel
+                  type: string
+                in_group_id:
+                  description: If provided, only search users in this group. Must have `manage_system` permission.
+                  type: string
+                limit:
+                  default: 100
+                  description: 'The maximum number of users to return in the results
+
+
+                    __Available as of server version 5.6. Defaults to `100` if not provided or on an earlier server version.__
+
+                    '
+                  type: integer
+                not_in_channel_id:
+                  description: If provided, only search users not in this channel. Must specifiy `team_id` when using this
+                    option
+                  type: string
+                not_in_team_id:
+                  description: If provided, only search users not on this team
+                  type: string
+                team_id:
+                  description: If provided, only search users on this team
+                  type: string
+                term:
+                  description: The term to match against username, full name, nickname and email
+                  type: string
+                without_team:
+                  description: Set this to `true` if you would like to search for users that are not on a team. This option
+                    takes precendence over `team_id`, `in_channel_id`, and `not_in_channel_id`.
+                  type: boolean
+              required:
+              - term
+              type: object
+        description: Search criteria
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/User'
+                type: array
+          description: User list retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Search users
+      tags:
+      - users
+      x-code-samples:
+      - lang: Go
+        source: "import \"github.com/mattermost/mattermost-server/v5/model\"\n\nClient := model.NewAPIv4Client(\"https://your-mattermost-url.com\"\
+          )\nClient.Login(\"email@domain.com\", \"Password1\")\n\nteamID := \"4xp9fdt77pncbef59f4k1qe83o\"\nteamID2 := \"\
+          JhMjDX9rAlCdBf0l9oyq4eGhxw\"\nchannelID := \"Ej3SKOHlWIKAblkUTK5Xvkj2cm\"\nchannelID2 := \"dWdfrUSdjJ7kyBvyBCgCav67Kz\"\
+          \n\nusers, resp := Client.SearchUsers(&model.UserSearch{\n  Term:           \"searchTerm\",\n  TeamId:         teamID,\n\
+          \  NotInTeamId:    teamID2,\n  InChannelId:    channelID,\n  NotInChannelId: channelID2,\n  AllowInactive:  true,\n\
+          \  WithoutTeam:    true,\n  Limit:          100,\n  Role:           \"admin\",\n})\n"
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$teamID = \"4xp9fdt77pncbef59f4k1qe83o\";\n$teamID2 = \"JhMjDX9rAlCdBf0l9oyq4eGhxw\";\n$channelID = \"Ej3SKOHlWIKAblkUTK5Xvkj2cm\"\
+          ;\n$channelID2 = \"dWdfrUSdjJ7kyBvyBCgCav67Kz\";\n\n$resp = $driver->getUserModel()->searchUsers([\n    \"term\"\
+          \ => \"searchTerm\",\n    \"team_id\" => $teamID,\n    \"not_in_team_id\" => $teamID2,\n    \"in_channel_id\" =>\
+          \ $channelID,\n    \"not_in_channel_id\" => $channelID2,\n    \"allow_inactive\" => true,\n    \"without_team\"\
+          \ => true,\n    \"limit\" => 100,\n]);\n\nif ($resp->getStatusCode() == 200) {\n    $users = json_decode($resp->getBody());\n\
+          }\n"
+  /api/v4/users/sessions/device:
+    put:
+      description: 'Attach a mobile device id to the currently logged in session. This will enable push notifications for
+        a user, if configured by the server.
+
+        ##### Permissions
+
+        Must be authenticated.
+
+        '
+      operationId: AttachDeviceId
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                device_id:
+                  description: Mobile device id. For Android prefix the id with `android:` and Apple with `apple:`
+                  type: string
+              required:
+              - device_id
+              type: object
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: Device id attach successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+      summary: Attach mobile device
+      tags:
+      - users
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          deviceID := "zWEyrTZ7GZ22aBSfoX60iWryTY"
+
+
+          pass, resp := Client.AttachDeviceId(deviceID)
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n      ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$deviceID = \"zWEyrTZ7GZ22aBSfoX60iWryTY\";\n\n$resp = $driver->getUserModel()->attachMobileDevice([\n    \"device_id\"\
+          \ => $deviceID,\n]);\n\nif ($resp->getStatusCode() == 200) {\n   $pass = json_decode($resp->getBody())->status;\n\
+          }\n"
+  /api/v4/users/sessions/revoke/all:
+    post:
+      description: 'For any session currently on the server (including admin) it will be revoked.
+
+        Clients will be notified to log out users.
+
+
+        __Minimum server version__: 5.14
+
+
+        ##### Permissions
+
+        Must have `manage_system` permission.
+
+        '
+      operationId: RevokeSessionsFromAllUsers
+      responses:
+        '200':
+          description: Sessions successfully revoked.
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Revoke all sessions from all users.
+      tags:
+      - users
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          response, err := Client.RevokeSessionsFromAllUsers()
+
+          '
+  /api/v4/users/stats:
+    get:
+      description: 'Get a total count of users in the system.
+
+        ##### Permissions
+
+        Must be authenticated.
+
+        '
+      operationId: GetTotalUsersStats
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UsersStats'
+          description: User stats retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Get total count of users in the system
+      tags:
+      - users
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          stats, resp := Client.GetTotalUsersStats("")
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n     ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$resp = $driver->getUserModel()->getTotalCountOfUsersInTheSystem();\n\nif ($resp->getStatusCode() == 200) {\n\
+          \    $stats = json_decode($resp->getBody())->total_users_count;\n}\n"
+  /api/v4/users/stats/filtered:
+    get:
+      description: 'Get a count of users in the system matching the specified filters.
+
+
+        __Minimum server version__: 5.26
+
+
+        ##### Permissions
+
+        Must have `manage_system` permission.
+
+        '
+      operationId: GetTotalUsersStatsFiltered
+      parameters:
+      - description: The ID of the team to get user stats for.
+        in: query
+        name: in_team
+        schema:
+          type: string
+      - description: The ID of the channel to get user stats for.
+        in: query
+        name: in_channel
+        schema:
+          type: string
+      - description: If deleted accounts should be included in the count.
+        in: query
+        name: include_deleted
+        schema:
+          type: boolean
+      - description: If bot accounts should be included in the count.
+        in: query
+        name: include_bots
+        schema:
+          type: boolean
+      - description: 'Comma separated string used to filter users based on any of the specified system roles
+
+
+          Example: `?roles=system_admin,system_user` will include users that are either system admins or system users
+
+          '
+        in: query
+        name: roles
+        schema:
+          type: string
+      - description: 'Comma separated string used to filter users based on any of the specified channel roles, can only be
+          used in conjunction with `in_channel`
+
+
+          Example: `?in_channel=4eb6axxw7fg3je5iyasnfudc5y&channel_roles=channel_user` will include users that are only channel
+          users and not admins or guests
+
+          '
+        in: query
+        name: channel_roles
+        schema:
+          type: string
+      - description: 'Comma separated string used to filter users based on any of the specified team roles, can only be used
+          in conjunction with `in_team`
+
+
+          Example: `?in_team=4eb6axxw7fg3je5iyasnfudc5y&team_roles=team_user` will include users that are only team users
+          and not admins or guests
+
+          '
+        in: query
+        name: team_roles
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UsersStats'
+          description: Filtered User stats retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Get total count of users in the system matching the specified filters
+      tags:
+      - users
+  /api/v4/users/status/ids:
+    post:
+      description: 'Get a list of user statuses by id from the server.
+
+        ##### Permissions
+
+        Must be authenticated.
+
+        '
+      operationId: GetUsersStatusesByIds
+      requestBody:
+        content:
+          application/json:
+            schema:
+              items:
+                type: string
+              type: array
+        description: List of user ids to fetch
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/Status'
+                type: array
+          description: User statuses retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+      summary: Get user statuses by id
+      tags:
+      - status
+  /api/v4/users/tokens:
+    get:
+      description: 'Get a page of user access tokens for users on the system. Does not include the actual authentication tokens.
+        Use query parameters for paging.
+
+
+        __Minimum server version__: 4.7
+
+
+        ##### Permissions
+
+        Must have `manage_system` permission.
+
+        '
+      operationId: GetUserAccessTokens
+      parameters:
+      - description: The page to select.
+        in: query
+        name: page
+        schema:
+          default: 0
+          type: integer
+      - description: The number of tokens per page.
+        in: query
+        name: per_page
+        schema:
+          default: 60
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/UserAccessTokenSanitized'
+                type: array
+          description: User access tokens retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Get user access tokens
+      tags:
+      - users
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          tokens, resp := Client.GetUserAccessTokens(0, 100)
+
+          '
+  /api/v4/users/tokens/disable:
+    post:
+      description: 'Disable a personal access token and delete any sessions using the token. The token can be re-enabled using
+        `/users/tokens/enable`.
+
+
+        __Minimum server version__: 4.4
+
+
+        ##### Permissions
+
+        Must have `revoke_user_access_token` permission. For non-self requests, must also have the `edit_other_users` permission.
+
+        '
+      operationId: DisableUserAccessToken
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                token_id:
+                  description: The personal access token GUID to disable
+                  type: string
+              required:
+              - token_id
+              type: object
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: Personal access token disable successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Disable personal access token
+      tags:
+      - users
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          tokenID := "adWv1qPZmHdtxk7Lmqh6RtxWxS"
+
+
+          ok, resp := Client.DisableUserAccessToken(tokenID)
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n      ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$tokenID = \"adWv1qPZmHdtxk7Lmqh6RtxWxS\";\n\n$resp = $driver->getUserModel()->disablePersonalAccessToken([\n\
+          \    \"token_id\" => $tokenID\n]);\n\nif ($resp->getStatusCode() == 200) {\n   $ok = json_decode($resp->getBody())->status;\n\
+          }\n"
+  /api/v4/users/tokens/enable:
+    post:
+      description: 'Re-enable a personal access token that has been disabled.
+
+
+        __Minimum server version__: 4.4
+
+
+        ##### Permissions
+
+        Must have `create_user_access_token` permission. For non-self requests, must also have the `edit_other_users` permission.
+
+        '
+      operationId: EnableUserAccessToken
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                token_id:
+                  description: The personal access token GUID to enable
+                  type: string
+              required:
+              - token_id
+              type: object
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: Personal access token enable successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Enable personal access token
+      tags:
+      - users
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          tokenID := "adWv1qPZmHdtxk7Lmqh6RtxWxS"
+
+
+          ok, resp := Client.EnableUserAccessToken(tokenID)
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n      ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$tokenID = \"adWv1qPZmHdtxk7Lmqh6RtxWxS\";\n\n$resp = $driver->getUserModel()->enablePersonalAccessToken([\n \
+          \   \"token_id\" => $tokenID\n]);\n\nif ($resp->getStatusCode() == 200) {\n   $ok = json_decode($resp->getBody())->status;\n\
+          }\n"
+  /api/v4/users/tokens/revoke:
+    post:
+      description: 'Revoke a user access token and delete any sessions using the token.
+
+
+        __Minimum server version__: 4.1
+
+
+        ##### Permissions
+
+        Must have `revoke_user_access_token` permission. For non-self requests, must also have the `edit_other_users` permission.
+
+        '
+      operationId: RevokeUserAccessToken
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                token_id:
+                  description: The user access token GUID to revoke
+                  type: string
+              required:
+              - token_id
+              type: object
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: User access token revoke successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Revoke a user access token
+      tags:
+      - users
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          tokenID := "adWv1qPZmHdtxk7Lmqh6RtxWxS"
+
+
+          ok, resp := Client.RevokeUserAccessToken(tokenID)
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n      ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$tokenID = \"adWv1qPZmHdtxk7Lmqh6RtxWxS\";\n\n$resp = $driver->getUserModel()->revokeToken([\n    \"token_id\"\
+          \ => $tokenID,\n]);\n\nif ($resp->getStatusCode() == 200) {\n   $ok = json_decode($resp->getBody())->status;\n}\n"
+  /api/v4/users/tokens/search:
+    post:
+      description: 'Get a list of tokens based on search criteria provided in the request body. Searches are done against
+        the token id, user id and username.
+
+
+        __Minimum server version__: 4.7
+
+
+        ##### Permissions
+
+        Must have `manage_system` permission.
+
+        '
+      operationId: SearchUserAccessTokens
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                term:
+                  description: The search term to match against the token id, user id or username.
+                  type: string
+              required:
+              - term
+              type: object
+        description: Search criteria
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/UserAccessTokenSanitized'
+                type: array
+          description: Personal access token search successful
+      summary: Search tokens
+      tags:
+      - users
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          tokenID := "adWv1qPZmHdtxk7Lmqh6RtxWxS"
+
+
+          userAccessTokens, resp = Client.SearchUserAccessTokens(&model.UserAccessTokenSearch{Term: tokenID})
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n      ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$tokenID = \"adWv1qPZmHdtxk7Lmqh6RtxWxS\";\n\n$resp = $driver->getUserModel()->searchTokens([\n    \"term\" =>\
+          \ $tokenID\n]);\n\nif ($resp->getStatusCode() == 200) {\n   $userAccessTokens = json_decode($resp->getBody());\n\
+          }\n"
+  /api/v4/users/tokens/{token_id}:
+    get:
+      description: 'Get a user access token. Does not include the actual authentication token.
+
+
+        __Minimum server version__: 4.1
+
+
+        ##### Permissions
+
+        Must have `read_user_access_token` permission. For non-self requests, must also have the `edit_other_users` permission.
+
+        '
+      operationId: GetUserAccessToken
+      parameters:
+      - description: User access token GUID
+        in: path
+        name: token_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserAccessTokenSanitized'
+          description: User access token retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Get a user access token
+      tags:
+      - users
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          tokenID := "adWv1qPZmHdtxk7Lmqh6RtxWxS"
+
+
+          token, resp := Client.GetUserAccessToken(tokenID)
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n      ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$tokenID = \"adWv1qPZmHdtxk7Lmqh6RtxWxS\";\n\n$resp = $driver->getUserModel()->getToken($tokenID);\n\nif ($resp->getStatusCode()\
+          \ == 200) {\n   $token = json_decode($resp->getBody());\n}\n"
+  /api/v4/users/username/{username}:
+    get:
+      description: 'Get a user object by providing a username. Sensitive information will be sanitized out.
+
+        ##### Permissions
+
+        Requires an active session but no other permissions.
+
+        '
+      operationId: GetUserByUsername
+      parameters:
+      - description: Username
+        in: path
+        name: username
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+          description: User retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Get a user by username
+      tags:
+      - users
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          userID := "4xp9fdt77pncbef59f4k1qe83o"
+
+
+          user, resp := Client.GetUserByUsername(userID, "")
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n      ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$username = \"username\";\n\n$resp = $driver->getUserModel()->getUserByUsername($username);\n\nif ($resp->getStatusCode()\
+          \ == 200) {\n   $user = json_decode($resp->getBody());\n}\n"
+  /api/v4/users/usernames:
+    post:
+      description: 'Get a list of users based on a provided list of usernames.
+
+        ##### Permissions
+
+        Requires an active session but no other permissions.
+
+        '
+      operationId: GetUsersByUsernames
+      requestBody:
+        content:
+          application/json:
+            schema:
+              items:
+                type: string
+              type: array
+        description: List of usernames
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/User'
+                type: array
+          description: User list retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+      summary: Get users by usernames
+      tags:
+      - users
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          users, resp := Client.GetUsersByUsernames([]string{"username1", "username2"})
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$resp = $driver->getUserModel()->getUsersByUsernames([\n    \"username1\",\n    \"username2\",\n]);\n\nif ($resp->getStatusCode()\
+          \ == 200) {\n    $users = json_decode($resp->getBody());\n}\n"
+  /api/v4/users/{user_id}:
+    delete:
+      description: 'Deactivates the user and revokes all its sessions by archiving its user object.
+
+
+        As of server version 5.28, optionally use the `permanent=true` query parameter to permanently delete the user for
+        compliance reasons. To use this feature `ServiceSettings.EnableAPIUserDeletion` must be set to `true` in the server''s
+        configuration.
+
+        ##### Permissions
+
+        Must be logged in as the user being deactivated or have the `edit_other_users` permission.
+
+        '
+      operationId: DeleteUser
+      parameters:
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: User deactivation successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Deactivate a user account.
+      tags:
+      - users
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          userID := "4xp9fdt77pncbef59f4k1qe83o"
+
+
+          ok, resp := Client.DeleteUser(userID)
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n      ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$userID = \"4xp9fdt77pncbef59f4k1qe83o\";\n\n$resp = $driver->getUserModel()->deactivateUserAccount($userID);\n\
+          \nif ($resp->getStatusCode() == 200) {\n   $ok = json_decode($resp->getBody())->status;\n}\n"
+    get:
+      description: 'Get a user a object. Sensitive information will be sanitized out.
+
+        ##### Permissions
+
+        Requires an active session but no other permissions.
+
+        '
+      operationId: GetUser
+      parameters:
+      - description: User GUID. This can also be "me" which will point to the current user.
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+          description: User retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Get a user
+      tags:
+      - users
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          userID := "4xp9fdt77pncbef59f4k1qe83o"
+
+
+          user, resp := Client.GetUser(userID, "")
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n      ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$userID = \"4xp9fdt77pncbef59f4k1qe83o\";\n\n$resp = $driver->getUserModel()->getUser($userID);\n\nif ($resp->getStatusCode()\
+          \ == 200) {\n    $user = json_decode($resp->getBody());\n}\n"
+    put:
+      description: 'Update a user by providing the user object. The fields that can be updated are defined in the request
+        body, all other provided fields will be ignored. Any fields not included in the request body will be set to null or
+        reverted to default values.
+
+        ##### Permissions
+
+        Must be logged in as the user being updated or have the `edit_other_users` permission.
+
+        '
+      operationId: UpdateUser
+      parameters:
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                email:
+                  type: string
+                first_name:
+                  type: string
+                id:
+                  type: string
+                last_name:
+                  type: string
+                locale:
+                  type: string
+                nickname:
+                  type: string
+                notify_props:
+                  $ref: '#/components/schemas/UserNotifyProps'
+                position:
+                  type: string
+                props:
+                  type: object
+                timezone:
+                  $ref: '#/components/schemas/Timezone'
+                username:
+                  type: string
+              required:
+              - id
+              - email
+              - username
+              type: object
+        description: User object that is to be updated
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+          description: User update successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Update a user
+      tags:
+      - users
+      x-code-samples:
+      - lang: Go
+        source: "import \"github.com/mattermost/mattermost-server/v5/model\"\n\nClient := model.NewAPIv4Client(\"https://your-mattermost-url.com\"\
+          )\nClient.Login(\"email@domain.com\", \"Password1\")\n\nuserID := \"4xp9fdt77pncbef59f4k1qe83o\"\nemail := \"test@domain.com\"\
+          \nusername := \"testUsername\"\nfirstName := \"testFirstname\"\nlastName := \"testLastname\"\nnickname := \"testNickname\"\
+          \nlocale := \"en\"\nposition := \"testPosition\"\nprops := model.StringMap{}\nprops[\"testPropKey\"] = \"testPropValue\"\
+          \nnotifyProps := model.StringMap{}\nnotifyProps[\"comment\"] = \"somethingrandom\"\n\nuser, resp := Client.UpdateUser(&model.User{\n\
+          \  Id:          userID,\n  Email:       email,\n  Username:    username,\n  FirstName:   firstName,\n  LastName:\
+          \    lastName,\n  Nickname:    nickname,\n  Locale:      locale,\n  Position:    position,\n  Props:       props,\n\
+          \  NotifyProps: notifyProps,\n})\n"
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n      ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$userID = \"4xp9fdt77pncbef59f4k1qe83o\";\n$email = \"test@domain.com\";\n$username = \"testUsername\";\n$firstName\
+          \ = \"testFirstname\";\n$lastName = \"testLastname\";\n$nickname = \"testNickname\";\n$locale = \"en\";\n$position\
+          \ = \"testPosition\";\n$props = [];\n$props[\"testPropKey\"] = \"testPropValue\";\n$notifyProps = [];\n$notifyProps[\"\
+          comment\"] = \"somethingrandom\";\n\n$resp = $driver->getUserModel()->updateUser($userID, [\n    \"email\" => $email,\n\
+          \    \"username\" => $username,\n    \"first_name\" => $firstName,\n    \"last_name\" => $lastName,\n    \"nickname\"\
+          \ => $nickname,\n    \"locale\" => $locale,\n    \"position\" => $position,\n    \"props\" => $props,\n    \"notify_props\"\
+          \ => $notifyProps,\n]);\n\nif ($resp->getStatusCode() == 200) {\n    $user = json_decode($resp->getBody());\n}\n"
+  /api/v4/users/{user_id}/active:
+    put:
+      description: 'Update user active or inactive status.
+
+
+        __Since server version 4.6, users using a SSO provider to login can be activated or deactivated with this endpoint.
+        However, if their activation status in Mattermost does not reflect their status in the SSO provider, the next synchronization
+        or login by that user will reset the activation status to that of their account in the SSO provider. Server versions
+        4.5 and before do not allow activation or deactivation of SSO users from this endpoint.__
+
+        ##### Permissions
+
+        User can deactivate themselves.
+
+        User with `manage_system` permission can activate or deactivate a user.
+
+        '
+      operationId: UpdateUserActive
+      parameters:
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                active:
+                  type: boolean
+              required:
+              - active
+              type: object
+        description: Use `true` to set the user active, `false` for inactive
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: User active status update successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Update user active status
+      tags:
+      - users
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          userID := "4xp9fdt77pncbef59f4k1qe83o"
+
+
+          ok, resp := Client.UpdateUserActive(userID, true)
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n      ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$userID = \"4xp9fdt77pncbef59f4k1qe83o\";\n\n$resp = $driver->getUserModel()->updateUserActive($userID, [\n  \
+          \  \"active\" => true,\n]);\n\nif ($resp->getStatusCode() == 200) {\n   $ok = json_decode($resp->getBody())->status;\n\
+          }\n"
+  /api/v4/users/{user_id}/audits:
+    get:
+      description: 'Get a list of audit by providing the user GUID.
+
+        ##### Permissions
+
+        Must be logged in as the user or have the `edit_other_users` permission.
+
+        '
+      operationId: GetUserAudits
+      parameters:
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/Audit'
+                type: array
+          description: User audits retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Get user's audits
+      tags:
+      - users
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          userID := "zWEyrTZ7GZ22aBSfoX60iWryTY"
+
+
+          audits, resp := Client.GetUserAudits(userID, 0, 100, "")
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n      ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$userID = \"zWEyrTZ7GZ22aBSfoX60iWryTY\";\n\n$resp = $driver->getUserModel()->getUserAudits($userID);\n\nif ($resp->getStatusCode()\
+          \ == 200) {\n   $audits = json_decode($resp->getBody());\n}\n"
+  /api/v4/users/{user_id}/auth:
+    put:
+      description: 'Updates a user''s authentication method. This can be used to change them to/from LDAP authentication for
+        example.
+
+
+        __Minimum server version__: 4.6
+
+        ##### Permissions
+
+        Must have the `edit_other_users` permission.
+
+        '
+      operationId: UpdateUserAuth
+      parameters:
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserAuthData'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserAuthData'
+          description: User auth update successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+      summary: Update a user's authentication method
+      tags:
+      - users
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          userID := "adWv1qPZmHdtxk7Lmqh6RtxWxS"
+
+          user, resp := Client.GetUser(userID, "")
+
+          userAuth := &model.UserAuth{}
+
+          userAuth.AuthData = user.AuthData
+
+          userAuth.AuthService = user.AuthService
+
+
+          user, resp := Client.UpdateUserAuth(userID, userAuth)
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n      ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$userID = \"adWv1qPZmHdtxk7Lmqh6RtxWxS\";\n$resp = $driver->getUserModel()->getUser($userID);\n\nif ($resp->getStatusCode()\
+          \ == 200) {\n    $user = json_decode($resp->getBody());\n} else {\n    throw new \\Exception(\"User not found.\"\
+          );\n}\n\n$userAuth = [];\n$userAuth[\"auth_data\"] = $user->auth_data;\n$userAuth[\"auth_service\"] = $user->auth_service;\n\
+          \n$resp = $driver->getUserModel()->updateUserAuthenticationMethod($userID, $userAuth);\n\nif ($resp->getStatusCode()\
+          \ == 200) {\n   $user = json_decode($resp->getBody());\n}\n"
+  /api/v4/users/{user_id}/channel_members:
+    get:
+      description: 'Get all channel members from all teams for a user.
+
+
+        __Minimum server version__: 6.2.0
+
+
+        ##### Permissions
+
+        Logged in as the user, or have `edit_other_users` permission.
+
+        '
+      operationId: GetChannelMembersWithTeamDataForUser
+      parameters:
+      - description: The ID of the user. This can also be "me" which will point to the current user.
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      - description: Page specifies which part of the results to return, by PageSize.
+        in: query
+        name: page
+        required: false
+        schema:
+          type: integer
+      - description: PageSize specifies the size of the returned chunk of results.
+        in: query
+        name: pageSize
+        required: false
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/ChannelMemberWithTeamData'
+                type: array
+          description: User's uploads retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Get all channel members from all teams for a user
+      tags:
+      - users
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+          channels, response, err := Client.GetChannelMembersWithTeamData("fc6suoon9pbbpmhrb9c967paxe", 0, 10)
+
+          '
+      - lang: Curl
+        source: 'curl ''http://localhost:8065/api/v4/users/me/channel_members?page=0&per_page=2'' \
+
+          -H ''Authorization: Bearer 9kg8nqrnxprd9jbykqeg4r51hw'' \
+
+          '
+  /api/v4/users/{user_id}/channels:
+    get:
+      description: 'Get all channels from all teams that a user is a member of.
+
+
+        __Minimum server version__: 6.1
+
+
+        ##### Permissions
+
+
+        Logged in as the user, or have `edit_other_users` permission.
+
+        '
+      operationId: GetChannelsForUser
+      parameters:
+      - description: The ID of the user. This can also be "me" which will point to the current user.
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      - description: Filters the deleted channels by this time in epoch format. Does not have any effect if include_deleted
+          is set to false.
+        in: query
+        name: last_delete_at
+        schema:
+          default: 0
+          type: integer
+      - description: Defines if deleted channels should be returned or not
+        in: query
+        name: include_deleted
+        schema:
+          default: false
+          type: boolean
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/Channel'
+                type: array
+          description: Channels retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Get all channels from all teams
+      tags:
+      - channels
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v6/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+          channels, response, err := Client.GetChannelsForUserWithLastDeleteAt("fc6suoon9pbbpmhrb9c967paxe", 0)
+
+          '
+      - lang: Curl
+        source: 'curl -X GET ''http://localhost:8065/api/v4/users/fc6suoon9pbbpmhrb9c967paxe/channels'' \
+
+          -H ''Authorization: Bearer 9kg8nqrnxprd9jbykqeg4r51hw''
+
+          '
+  /api/v4/users/{user_id}/channels/{channel_id}/posts/unread:
+    get:
+      description: 'Get the oldest unread post in the channel for the given user as well as the posts around it. The returned
+        list is sorted in descending order (most recent post first).
+
+        ##### Permissions
+
+        Must be logged in as the user or have `edit_other_users` permission, and must have `read_channel` permission for the
+        channel.
+
+        __Minimum server version__: 5.14
+
+        '
+      operationId: GetPostsAroundLastUnread
+      parameters:
+      - description: ID of the user
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      - description: The channel ID to get the posts for
+        in: path
+        name: channel_id
+        required: true
+        schema:
+          type: string
+      - description: Number of posts before the oldest unread posts. Maximum is 200 posts if limit is set greater than that.
+        in: query
+        name: limit_before
+        schema:
+          default: 60
+          maximum: 200
+          minimum: 0
+          type: integer
+      - description: Number of posts after and including the oldest unread post. Maximum is 200 posts if limit is set greater
+          than that.
+        in: query
+        name: limit_after
+        schema:
+          default: 60
+          maximum: 200
+          minimum: 1
+          type: integer
+      - description: Whether to skip fetching threads or not
+        in: query
+        name: skipFetchThreads
+        schema:
+          default: false
+          type: boolean
+      - description: Whether the client uses CRT or not
+        in: query
+        name: collapsedThreads
+        schema:
+          default: false
+          type: boolean
+      - description: Whether to return the associated users as part of the response or not
+        in: query
+        name: collapsedThreadsExtended
+        schema:
+          default: false
+          type: boolean
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PostList'
+          description: Post list retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Get posts around oldest unread
+      tags:
+      - posts
+  /api/v4/users/{user_id}/channels/{channel_id}/unread:
+    get:
+      description: 'Get the total unread messages and mentions for a channel for a user.
+
+        ##### Permissions
+
+        Must be logged in as user and have the `read_channel` permission, or have `edit_other_usrs` permission.
+
+        '
+      operationId: GetChannelUnread
+      parameters:
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      - description: Channel GUID
+        in: path
+        name: channel_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChannelUnread'
+          description: Channel unreads retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Get unread messages
+      tags:
+      - channels
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          // GetChannelUnread
+
+          channelUnread, resp := Client.GetChannelUnread(<CHANNELID>, <USERID>)
+
+          '
+  /api/v4/users/{user_id}/convert_to_bot:
+    post:
+      description: 'Convert a user into a bot.
+
+
+        __Minimum server version__: 5.26
+
+
+        ##### Permissions
+
+        Must have `manage_system` permission.
+
+        '
+      operationId: ConvertUserToBot
+      parameters:
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: User successfully converted
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Convert a user into a bot
+      tags:
+      - bots
+      - users
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+
+          userId := "BbaYBYDV5IDOZFiJGBSzkw1k5u"
+
+
+          bot, resp := Client.ConvertUserToBot(userId)
+
+          '
+  /api/v4/users/{user_id}/data_retention/channel_policies:
+    get:
+      description: 'Gets the policies which are applied to the all of the channels to which a user belongs.
+
+
+        __Minimum server version__: 5.35
+
+
+        ##### Permissions
+
+        Must be logged in as the user or have the `manage_system` permission.
+
+
+        ##### License
+
+        Requires an E20 license.
+
+        '
+      operationId: GetChannelPoliciesForUser
+      parameters:
+      - description: The ID of the user. This can also be "me" which will point to the current user.
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      - description: The page to select.
+        in: query
+        name: page
+        schema:
+          default: 0
+          type: integer
+      - description: The number of policies per page. There is a maximum limit of 200 per page.
+        in: query
+        name: per_page
+        schema:
+          default: 60
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RetentionPolicyForChannelList'
+          description: Channels for retention policy successfully retrieved.
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+      summary: Get the policies which are applied to a user's channels
+      tags:
+      - data retention
+  /api/v4/users/{user_id}/data_retention/team_policies:
+    get:
+      description: 'Gets the policies which are applied to the all of the teams to which a user belongs.
+
+
+        __Minimum server version__: 5.35
+
+
+        ##### Permissions
+
+        Must be logged in as the user or have the `manage_system` permission.
+
+
+        ##### License
+
+        Requires an E20 license.
+
+        '
+      operationId: GetTeamPoliciesForUser
+      parameters:
+      - description: The ID of the user. This can also be "me" which will point to the current user.
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      - description: The page to select.
+        in: query
+        name: page
+        schema:
+          default: 0
+          type: integer
+      - description: The number of policies per page. There is a maximum limit of 200 per page.
+        in: query
+        name: per_page
+        schema:
+          default: 60
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RetentionPolicyForTeamList'
+          description: Teams for retention policy successfully retrieved.
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+      summary: Get the policies which are applied to a user's teams
+      tags:
+      - data retention
+  /api/v4/users/{user_id}/demote:
+    post:
+      description: 'Convert a regular user into a guest. This will convert the user into a
+
+        guest for the whole system while retaining their existing team and
+
+        channel memberships.
+
+
+        __Minimum server version__: 5.16
+
+
+        ##### Permissions
+
+        Must be logged in as the user or have the `demote_to_guest` permission.
+
+        '
+      operationId: DemoteUserToGuest
+      parameters:
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: User successfully demoted
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+      summary: Demote a user to a guest
+      tags:
+      - users
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          userID := "BbaYBYDV5IDOZFiJGBSzkw1k5u"
+
+
+          ok, resp = Client.demoteUserToGuest(userID)
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n      ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$userID = \"BbaYBYDV5IDOZFiJGBSzkw1k5u\";\n\n$resp = $driver->getUserModel()->demoteUserToGuest($userID);\n\n\
+          if ($resp->getStatusCode() == 200) {\n   $ok = json_decode($resp->getBody()->status;\n}\n"
+  /api/v4/users/{user_id}/email/verify/member:
+    post:
+      description: 'Verify the email used by a user without a token.
+
+
+        __Minimum server version__: 5.24
+
+
+        ##### Permissions
+
+
+        Must have `manage_system` permission.
+
+        '
+      operationId: VerifyUserEmailWithoutToken
+      parameters:
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+          description: User email verification successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Verify user email by ID
+      tags:
+      - users
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          userID := "BbaYBYDV5IDOZFiJGBSzkw1k5u
+
+
+          user, resp := Client.VerifyUserEmailWithoutToken(userID)
+
+          '
+  /api/v4/users/{user_id}/groups:
+    get:
+      description: 'Retrieve the list of groups associated to the user
+
+
+        __Minimum server version__: 5.24
+
+        '
+      operationId: GetGroupsByUserId
+      parameters:
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/Group'
+                type: array
+          description: Group list retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+      summary: Get groups for a userId
+      tags:
+      - groups
+  /api/v4/users/{user_id}/mfa:
+    put:
+      description: 'Activates multi-factor authentication for the user if `activate` is true and a valid `code` is provided.
+        If activate is false, then `code` is not required and multi-factor authentication is disabled for the user.
+
+        ##### Permissions
+
+        Must be logged in as the user being updated or have the `edit_other_users` permission.
+
+        '
+      operationId: UpdateUserMfa
+      parameters:
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                activate:
+                  description: Use `true` to activate, `false` to deactivate
+                  type: boolean
+                code:
+                  description: The code produced by your MFA client. Required if `activate` is true
+                  type: string
+              required:
+              - activate
+              type: object
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: User MFA update successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+      summary: Update a user's MFA
+      tags:
+      - users
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          userID := "BbaYBYDV5IDOZFiJGBSzkw1k5u"
+
+          code := "4xp9fdt77pncbef59f4k1qe83o"
+
+
+          ok, resp := Client.UpdateUserMfa(userID, code, true)
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n      ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$userID = \"BbaYBYDV5IDOZFiJGBSzkw1k5u\";\n$code = \"4xp9fdt77pncbef59f4k1qe83o\";\n\n$resp = $driver->getUserModel()->updateUserMfa($userID,\
+          \ [\n    \"activate\" => true,\n    \"code\" => $code,\n]);\n\nif ($resp->getStatusCode() == 200) {\n   $ok = json_decode($resp->getBody()->status;\n\
+          }\n"
+  /api/v4/users/{user_id}/mfa/generate:
+    post:
+      description: 'Generates an multi-factor authentication secret for a user and returns it as a string and as base64 encoded
+        QR code image.
+
+        ##### Permissions
+
+        Must be logged in as the user or have the `edit_other_users` permission.
+
+        '
+      operationId: GenerateMfaSecret
+      parameters:
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  qr_code:
+                    description: A base64 encoded QR code image
+                    type: string
+                  secret:
+                    description: The MFA secret as a string
+                    type: string
+                type: object
+          description: MFA secret generation successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+      summary: Generate MFA secret
+      tags:
+      - users
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          userID := "BbaYBYDV5IDOZFiJGBSzkw1k5u"
+
+
+          mfaSecret, resp = Client.GenerateMfaSecret(userID)
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n      ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$userID = \"BbaYBYDV5IDOZFiJGBSzkw1k5u\";\n\n$resp = $driver->getUserModel()->generateMfaSecret($userID);\n\n\
+          if ($resp->getStatusCode() == 200) {\n   $mfaSecret = json_decode($resp->getBody());\n}\n"
+  /api/v4/users/{user_id}/oauth/apps/authorized:
+    get:
+      description: 'Get a page of OAuth 2.0 client applications authorized to access a user''s account.
+
+        ##### Permissions
+
+        Must be authenticated as the user or have `edit_other_users` permission.
+
+        '
+      operationId: GetAuthorizedOAuthAppsForUser
+      parameters:
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      - description: The page to select.
+        in: query
+        name: page
+        schema:
+          default: 0
+          type: integer
+      - description: The number of apps per page.
+        in: query
+        name: per_page
+        schema:
+          default: 60
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/OAuthApp'
+                type: array
+          description: OAuthApp list retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+      summary: Get authorized OAuth apps
+      tags:
+      - OAuth
+  /api/v4/users/{user_id}/password:
+    put:
+      description: 'Update a user''s password. New password must meet password policy set by server configuration. Current
+        password is required if you''re updating your own password.
+
+        ##### Permissions
+
+        Must be logged in as the user the password is being changed for or have `manage_system` permission.
+
+        '
+      operationId: UpdateUserPassword
+      parameters:
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                current_password:
+                  description: The current password for the user
+                  type: string
+                new_password:
+                  description: The new password for the user
+                  type: string
+              required:
+              - new_password
+              type: object
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: User password update successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Update a user's password
+      tags:
+      - users
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          userID := "BbaYBYDV5IDOZFiJGBSzkw1k5u"
+
+          currentPassword := "badPassword"
+
+          newPassword := "awesomePassword"
+
+
+          ok, resp := Client.UpdateUserPassword(userID, currentPassword, newPassword)
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n      ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$userID = \"BbaYBYDV5IDOZFiJGBSzkw1k5u\";\n$currentPassword = \"badPassword\";\n$newPassword = \"awesomePassword\"\
+          ;\n\n$resp = $driver->getUserModel()->updateUserPassword($userID, [\n    \"current_password\" => $currentPassword,\n\
+          \    \"new_password\" => $newPassword,\n]);\n\nif ($resp->getStatusCode() == 200) {\n   $ok = json_decode($resp->getBody())->status;\n\
+          }\n"
+  /api/v4/users/{user_id}/patch:
+    put:
+      description: 'Partially update a user by providing only the fields you want to update. Omitted fields will not be updated.
+        The fields that can be updated are defined in the request body, all other provided fields will be ignored.
+
+        ##### Permissions
+
+        Must be logged in as the user being updated or have the `edit_other_users` permission.
+
+        '
+      operationId: PatchUser
+      parameters:
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                email:
+                  type: string
+                first_name:
+                  type: string
+                last_name:
+                  type: string
+                locale:
+                  type: string
+                nickname:
+                  type: string
+                notify_props:
+                  $ref: '#/components/schemas/UserNotifyProps'
+                position:
+                  type: string
+                props:
+                  type: object
+                username:
+                  type: string
+              type: object
+        description: User object that is to be updated
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+          description: User patch successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Patch a user
+      tags:
+      - users
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          userID := "4xp9fdt77pncbef59f4k1qe83o"
+
+
+          patch := &model.UserPatch{}
+
+          patch.Email = model.NewString("test@domain.com")
+
+          patch.Username = model.NewString("testUsername")
+
+          patch.FirstName = model.NewString("testFirstname")
+
+          patch.LastName = model.NewString("testLastname")
+
+          patch.Nickname = model.NewString("testNickname")
+
+          patch.Locale = model.NewString("en")
+
+          patch.Position = model.NewString("testPosition")
+
+          patch.Props = model.StringMap{}
+
+          patch.Props["testPropKey"] = "testPropValue"
+
+          patch.NotifyProps = model.StringMap{}
+
+          patch.NotifyProps["comment"] = "somethingrandom"
+
+
+          user, resp := Client.PatchUser(userID, patch)
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n      ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$userID = \"4xp9fdt77pncbef59f4k1qe83o\";\n$email = \"test@domain.com\";\n$username = \"testUsername\";\n$firstName\
+          \ = \"testFirstname\";\n$lastName = \"testLastname\";\n$nickname = \"testNickname\";\n$locale = \"en\";\n$position\
+          \ = \"testPosition\";\n$props = [];\n$props[\"testPropKey\"] = \"testPropValue\";\n$notifyProps = [];\n$notifyProps[\"\
+          comment\"] = \"somethingrandom\";\n\n$resp = $driver->getUserModel()->patchUser($userID, [\n  \"email\" => $email,\n\
+          \  \"username\" => $username,\n  \"first_name\" => $firstName,\n  \"last_name\" => $lastName,\n  \"nickname\" =>\
+          \ $nickname,\n  \"locale\" => $locale,\n  \"position\" => $position,\n  \"props\" => $props,\n  \"notify_props\"\
+          \ => $notifyProps,\n]);\n\nif ($resp->getStatusCode() == 200) {\n   $user = json_decode($resp->getBody());\n}\n"
+  /api/v4/users/{user_id}/posts/flagged:
+    get:
+      description: 'Get a page of flagged posts of a user provided user id string. Selects from a channel, team, or all flagged
+        posts by a user. Will only return posts from channels in which the user is member.
+
+        ##### Permissions
+
+        Must be user or have `manage_system` permission.
+
+        '
+      operationId: GetFlaggedPostsForUser
+      parameters:
+      - description: ID of the user
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      - description: Team ID
+        in: query
+        name: team_id
+        schema:
+          type: string
+      - description: Channel ID
+        in: query
+        name: channel_id
+        schema:
+          type: string
+      - description: The page to select
+        in: query
+        name: page
+        schema:
+          default: 0
+          type: integer
+      - description: The number of posts per page
+        in: query
+        name: per_page
+        schema:
+          default: 60
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/PostList'
+                type: array
+          description: Post list retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Get a list of flagged posts
+      tags:
+      - posts
+  /api/v4/users/{user_id}/posts/{post_id}/ack:
+    delete:
+      description: 'Delete an acknowledgement form a post that you had previously acknowledged.
+
+        ##### Permissions
+
+        Must have `read_channel` permission for the channel the post is in.<br/> Must be logged in as the user or have `edit_other_users`
+        permission.<br/> The post must have been acknowledged in the previous 5 minutes.
+
+
+        __Minimum server version__: 7.7
+
+        '
+      operationId: SaveAcknowledgementForPost
+      parameters:
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      - description: Post GUID
+        in: path
+        name: post_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: Acknowledgement deleted successfully
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Delete a post acknowledgement
+      tags:
+      - posts
+    post:
+      description: 'Acknowledge a post that has a request for acknowledgements.
+
+        ##### Permissions
+
+        Must have `read_channel` permission for the channel the post is in.<br/> Must be logged in as the user or have `edit_other_users`
+        permission.
+
+
+        __Minimum server version__: 7.7
+
+        '
+      operationId: SaveAcknowledgementForPost
+      parameters:
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      - description: Post GUID
+        in: path
+        name: post_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PostAcknowledgement'
+          description: Acknowledgement saved successfully
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Acknowledge a post
+      tags:
+      - posts
+  /api/v4/users/{user_id}/posts/{post_id}/reactions/{emoji_name}:
+    delete:
+      description: 'Deletes a reaction made by a user from the given post.
+
+        ##### Permissions
+
+        Must be user or have `manage_system` permission.
+
+        '
+      operationId: DeleteReaction
+      parameters:
+      - description: ID of the user
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      - description: ID of the post
+        in: path
+        name: post_id
+        required: true
+        schema:
+          type: string
+      - description: emoji name
+        in: path
+        name: emoji_name
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: Reaction deletion successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Remove a reaction from a post
+      tags:
+      - reactions
+  /api/v4/users/{user_id}/posts/{post_id}/reminder:
+    post:
+      description: 'Set a reminder for the user for the post.
+
+        ##### Permissions
+
+        Must have `read_channel` permission for the channel the post is in.
+
+
+        __Minimum server version__: 7.2
+
+        '
+      operationId: SetPostReminder
+      parameters:
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      - description: Post GUID
+        in: path
+        name: post_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                target_time:
+                  description: Target time for the reminder
+                  type: integer
+              required:
+              - target_time
+              type: object
+        description: Target time for the reminder
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: Reminder set successfully
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Set a post reminder
+      tags:
+      - posts
+  /api/v4/users/{user_id}/posts/{post_id}/set_unread:
+    post:
+      description: 'Mark a channel as being unread from a given post.
+
+        ##### Permissions
+
+        Must have `read_channel` permission for the channel the post is in or if the channel is public, have the `read_public_channels`
+        permission for the team.
+
+        Must have `edit_other_users` permission if the user is not the one marking the post for himself.
+
+
+        __Minimum server version__: 5.18
+
+        '
+      operationId: SetPostUnread
+      parameters:
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      - description: Post GUID
+        in: path
+        name: post_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChannelUnreadAt'
+          description: Post marked as unread successfully
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Mark as unread from a post.
+      tags:
+      - posts
+  /api/v4/users/{user_id}/preferences:
+    get:
+      description: 'Get a list of the user''s preferences.
+
+        ##### Permissions
+
+        Must be logged in as the user being updated or have the `edit_other_users` permission.
+
+        '
+      operationId: GetPreferences
+      parameters:
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/Preference'
+                type: array
+          description: User preferences retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Get the user's preferences
+      tags:
+      - preferences
+    put:
+      description: 'Save a list of the user''s preferences.
+
+        ##### Permissions
+
+        Must be logged in as the user being updated or have the `edit_other_users` permission.
+
+        '
+      operationId: UpdatePreferences
+      parameters:
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              items:
+                $ref: '#/components/schemas/Preference'
+              type: array
+        description: List of preference objects
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: User preferences saved successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Save the user's preferences
+      tags:
+      - preferences
+  /api/v4/users/{user_id}/preferences/delete:
+    post:
+      description: 'Delete a list of the user''s preferences.
+
+        ##### Permissions
+
+        Must be logged in as the user being updated or have the `edit_other_users` permission.
+
+        '
+      operationId: DeletePreferences
+      parameters:
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              items:
+                $ref: '#/components/schemas/Preference'
+              type: array
+        description: List of preference objects
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: User preferences saved successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Delete user's preferences
+      tags:
+      - preferences
+  /api/v4/users/{user_id}/preferences/{category}:
+    get:
+      description: 'Lists the current user''s stored preferences in the given category.
+
+        ##### Permissions
+
+        Must be logged in as the user being updated or have the `edit_other_users` permission.
+
+        '
+      operationId: GetPreferencesByCategory
+      parameters:
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      - description: The category of a group of preferences
+        in: path
+        name: category
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/Preference'
+                type: array
+          description: A list of all of the current user's preferences in the given category
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: List a user's preferences by category
+      tags:
+      - preferences
+  /api/v4/users/{user_id}/preferences/{category}/name/{preference_name}:
+    get:
+      description: 'Gets a single preference for the current user with the given category and name.
+
+        ##### Permissions
+
+        Must be logged in as the user being updated or have the `edit_other_users` permission.
+
+        '
+      operationId: GetPreferencesByCategoryByName
+      parameters:
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      - description: The category of a group of preferences
+        in: path
+        name: category
+        required: true
+        schema:
+          type: string
+      - description: The name of the preference
+        in: path
+        name: preference_name
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Preference'
+          description: 'A single preference for the current user in the current categorylist of all of the current user''s
+            preferences in the given category.
+
+            '
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+      summary: Get a specific user preference
+      tags:
+      - preferences
+  /api/v4/users/{user_id}/promote:
+    post:
+      description: 'Convert a guest into a regular user. This will convert the guest into a
+
+        user for the whole system while retaining any team and channel
+
+        memberships and automatically joining them to the default channels.
+
+
+        __Minimum server version__: 5.16
+
+
+        ##### Permissions
+
+        Must be logged in as the user or have the `promote_guest` permission.
+
+        '
+      operationId: PromoteGuestToUser
+      parameters:
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: Guest successfully promoted
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+      summary: Promote a guest to user
+      tags:
+      - users
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          userID := "BbaYBYDV5IDOZFiJGBSzkw1k5u"
+
+
+          ok, resp = Client.PromoteGuestToUser(userID)
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n      ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$userID = \"BbaYBYDV5IDOZFiJGBSzkw1k5u\";\n\n$resp = $driver->getUserModel()->promoteGuestToUser($userID);\n\n\
+          if ($resp->getStatusCode() == 200) {\n   $ok = json_decode($resp->getBody()->status;\n}\n"
+  /api/v4/users/{user_id}/roles:
+    put:
+      description: 'Update a user''s system-level roles. Valid user roles are "system_user", "system_admin" or both of them.
+        Overwrites any previously assigned system-level roles.
+
+        ##### Permissions
+
+        Must have the `manage_roles` permission.
+
+        '
+      operationId: UpdateUserRoles
+      parameters:
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                roles:
+                  type: string
+              required:
+              - roles
+              type: object
+        description: Space-delimited system roles to assign to the user
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: User roles update successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Update a user's roles
+      tags:
+      - users
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          userID := "4xp9fdt77pncbef59f4k1qe83o"
+
+          roles := "team_user team_admin"
+
+
+          ok, resp = Client.UpdateUserRoles(userID, roles)
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n      ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$userID = \"4xp9fdt77pncbef59f4k1qe83o\";\n$roles = \"team_user team_admin\";\n\n$resp = $driver->getUserModel()->updateUserRoles($userID,\
+          \ [\n    \"roles\" => $roles,\n]);\n\nif ($resp->getStatusCode() == 200) {\n   $ok = json_decode($resp->getBody())->status;\n\
+          }\n"
+  /api/v4/users/{user_id}/sessions:
+    get:
+      description: 'Get a list of sessions by providing the user GUID. Sensitive information will be sanitized out.
+
+        ##### Permissions
+
+        Must be logged in as the user being updated or have the `edit_other_users` permission.
+
+        '
+      operationId: GetSessions
+      parameters:
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/Session'
+                type: array
+          description: User session retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Get user's sessions
+      tags:
+      - users
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          userID := "zWEyrTZ7GZ22aBSfoX60iWryTY"
+
+
+          sessions, resp := Client.GetSessions(userID, "")
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n      ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$userID = \"zWEyrTZ7GZ22aBSfoX60iWryTY\";\n\n$resp = $driver->getUserModel()->getUserSessions($userID);\n\nif\
+          \ ($resp->getStatusCode() == 200) {\n   $sessions = json_decode($resp->getBody());\n}\n"
+  /api/v4/users/{user_id}/sessions/revoke:
+    post:
+      description: 'Revokes a user session from the provided user id and session id strings.
+
+        ##### Permissions
+
+        Must be logged in as the user being updated or have the `edit_other_users` permission.
+
+        '
+      operationId: RevokeSession
+      parameters:
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                session_id:
+                  description: The session GUID to revoke.
+                  type: string
+              required:
+              - session_id
+              type: object
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: User session revoked successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Revoke a user session
+      tags:
+      - users
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          userID := "zWEyrTZ7GZ22aBSfoX60iWryTY"
+
+          sessionID := "adWv1qPZmHdtxk7Lmqh6RtxWxS"
+
+
+          ok, resp = Client.RevokeSession(userID, sessionID)
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n      ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$userID = \"zWEyrTZ7GZ22aBSfoX60iWryTY\";\n$sessionID = \"adWv1qPZmHdtxk7Lmqh6RtxWxS\";\n\n$resp = $driver->getUserModel()->revokeUserSession($userID,\
+          \ [\n    \"session_id\" => $sessionID,\n]);\n\nif ($resp->getStatusCode() == 200) {\n   $ok = json_decode($resp->getBody())->status;\n\
+          }\n"
+  /api/v4/users/{user_id}/sessions/revoke/all:
+    post:
+      description: 'Revokes all user sessions from the provided user id and session id strings.
+
+        ##### Permissions
+
+        Must be logged in as the user being updated or have the `edit_other_users` permission.
+
+        __Minimum server version__: 4.4
+
+        '
+      operationId: RevokeAllSessions
+      parameters:
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: User sessions revoked successfully
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Revoke all active sessions for a user
+      tags:
+      - users
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          userID := "zWEyrTZ7GZ22aBSfoX60iWryTY"
+
+
+          ok, resp := Client.RevokeAllSessions(userID)
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n      ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$userID = \"zWEyrTZ7GZ22aBSfoX60iWryTY\";\n\n$resp = $driver->getUserModel()->revokeAllUserSessions($userID);\n\
+          \nif ($resp->getStatusCode() == 200) {\n   $ok = json_decode($resp->getBody())->status;\n}\n"
+  /api/v4/users/{user_id}/status:
+    get:
+      description: 'Get user status by id from the server.
+
+        ##### Permissions
+
+        Must be authenticated.
+
+        '
+      operationId: GetUserStatus
+      parameters:
+      - description: User ID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+          description: User status retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+      summary: Get user status
+      tags:
+      - status
+    put:
+      description: 'Manually set a user''s status. When setting a user''s status, the status will remain that value until
+        set "online" again, which will return the status to being automatically updated based on user activity.
+
+        ##### Permissions
+
+        Must have `edit_other_users` permission for the team.
+
+        '
+      operationId: UpdateUserStatus
+      parameters:
+      - description: User ID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                dnd_end_time:
+                  description: Time in epoch seconds at which a dnd status would be unset.
+                  type: integer
+                status:
+                  description: User status, can be `online`, `away`, `offline` and `dnd`
+                  type: string
+                user_id:
+                  description: User ID
+                  type: string
+              required:
+              - status
+              - user_id
+              type: object
+        description: Status object that is to be updated
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+          description: User status update successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+      summary: Update user status
+      tags:
+      - status
+  /api/v4/users/{user_id}/status/custom:
+    delete:
+      description: 'Unsets a user''s custom status by updating the user''s props and updates the user
+
+        ##### Permissions
+
+        Must be logged in as the user whose custom status is being removed.
+
+        '
+      operationId: UnsetUserCustomStatus
+      parameters:
+      - description: User ID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: User custom status delete successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+      summary: Unsets user custom status
+      tags:
+      - status
+    put:
+      description: 'Updates a user''s custom status by setting the value in the user''s props and updates the user. Also save
+        the given custom status to the recent custom statuses in the user''s props
+
+        ##### Permissions
+
+        Must be logged in as the user whose custom status is being updated.
+
+        '
+      operationId: UpdateUserCustomStatus
+      parameters:
+      - description: User ID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                duration:
+                  description: Duration of custom status, can be `thirty_minutes`, `one_hour`, `four_hours`, `today`, `this_week`
+                    or `date_and_time`
+                  type: string
+                emoji:
+                  description: Any emoji
+                  type: string
+                expires_at:
+                  description: The time at which custom status should be expired. It should be in ISO format.
+                  type: string
+                text:
+                  description: Any custom status text
+                  type: string
+              required:
+              - emoji
+              - text
+              type: object
+        description: Custom status object that is to be updated
+        required: true
+      responses:
+        '200':
+          description: User custom status update successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+      summary: Update user custom status
+      tags:
+      - status
+  /api/v4/users/{user_id}/status/custom/recent:
+    delete:
+      description: 'Deletes a user''s recent custom status by removing the specific status from the recentCustomStatuses in
+        the user''s props and updates the user.
+
+        ##### Permissions
+
+        Must be logged in as the user whose recent custom status is being deleted.
+
+        '
+      operationId: RemoveRecentCustomStatus
+      parameters:
+      - description: User ID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                duration:
+                  description: Duration of custom status, can be `thirty_minutes`, `one_hour`, `four_hours`, `today`, `this_week`
+                    or `date_and_time`
+                  type: string
+                emoji:
+                  description: Any emoji
+                  type: string
+                expires_at:
+                  description: The time at which custom status should be expired. It should be in ISO format.
+                  type: string
+                text:
+                  description: Any custom status text
+                  type: string
+              required:
+              - emoji
+              - text
+              - duration
+              - expires_at
+              type: object
+        description: Custom Status object that is to be removed from the recent custom statuses.
+        required: true
+      responses:
+        '200':
+          description: User recent custom status delete successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+      summary: Delete user's recent custom status
+      tags:
+      - status
+  /api/v4/users/{user_id}/status/custom/recent/delete:
+    post:
+      description: 'Deletes a user''s recent custom status by removing the specific status from the recentCustomStatuses in
+        the user''s props and updates the user.
+
+        ##### Permissions
+
+        Must be logged in as the user whose recent custom status is being deleted.
+
+        '
+      operationId: PostUserRecentCustomStatusDelete
+      parameters:
+      - description: User ID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                duration:
+                  description: Duration of custom status, can be `thirty_minutes`, `one_hour`, `four_hours`, `today`, `this_week`
+                    or `date_and_time`
+                  type: string
+                emoji:
+                  description: Any emoji
+                  type: string
+                expires_at:
+                  description: The time at which custom status should be expired. It should be in ISO format.
+                  type: string
+                text:
+                  description: Any custom status text
+                  type: string
+              required:
+              - emoji
+              - text
+              - duration
+              - expires_at
+              type: object
+        description: Custom Status object that is to be removed from the recent custom statuses.
+        required: true
+      responses:
+        '200':
+          description: User recent custom status delete successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+      summary: Delete user's recent custom status
+      tags:
+      - status
+  /api/v4/users/{user_id}/teams:
+    get:
+      description: 'Get a list of teams that a user is on.
+
+        ##### Permissions
+
+        Must be authenticated as the user or have the `manage_system` permission.
+
+        '
+      operationId: GetTeamsForUser
+      parameters:
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/Team'
+                type: array
+          description: Team list retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Get a user's teams
+      tags:
+      - teams
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          userID := "4xp9fdt77pncbef59f4k1qe83o"
+
+
+          teams, resp := Client.GetTeamsForUser(userID, "")
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$userID = \"4xp9fdt77pncbef59f4k1qe83o\";\n\n$resp = $driver->getTeamModel()->getUserTeams($userID);\n\nif ($resp->getStatusCode()\
+          \ == 200) {\n    $teams = json_decode($resp->getBody());\n}\n"
+  /api/v4/users/{user_id}/teams/members:
+    get:
+      description: 'Get a list of team members for a user. Useful for getting the ids of teams the user is on and the roles
+        they have in those teams.
+
+        ##### Permissions
+
+        Must be logged in as the user or have the `edit_other_users` permission.
+
+        '
+      operationId: GetTeamMembersForUser
+      parameters:
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/TeamMember'
+                type: array
+          description: Team members retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Get team members for a user
+      tags:
+      - teams
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          userID := "zWEyrTZ7GZ22aBSfoX60iWryTY"
+
+
+          teamMembers, resp = Client.GetTeamMembersForUser(userID, "")
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$userID = \"zWEyrTZ7GZ22aBSfoX60iWryTY\";\n\n$resp = $driver->getTeamModel()->getTeamMembersForUser($userID);\n\
+          \nif ($resp->getStatusCode() == 200) {\n    $teamMembers = json_decode($resp->getBody());\n}\n"
+  /api/v4/users/{user_id}/teams/unread:
+    get:
+      description: 'Get the count for unread messages and mentions in the teams the user is a member of.
+
+        ##### Permissions
+
+        Must be logged in.
+
+        '
+      operationId: GetTeamsUnreadForUser
+      parameters:
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      - description: Optional team id to be excluded from the results
+        in: query
+        name: exclude_team
+        required: true
+        schema:
+          type: string
+      - description: Boolean to determine whether the collapsed threads should be included or not
+        in: query
+        name: include_collapsed_threads
+        required: false
+        schema:
+          default: false
+          type: boolean
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/TeamUnread'
+                type: array
+          description: Team unreads retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Get team unreads for a user
+      tags:
+      - teams
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          userID := "NqCSr5HMDZjrWS74IEmedvlOYf"
+
+          teamID := "zWEyrTZ7GZ22aBSfoX60iWryTY"
+
+
+          teams, resp := Client.GetTeamsUnreadForUser(userID, teamID)
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$userID = \"NqCSr5HMDZjrWS74IEmedvlOYf\";\n$teamID = \"zWEyrTZ7GZ22aBSfoX60iWryTY\";\n\n$resp = $driver->getTeamModel()->getUserTotalUnreadMessagesFromTeams($userID,\
+          \ [\n  \"exclude_team\" => $teamID,\n]);\n\nif ($resp->getStatusCode() == 200) {\n    $teams = json_decode($resp->getBody());\n\
+          }\n"
+  /api/v4/users/{user_id}/teams/{team_id}/channels:
+    get:
+      description: 'Get all the channels on a team for a user.
+
+        ##### Permissions
+
+        Logged in as the user, or have `edit_other_users` permission, and `view_team` permission for the team.
+
+        '
+      operationId: GetChannelsForTeamForUser
+      parameters:
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      - description: Defines if deleted channels should be returned or not
+        in: query
+        name: include_deleted
+        schema:
+          default: false
+          type: boolean
+      - description: Filters the deleted channels by this time in epoch format. Does not have any effect if include_deleted
+          is set to false.
+        in: query
+        name: last_delete_at
+        schema:
+          default: 0
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/Channel'
+                type: array
+          description: Channels retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Get channels for user
+      tags:
+      - channels
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          // GetChannelsForTeamForUser
+
+          channels, resp := Client.GetChannelsForTeamForUser(<TEAMID>, <USERID>, "")
+
+          '
+  /api/v4/users/{user_id}/teams/{team_id}/channels/categories:
+    get:
+      description: 'Get a list of sidebar categories that will appear in the user''s sidebar on the given team, including
+        a list of channel IDs in each category.
+
+        __Minimum server version__: 5.26
+
+        ##### Permissions
+
+        Must be authenticated and have the `list_team_channels` permission.
+
+        '
+      operationId: GetSidebarCategoriesForTeamForUser
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/OrderedSidebarCategories'
+                type: array
+          description: Category retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Get user's sidebar categories
+      tags:
+      - channels
+    post:
+      description: 'Create a custom sidebar category for the user on the given team.
+
+        __Minimum server version__: 5.26
+
+        ##### Permissions
+
+        Must be authenticated and have the `list_team_channels` permission.
+
+        '
+      operationId: CreateSidebarCategoryForTeamForUser
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SidebarCategory'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SidebarCategory'
+          description: Category creation successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Create user's sidebar category
+      tags:
+      - channels
+    put:
+      description: 'Update any number of sidebar categories for the user on the given team. This can be used to reorder the
+        channels in these categories.
+
+        __Minimum server version__: 5.26
+
+        ##### Permissions
+
+        Must be authenticated and have the `list_team_channels` permission.
+
+        '
+      operationId: UpdateSidebarCategoriesForTeamForUser
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              items:
+                $ref: '#/components/schemas/SidebarCategory'
+              type: array
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SidebarCategory'
+          description: Category update successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Update user's sidebar categories
+      tags:
+      - channels
+  /api/v4/users/{user_id}/teams/{team_id}/channels/categories/order:
+    get:
+      description: 'Returns the order of the sidebar categories for a user on the given team as an array of IDs.
+
+        __Minimum server version__: 5.26
+
+        ##### Permissions
+
+        Must be authenticated and have the `list_team_channels` permission.
+
+        '
+      operationId: GetSidebarCategoryOrderForTeamForUser
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  type: string
+                type: array
+          description: Order retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Get user's sidebar category order
+      tags:
+      - channels
+    put:
+      description: 'Updates the order of the sidebar categories for a user on the given team. The provided array must include
+        the IDs of all categories on the team.
+
+        __Minimum server version__: 5.26
+
+        ##### Permissions
+
+        Must be authenticated and have the `list_team_channels` permission.
+
+        '
+      operationId: UpdateSidebarCategoryOrderForTeamForUser
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              items:
+                type: string
+              type: array
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  type: string
+                type: array
+          description: Order update successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Update user's sidebar category order
+      tags:
+      - channels
+  /api/v4/users/{user_id}/teams/{team_id}/channels/categories/{category_id}:
+    delete:
+      description: 'Deletes a single sidebar category for the user on the given team. Only custom categories can be deleted.
+
+        __Minimum server version__: 5.26
+
+        ##### Permissions
+
+        Must be authenticated and have the `list_team_channels` permission.
+
+        '
+      operationId: RemoveSidebarCategoryForTeamForUser
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      - description: Category GUID
+        in: path
+        name: category_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SidebarCategory'
+          description: Category delete successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Delete sidebar category
+      tags:
+      - channels
+    get:
+      description: 'Returns a single sidebar category for the user on the given team.
+
+        __Minimum server version__: 5.26
+
+        ##### Permissions
+
+        Must be authenticated and have the `list_team_channels` permission.
+
+        '
+      operationId: GetSidebarCategoryForTeamForUser
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      - description: Category GUID
+        in: path
+        name: category_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SidebarCategory'
+          description: Category retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Get sidebar category
+      tags:
+      - channels
+    put:
+      description: 'Updates a single sidebar category for the user on the given team.
+
+        __Minimum server version__: 5.26
+
+        ##### Permissions
+
+        Must be authenticated and have the `list_team_channels` permission.
+
+        '
+      operationId: UpdateSidebarCategoryForTeamForUser
+      parameters:
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      - description: Category GUID
+        in: path
+        name: category_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SidebarCategory'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SidebarCategory'
+          description: Category update successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Update sidebar category
+      tags:
+      - channels
+  /api/v4/users/{user_id}/teams/{team_id}/channels/members:
+    get:
+      description: 'Get all channel memberships and associated membership roles (i.e. `channel_user`, `channel_admin`) for
+        a user on a specific team.
+
+        ##### Permissions
+
+        Logged in as the user and `view_team` permission for the team. Having `manage_system` permission voids the previous
+        requirements.
+
+        '
+      operationId: GetChannelMembersForUser
+      parameters:
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/ChannelMember'
+                type: array
+          description: Channel members retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Get channel memberships and roles for a user
+      tags:
+      - channels
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          // GetChannelMembersForUser
+
+          members, resp := Client.GetChannelMembersForUser(<USERID>, <TEAMID>, "")
+
+          '
+  /api/v4/users/{user_id}/teams/{team_id}/threads:
+    get:
+      description: 'Get all threads that user is following
+
+
+        __Minimum server version__: 5.29
+
+
+        ##### Permissions
+
+        Must be logged in as the user or have `edit_other_users` permission.
+
+        '
+      operationId: GetUserThreads
+      parameters:
+      - description: The ID of the user. This can also be "me" which will point to the current user.
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      - description: The ID of the team in which the thread is.
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      - description: Since filters the threads based on their LastUpdateAt timestamp.
+        in: query
+        name: since
+        required: false
+        schema:
+          type: integer
+      - description: Deleted will specify that even deleted threads should be returned (For mobile sync).
+        in: query
+        name: deleted
+        required: false
+        schema:
+          default: false
+          type: boolean
+      - description: Extended will enrich the response with participant details.
+        in: query
+        name: extended
+        required: false
+        schema:
+          default: false
+          type: boolean
+      - description: Page specifies which part of the results to return, by PageSize.
+        in: query
+        name: page
+        required: false
+        schema:
+          default: 0
+          type: integer
+      - description: PageSize specifies the size of the returned chunk of results.
+        in: query
+        name: pageSize
+        required: false
+        schema:
+          default: 30
+          type: integer
+      - description: Setting this to true will only return the total counts.
+        in: query
+        name: totalsOnly
+        required: false
+        schema:
+          default: false
+          type: boolean
+      - description: Setting this to true will only return threads.
+        in: query
+        name: threadsOnly
+        required: false
+        schema:
+          default: false
+          type: boolean
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserThreads'
+          description: User's thread retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Get all threads that user is following
+      tags:
+      - threads
+      x-code-samples:
+      - lang: Go
+        source: "import \"github.com/mattermost/mattermost-server/v5/model\"\nClient := model.NewAPIv4Client(\"https://your-mattermost-url.com\"\
+          ) Client.Login(\"email@domain.com\", \"Password1\")\nuss, response := Client.GetUserThreads(\"fc6suoon9pbbpmhrb9c967paxe\"\
+          , \"fc6su111111pmhrb9c967paxe\", model.GetUserThreadsOpts{\n                                                   \
+          \                         Deleted: true,\n                                                                     \
+          \       Since: 123123,\n                                                                            Page: 0,\n \
+          \                                                                           PageSize: 40,\n                    \
+          \                                                        })\n"
+      - lang: Curl
+        source: 'curl ''http://localhost:8065/api/v4/users/fc6suoon9pbbpmhrb9c967paxe/threads'' \
+
+          -H ''Authorization: Bearer 9kg8nqrnxprd9jbykqeg4r51hw'' \
+
+          '
+  /api/v4/users/{user_id}/teams/{team_id}/threads/mention_counts:
+    get:
+      description: 'Get all unread mention counts from followed threads
+
+
+        __Minimum server version__: 5.29
+
+
+        ##### Permissions
+
+        Must be logged in as the user or have `edit_other_users` permission.
+
+        '
+      operationId: GetThreadMentionCountsByChannel
+      parameters:
+      - description: The ID of the user. This can also be "me" which will point to the current user.
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      - description: The ID of the team in which the thread is.
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Get was successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Get all unread mention counts from followed threads, per-channel
+      tags:
+      - threads
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+          uss, response := Client.GetThreadMentionsForUserPerChannel("fc6suoon9pbbpmhrb9c967paxe", "fc6su111111pmhrb9c967paxe")
+
+          '
+      - lang: Curl
+        source: "curl -X PUT 'http://localhost:8065/api/v4/users/fc6suoon9pbbpmhrb9c967paxe/threads/mention_counts' \\\n-H\
+          \ 'Authorization: Bearer 9kg8nqrnxprd9jbykqeg4r51hw' \\          \n"
+  /api/v4/users/{user_id}/teams/{team_id}/threads/read:
+    put:
+      description: 'Mark all threads that user is following as read
+
+
+        __Minimum server version__: 5.29
+
+
+        ##### Permissions
+
+        Must be logged in as the user or have `edit_other_users` permission.
+
+        '
+      operationId: UpdateThreadsReadForUser
+      parameters:
+      - description: The ID of the user. This can also be "me" which will point to the current user.
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      - description: The ID of the team in which the thread is.
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: User's thread update successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Mark all threads that user is following as read
+      tags:
+      - threads
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+          uss, response := Client.UpdateThreadsReadForUser("fc6suoon9pbbpmhrb9c967paxe", "fc6su111111pmhrb9c967paxe")
+
+          '
+      - lang: Curl
+        source: 'curl -X PUT ''http://localhost:8065/api/v4/users/fc6suoon9pbbpmhrb9c967paxe/threads/read'' \
+
+          -H ''Authorization: Bearer 9kg8nqrnxprd9jbykqeg4r51hw'' \
+
+          '
+  /api/v4/users/{user_id}/teams/{team_id}/threads/{thread_id}:
+    get:
+      description: 'Get a thread
+
+
+        __Minimum server version__: 5.29
+
+
+        ##### Permissions
+
+        Must be logged in as the user or have `edit_other_users` permission.
+
+        '
+      operationId: GetUserThread
+      parameters:
+      - description: The ID of the user. This can also be "me" which will point to the current user.
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      - description: The ID of the team in which the thread is.
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      - description: The ID of the thread to follow
+        in: path
+        name: thread_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Get was successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Get a thread followed by the user
+      tags:
+      - threads
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+          uss, response := Client.GetUserThread("fc6suoon9pbbpmhrb9c967paxe", "fc6su111111pmhrb9c967paxe", "f96cv0897624352346e")
+
+          '
+      - lang: Curl
+        source: 'curl -X GET ''http://localhost:8065/api/v4/users/fc6suoon9pbbpmhrb9c967paxe/threads/f96345234975624'' \
+
+          -H ''Authorization: Bearer 9kg8nqrnxprd9jbykqeg4r51hw'' \
+
+          '
+  /api/v4/users/{user_id}/teams/{team_id}/threads/{thread_id}/following:
+    delete:
+      description: 'Stop following a thread
+
+
+        __Minimum server version__: 5.29
+
+
+        ##### Permissions
+
+        Must be logged in as the user or have `edit_other_users` permission.
+
+        '
+      operationId: StopFollowingThread
+      parameters:
+      - description: The ID of the user. This can also be "me" which will point to the current user.
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      - description: The ID of the team in which the thread is.
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      - description: The ID of the thread to update
+        in: path
+        name: thread_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: User's thread update successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Stop following a thread
+      tags:
+      - threads
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+          uss, response := Client.UpdateThreadFollowForUser("fc6suoon9pbbpmhrb9c967paxe", "fc6su111111pmhrb9c967paxe", "f96cv0897624352346e"
+          false)
+
+          '
+      - lang: Curl
+        source: 'curl -X DELETE ''http://localhost:8065/api/v4/users/fc6suoon9pbbpmhrb9c967paxe/threads/f96345234975624/following''
+          \
+
+          -H ''Authorization: Bearer 9kg8nqrnxprd9jbykqeg4r51hw'' \
+
+          '
+    put:
+      description: 'Start following a thread
+
+
+        __Minimum server version__: 5.29
+
+
+        ##### Permissions
+
+        Must be logged in as the user or have `edit_other_users` permission.
+
+        '
+      operationId: StartFollowingThread
+      parameters:
+      - description: The ID of the user. This can also be "me" which will point to the current user.
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      - description: The ID of the team in which the thread is.
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      - description: The ID of the thread to follow
+        in: path
+        name: thread_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: User's thread update successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Start following a thread
+      tags:
+      - threads
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+          uss, response := Client.UpdateThreadFollowForUser("fc6suoon9pbbpmhrb9c967paxe", "fc6su111111pmhrb9c967paxe", "f96cv0897624352346e"
+          true)
+
+          '
+      - lang: Curl
+        source: 'curl -X PUT ''http://localhost:8065/api/v4/users/fc6suoon9pbbpmhrb9c967paxe/threads/f96345234975624/followin''
+          \
+
+          -H ''Authorization: Bearer 9kg8nqrnxprd9jbykqeg4r51hw'' \
+
+          '
+  /api/v4/users/{user_id}/teams/{team_id}/threads/{thread_id}/read/{timestamp}:
+    put:
+      description: 'Mark a thread that user is following as read
+
+
+        __Minimum server version__: 5.29
+
+
+        ##### Permissions
+
+        Must be logged in as the user or have `edit_other_users` permission.
+
+        '
+      operationId: UpdateThreadReadForUser
+      parameters:
+      - description: The ID of the user. This can also be "me" which will point to the current user.
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      - description: The ID of the team in which the thread is.
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      - description: The ID of the thread to update
+        in: path
+        name: thread_id
+        required: true
+        schema:
+          type: string
+      - description: The timestamp to which the thread's "last read" state will be reset.
+        in: path
+        name: timestamp
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: User's thread update successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Mark a thread that user is following read state to the timestamp
+      tags:
+      - threads
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+          uss, response := Client.UpdateThreadReadForUser("fc6suoon9pbbpmhrb9c967paxe", "fc6su111111pmhrb9c967paxe", "f96cv0897624352346e"
+          true)
+
+          '
+      - lang: Curl
+        source: "curl -X PUT 'http://localhost:8065/api/v4/users/fc6suoon9pbbpmhrb9c967paxe/threads/f96345234975624/read'\
+          \ \\\n-H 'Authorization: Bearer 9kg8nqrnxprd9jbykqeg4r51hw' \n"
+  /api/v4/users/{user_id}/teams/{team_id}/threads/{thread_id}/set_unread/{post_id}:
+    put:
+      description: 'Mark a thread that user is following as unread
+
+
+        __Minimum server version__: 6.7
+
+
+        ##### Permissions
+
+        Must have `read_channel` permission for the channel the thread is in or if the channel is public, have the `read_public_channels`
+        permission for the team.
+
+
+        Must have `edit_other_users` permission if the user is not the one marking the thread for himself.
+
+        '
+      operationId: SetThreadUnreadByPostId
+      parameters:
+      - description: The ID of the user. This can also be "me" which will point to the current user.
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      - description: The ID of the team in which the thread is.
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      - description: The ID of the thread to update
+        in: path
+        name: thread_id
+        required: true
+        schema:
+          type: string
+      - description: The ID of a post belonging to the thread to mark as unread.
+        in: path
+        name: post_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: User's thread update successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Mark a thread that user is following as unread based on a post id
+      tags:
+      - threads
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+          uss, response := Client.SetThreadUnreadByPostId("fc6suoon9pbbpmhrb9c967paxe", "fc6su111111pmhrb9c967paxe", "f96cv0897624352346e",
+          "f96cv0897624352346e")
+
+          '
+      - lang: Curl
+        source: "curl -X PUT 'http://localhost:8065/api/v4/users/fc6suoon9pbbpmhrb9c967paxe/teams/fc6su111111pmhrb9c967paxe/threads/f96cv0897624352346e/set_unread'\
+          \ \\\n-H 'Authorization: Bearer 9kg8nqrnxprd9jbykqeg4r51hw' \n"
+  /api/v4/users/{user_id}/teams/{team_id}/unread:
+    get:
+      description: 'Get the unread mention and message counts for a team for the specified user.
+
+        ##### Permissions
+
+        Must be the user or have `edit_other_users` permission and have `view_team` permission for the team.
+
+        '
+      operationId: GetTeamUnread
+      parameters:
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      - description: Team GUID
+        in: path
+        name: team_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TeamUnread'
+          description: Team unread count retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Get unreads for a team
+      tags:
+      - teams
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          userID := "NqCSr5HMDZjrWS74IEmedvlOYf"
+
+          teamID := "zWEyrTZ7GZ22aBSfoX60iWryTY"
+
+
+          teamUnread, resp := Client.GetTeamUnread(userID, teamID)
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$userID = \"NqCSr5HMDZjrWS74IEmedvlOYf\";\n$teamID = \"zWEyrTZ7GZ22aBSfoX60iWryTY\";\n\n$resp = $driver->getTeamModel()->getUserTotalUnreadMessagesFromTeam($userID,\
+          \ $teamID);\n\nif ($resp->getStatusCode() == 200) {\n    $teamUnread = json_decode($resp->getBody());\n}\n"
+  /api/v4/users/{user_id}/terms_of_service:
+    get:
+      description: 'Will be deprecated in v6.0
+
+        Fetches user''s latest terms of service action if the latest action was for acceptance.
+
+
+        __Minimum server version__: 5.6
+
+        ##### Permissions
+
+        Must be logged in as the user being acted on.
+
+        '
+      operationId: GetUserTermsOfService
+      parameters:
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserTermsOfService'
+          description: User's accepted terms of service action
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AppError'
+          description: User hasn't performed an action or the latest action was a rejection.
+      summary: Fetches user's latest terms of service action if the latest action was for acceptance.
+      tags:
+      - users
+      - terms of service
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          userID := "adWv1qPZmHdtxk7Lmqh6RtxWxS"
+
+
+          userTermsOfService, resp := Client.GetUserTermsOfService(userID, "")
+
+          '
+    post:
+      description: 'Records user action when they accept or decline custom terms of service. Records the action in audit table.
+
+        Updates user''s last accepted terms of service ID if they accepted it.
+
+
+        __Minimum server version__: 5.4
+
+        ##### Permissions
+
+        Must be logged in as the user being acted on.
+
+        '
+      operationId: RegisterTermsOfServiceAction
+      parameters:
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                accepted:
+                  description: true or false, indicates whether the user accepted or rejected the terms of service.
+                  type: string
+                serviceTermsId:
+                  description: terms of service ID on which the user is acting on
+                  type: string
+              required:
+              - serviceTermsId
+              - accepted
+              type: object
+        description: terms of service details
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: Terms of service action recorded successfully
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Records user action when they accept or decline custom terms of service
+      tags:
+      - users
+      - terms of service
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          userID := "adWv1qPZmHdtxk7Lmqh6RtxWxS"
+
+          serviceTermsID := "RdDjEDlkWgt7ndjyVLwWGvnX8c"
+
+
+          success, resp = Client.RegisterTermsOfServiceAction(userID, serviceTermsID, true)
+
+          '
+  /api/v4/users/{user_id}/tokens:
+    get:
+      description: 'Get a list of user access tokens for a user. Does not include the actual authentication tokens. Use query
+        parameters for paging.
+
+
+        __Minimum server version__: 4.1
+
+
+        ##### Permissions
+
+        Must have `read_user_access_token` permission. For non-self requests, must also have the `edit_other_users` permission.
+
+        '
+      operationId: GetUserAccessTokensForUser
+      parameters:
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      - description: The page to select.
+        in: query
+        name: page
+        schema:
+          default: 0
+          type: integer
+      - description: The number of tokens per page.
+        in: query
+        name: per_page
+        schema:
+          default: 60
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/UserAccessTokenSanitized'
+                type: array
+          description: User access tokens retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Get user access tokens
+      tags:
+      - users
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          userID := "adWv1qPZmHdtxk7Lmqh6RtxWxS"
+
+
+          tokens, resp := Client.GetUserAccessTokensForUser(userID, 0, 100)
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n      ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$userID = \"adWv1qPZmHdtxk7Lmqh6RtxWxS\";\n\n$resp = $driver->getUserModel()->getTokens($userID, [\n    \"page\"\
+          \ => 0,\n    \"per_page\" => 100,\n]);\n\nif ($resp->getStatusCode() == 200) {\n   $tokens = json_decode($resp->getBody());\n\
+          }\n"
+    post:
+      description: 'Generate a user access token that can be used to authenticate with the Mattermost REST API.
+
+
+        __Minimum server version__: 4.1
+
+
+        ##### Permissions
+
+        Must have `create_user_access_token` permission. For non-self requests, must also have the `edit_other_users` permission.
+
+        '
+      operationId: CreateUserAccessToken
+      parameters:
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                description:
+                  description: A description of the token usage
+                  type: string
+              required:
+              - description
+              type: object
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserAccessToken'
+          description: User access token creation successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Create a user access token
+      tags:
+      - users
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          userID := "adWv1qPZmHdtxk7Lmqh6RtxWxS"
+
+
+          userAccessToken, resp := Client.CreateUserAccessToken(userID, "test token")
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n      ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$userID = \"adWv1qPZmHdtxk7Lmqh6RtxWxS\";\n\n$resp = $driver->getUserModel()->createToken($userID, [\n    \"description\"\
+          \ => \"test token\",\n]);\n\nif ($resp->getStatusCode() == 200) {\n   $userAccessToken = json_decode($resp->getBody());\n\
+          }\n"
+  /api/v4/users/{user_id}/typing:
+    post:
+      description: 'Notify users in the given channel via websocket that the given user is typing.
+
+        __Minimum server version__: 5.26
+
+        ##### Permissions
+
+        Must have `manage_system` permission to publish for any user other than oneself.
+
+        '
+      operationId: PublishUserTyping
+      parameters:
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                channel_id:
+                  description: The id of the channel to which to direct the typing event.
+                  type: string
+                parent_id:
+                  description: The optional id of the root post of the thread to which the user is replying. If unset, the
+                    typing event is directed at the entire channel.
+                  type: string
+              required:
+              - channel_id
+              type: object
+      responses:
+        '200':
+          description: User typing websocket event accepted for publishing.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Publish a user typing websocket event.
+      tags:
+      - users
+      x-code-samples:
+      - lang: Go
+        source: "import \"github.com/mattermost/mattermost-server/v5/model\"\n\nClient := model.NewAPIv4Client(\"https://your-mattermost-url.com\"\
+          )\nClient.Login(\"email@domain.com\", \"Password1\")\n\nok, response := Client.PublishUserTyping(userID, TypingRequest{\n\
+          \    ChannelId: \"channel_id\",\n    ParentId: \"post_id\",\n})\n"
+  /api/v4/users/{user_id}/uploads:
+    get:
+      description: 'Gets all the upload sessions belonging to a user.
+
+
+        __Minimum server version__: 5.28
+
+
+        ##### Permissions
+
+        Must be logged in as the user who created the upload sessions.
+
+        '
+      operationId: GetUploadsForUser
+      parameters:
+      - description: The ID of the user. This can also be "me" which will point to the current user.
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/UploadSession'
+                type: array
+          description: User's uploads retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Get uploads for a user
+      tags:
+      - users
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+          uss, response := Client.GetUploadsForUser("fc6suoon9pbbpmhrb9c967paxe")
+
+          '
+      - lang: Curl
+        source: 'curl ''http://localhost:8065/api/v4/users/fc6suoon9pbbpmhrb9c967paxe/uploads'' \
+
+          -H ''Authorization: Bearer 9kg8nqrnxprd9jbykqeg4r51hw'' \
+
+          '
+security:
+- bearerAuth: []
+servers:
+- url: http://your-mattermost-url.com
+- url: https://your-mattermost-url.com
+tags:
+- description: 'The Mattermost Web Services API is used by Mattermost clients and third party applications to interact with
+    the server. [JavaScript and Golang drivers for](/#tag/drivers) connecting to the APIs are also available.
+
+
+    ### Support
+
+
+    Mattermost core committers work with the community to keep the API documentation up-to-date.
+
+
+    If you have questions on API routes not listed in this reference, please [join the Mattermost community server](https://community.mattermost.com)
+    to ask questions in the Developers channel, [or post questions to our Developer Discussion forum](https://forum.mattermost.org/c/dev).
+
+
+    [Bug reports](https://github.com/mattermost/mattermost-api-reference/issues) in the documentation or the API are also
+    welcome, as are pull requests to fix the issues.
+
+
+    ### Contributing
+
+
+    When you have answers to API questions not addressed in our documentation we ask you to consider making a pull request
+    to improve our reference. [Small changes](https://github.com/mattermost/mattermost-api-reference/commit/d574c0c1e95dc2228dc96663afd562f1305e3ece)
+    and [larger changes](https://github.com/mattermost/mattermost-api-reference/commit/1ae3314f0935eebba8c885d8969dcad72f801501)
+    are all welcome.
+
+
+    We also have [Help Wanted tickets](https://github.com/mattermost/mattermost-api-reference/issues) available for community
+    members who would like to help others more easily use the APIs. We acknowledge everyone''s contribution in the [release
+    notes of our next version](https://docs.mattermost.com/administration/changelog.html#contributors).
+
+
+    The source code for this API reference is hosted at https://github.com/mattermost/mattermost-api-reference.
+
+    '
+  name: introduction
+- description: 'All API access is through HTTP(S) requests at `your-mattermost-url.com/api/v4`. All request and response bodies
+    are `application/json`.
+
+
+    When using endpoints that require a user id, the string `me` can be used in place of the user id to indicate the action
+    is to be taken for the logged in user.
+
+    '
+  name: schema
+- description: 'The easiest way to interact with the Mattermost Web Service API is through a language specific driver.
+
+
+    #### Official Drivers
+
+    * [Mattermost JavaScript Driver](https://github.com/mattermost/mattermost-redux/blob/master/src/client/client4.ts)
+
+    * [Mattermost Golang Driver](https://github.com/mattermost/mattermost/blob/master/server/public/model/client4.go)
+
+
+    #### Community-built Drivers
+
+    * [PHP Driver](https://github.com/gnello/php-mattermost-driver) - built by [@gnello](https://github.com/gnello) and [@prixone](https://github.com/prixone)
+
+    * [Python Driver](https://github.com/Vaelor/python-mattermost-driver) - built by [@Vaelor](https://github.com/Vaelor)
+
+
+    For other community-built drivers and API wrappers, see [our app directory](https://mattermost.com/marketplace/).
+
+    '
+  name: drivers
+- description: 'There are multiple ways to authenticate against the Mattermost API.
+
+
+    All examples assume there is a Mattermost instance running at http://localhost:8065.
+
+
+    #### Session Token
+
+
+    Make an HTTP POST to `your-mattermost-url.com/api/v4/users/login` with a JSON body indicating the user’s `login_id`, `password`
+    and optionally the MFA `token`. The `login_id` can be an email, username or an AD/LDAP ID depending on the system''s configuration.
+
+
+    ```
+
+    curl -i -d ''{"login_id":"someone@nowhere.com","password":"thisisabadpassword"}'' http://localhost:8065/api/v4/users/login
+
+    ```
+
+
+    NOTE: If you''re running cURL on windows, you will have to change the single quotes to double quotes, and escape the inner
+    double quotes with backslash, like below:
+
+
+    ```
+
+    curl -i -d "{\"login_id\":\"someone@nowhere.com\",\"password\":\"thisisabadpassword\"}" http://localhost:8065/api/v4/users/login
+
+    ```
+
+
+    If successful, the response will contain a `Token` header and a user object in the body.
+
+
+    ```
+
+    HTTP/1.1 200 OK
+
+    Set-Cookie: MMSID=hyr5dmb1mbb49c44qmx4whniso; Path=/; Max-Age=2592000; HttpOnly
+
+    Token: hyr5dmb1mbb49c44qmx4whniso
+
+    X-Ratelimit-Limit: 10
+
+    X-Ratelimit-Remaining: 9
+
+    X-Ratelimit-Reset: 1
+
+    X-Request-Id: smda55ckcfy89b6tia58shk5fh
+
+    X-Version-Id: developer
+
+    Date: Fri, 11 Sep 2015 13:21:14 GMT
+
+    Content-Length: 657
+
+    Content-Type: application/json; charset=utf-8
+
+
+    {{user object as json}}
+
+    ```
+
+
+    Include the `Token` as part of the `Authorization` header on your future API requests with the `Bearer` method.
+
+
+    ```
+
+    curl -i -H ''Authorization: Bearer hyr5dmb1mbb49c44qmx4whniso'' http://localhost:8065/api/v4/users/me
+
+    ```
+
+
+    You should now be able to access the API as the user you logged in as.
+
+
+    #### Personal Access Tokens
+
+
+    Using [personal access tokens](https://docs.mattermost.com/developer/personal-access-tokens.html) is very similar to using
+    a session token. The only real difference is that session tokens will expire, while personal access tokens will live until
+    they are manually revoked by the user or an admin.
+
+
+    Just like session tokens, include the personal access token as part of the `Authorization` header in your requests using
+    the `Bearer` method. Assuming our personal access token is `9xuqwrwgstrb3mzrxb83nb357a`, we could use it as shown below.
+
+
+    ```
+
+    curl -i -H ''Authorization: Bearer 9xuqwrwgstrb3mzrxb83nb357a'' http://localhost:8065/api/v4/users/me
+
+    ```
+
+
+    #### OAuth 2.0
+
+
+    Mattermost has the ability to act as an [OAuth 2.0](https://tools.ietf.org/html/rfc6749) service provider.
+
+
+    The official documentation for [using your Mattermost server as an OAuth 2.0 service provider can be found here.](https://docs.mattermost.com/developer/oauth-2-0-applications.html)
+
+
+    For an example on how to register an OAuth 2.0 app with your Mattermost instance, please see the [Mattermost-Zapier integration
+    documentation](https://docs.mattermost.com/integrations/zapier.html#register-zapier-as-an-oauth-2-0-application).
+
+    '
+  name: authentication
+- description: "All errors will return an appropriate HTTP response code along with the following JSON body:\n```\n{\n   \
+    \ \"id\": \"the.error.id\",\n    \"message\": \"Something went wrong\", // the reason for the error\n    \"request_id\"\
+    : \"\", // the ID of the request\n    \"status_code\": 0, // the HTTP status code\n    \"is_oauth\": false // whether\
+    \ the error is OAuth specific\n}\n```\n"
+  name: errors
+- description: 'Whenever you make an HTTP request to the Mattermost API you might notice the following headers included in
+    the response:
+
+    ```
+
+    X-Ratelimit-Limit: 10
+
+    X-Ratelimit-Remaining: 9
+
+    X-Ratelimit-Reset: 1441983590
+
+    ```
+
+
+    These headers are telling you your current rate limit status.
+
+
+    | Header | Description |
+
+    | ------ | ----------- |
+
+    | X-Ratelimit-Limit | The maximum number of requests you can make per second. |
+
+    | X-Ratelimit-Remaining | The number of requests remaining in the current window. |
+
+    | X-Ratelimit-Reset | The remaining UTC epoch seconds before the rate limit resets. |
+
+
+    If you exceed your rate limit for a window you will receive the following error in the body of the response:
+
+
+    ```
+
+    HTTP/1.1 429 Too Many Requests
+
+    Date: Tue, 10 Sep 2015 11:20:28 GMT
+
+    X-RateLimit-Limit: 10
+
+    X-RateLimit-Remaining: 0
+
+    X-RateLimit-Reset: 1
+
+
+    limit exceeded
+
+    ```
+
+    '
+  name: rate limiting
+- description: "In addition to the HTTP RESTful web service, Mattermost also offers a WebSocket event delivery system and\
+    \ some API functionality.\n\nTo connect to the WebSocket follow the standard opening handshake as [defined by the RFC\
+    \ specification](https://tools.ietf.org/html/rfc6455#section-1.3) to the `/api/v4/websocket` endpoint of Mattermost.\n\
+    \n#### Authentication\n\nThe Mattermost WebSocket can be authenticated using [the standard API authentication methods](/#tag/authentication)\
+    \ (by a cookie or with an explicit Authorization header) or through an authentication challenge. If you're authenticating\
+    \ from a browser and have logged in with the Mattermost API, your authentication cookie should already be set. This is\
+    \ how the Mattermost webapp authenticates with the WebSocket.\n\nTo authenticate with an authentication challenge, first\
+    \ connect the WebSocket and then send the following JSON over the connection:\n\n```\n{\n  \"seq\": 1,\n  \"action\":\
+    \ \"authentication_challenge\",\n  \"data\": {\n    \"token\": \"mattermosttokengoeshere\"\n  }\n}\n```\n\nIf successful,\
+    \ you will receive a standard OK response over the WebSocket connection:\n\n```\n{\n  \"status\": \"OK\",\n  \"seq_reply\"\
+    : 1\n}\n```\n\nOnce successfully authenticated, the server will pass a `hello` WebSocket event containing server version\
+    \ over the connection.\n\n#### Events\n\nWebSocket events are primarily used to alert the client to changes in Mattermost,\
+    \ such as delivering new posts or alerting the client that another user is typing in a channel.\n\nEvents on the WebSocket\
+    \ will have the form:\n\n```\n{\n  \"event\": \"hello\",\n  \"data\": {\n    \"server_version\": \"3.6.0.1451.1c38da627ebb4e3635677db6939e9195\"\
+    \n  },\n  \"broadcast\":{\n    \"omit_users\": null,\n    \"user_id\": \"ay5sq51sebfh58ktrce5ijtcwy\",\n    \"channel_id\"\
+    : \"\",\n    \"team_id\": \"\"\n  },\n  \"seq\": 0\n}\n```\n\nThe `event` field indicates the event type, `data` contains\
+    \ any data relevant to the event and `broadcast` contains information about who the event was sent to. For example, the\
+    \ above example has `user_id` set to \"ay5sq51sebfh58ktrce5ijtcwy\" meaning that only the user with that ID received this\
+    \ event broadcast. The `omit_users` field can contain an array of user IDs that were specifically omitted from receiving\
+    \ the event.\n\nThe list of Mattermost WebSocket events are:\n- added_to_team\n- authentication_challenge\n- channel_converted\n\
+    - channel_created\n- channel_deleted\n- channel_member_updated\n- channel_updated\n- channel_viewed\n- config_changed\n\
+    - delete_team\n- direct_added\n- emoji_added\n- ephemeral_message\n- group_added\n- hello\n- leave_team\n- license_changed\n\
+    - memberrole_updated\n- new_user\n- plugin_disabled\n- plugin_enabled\n- plugin_statuses_changed\n- post_deleted\n- post_edited\n\
+    - post_unread\n- posted\n- preference_changed\n- preferences_changed\n- preferences_deleted\n- reaction_added\n- reaction_removed\n\
+    - response\n- role_updated\n- status_change\n- typing\n- update_team\n- user_added\n- user_removed\n- user_role_updated\n\
+    - user_updated\n- dialog_opened\n- thread_updated\n- thread_follow_changed\n- thread_read_changed\n\n#### WebSocket API\n\
+    \nMattermost has some basic support for WebSocket APIs. A connected WebSocket can make requests by sending the following\
+    \ over the connection:\n\n```\n{\n  \"action\": \"user_typing\",\n  \"seq\": 2,\n  \"data\": {\n    \"channel_id\": \"\
+    nhze199c4j87ped4wannrjdt9c\",\n    \"parent_id\": \"\"\n  }\n}\n```\n\nThis is an example of making a `user_typing` request,\
+    \ with the purpose of alerting the server that the connected client has begun typing in a channel or thread. The `action`\
+    \ field indicates what is being requested, and performs a similar duty as the route in a HTTP API. The `data` field is\
+    \ used to add any additional data along with the request. The server supports binary websocket messages as well in case\
+    \ the client has such a requirement.\n\nThe `seq` or sequence number is set by the client and should be incremented with\
+    \ every use. It is used to distinguish responses to requests that come down the WebSocket. For example, a standard response\
+    \ to the above request would be:\n\n```\n{\n  \"status\": \"OK\",\n  \"seq_reply\": 2\n}\n```\n\nNotice `seq_reply` is\
+    \ 2, matching the `seq` of the original request. Using this a client can distinguish which request the response is meant\
+    \ for.\n\nIf there was any information to respond with, it would be encapsulated in a `data` field.\n\nIn the case of\
+    \ an error, the response would be:\n\n```\n{\n  \"status\": \"FAIL\",\n  \"seq_reply\": 2,\n  \"error\": {\n    \"id\"\
+    : \"some.error.id.here\",\n    \"message\": \"Some error message here\"\n  }\n}\n```\n\nThe list of WebSocket API actions\
+    \ is:\n- user_typing\n- get_statuses\n- get_statuses_by_ids\n\nTo see how these actions work, please refer to either the\
+    \ [Golang WebSocket driver](https://github.com/mattermost/mattermost-server/blob/master/model/websocket_client.go) or\
+    \ our [JavaScript WebSocket driver](https://github.com/mattermost/mattermost-redux/blob/master/src/client/websocket_client.ts).\n"
+  name: WebSocket
+- description: "Since Mattermost 4.6 released on January 16, 2018, API v3 has no longer been supported and it will be removed\
+    \ in Mattermost Server v5.0 on June 16, 2018. Follow these simple steps to migrate your integrations and apps to API v4.\
+    \ Otherwise your integrations may break once you upgrade to Mattermost 5.0\n\n1. Set your server's log level to `DEBUG`\
+    \ in **System Console > General > Logging > File Log Level** to print detailed logs for API requests.\n2. In **System\
+    \ Console > Logs**, search for requests hitting `/api/v3/` endpoints. Any requests hitting these endpoints are from integrations\
+    \ that should be migrated to API v4.\n  - For in-house or self-built integrations, update them to use v4 with the help\
+    \ of [this API reference](https://api.mattermost.com). Most v3 endpoints have direct counterparts in v4 and should be\
+    \ migrated easily.\n  - For third-party integrations, visit their homepage (on GitHub, GitLab, etc.). Check if they already\
+    \ have a version that uses the Mattermost v4 API. If they do not, consider opening an issue asking them if support is\
+    \ planned.\n3. Once all integrations have been migrated to API v4, review the server logs with log level set to `DEBUG`.\
+    \ Confirm no requests hit `/api/v3/` endpoints.\n4. Set **Allow use of API v3 endpoints** to `false` in **System Console\
+    \ > General > Configuration**, or set `EnableAPIv3` to `false` in `config.json`. This setting disables API v3 on your\
+    \ server. Any time a v3 endpoint is used, an error is logged in **System Console > Logs**.\n5. Set your server's log level\
+    \ back to `ERROR`. Use the error logs to help track down any remaining uses of API v3.\n\nBelow are the major changes\
+    \ made between v3 and v4:\n\n1. Endpoint URLs only require team IDs when necessary. For example, getting a channel by\
+    \ ID no longer requires a team ID in v4.\n2. Collection endpoints now generally return lists and include paging as part\
+    \ of the query string.\n3. User ID is now included in most user endpoints. This allows admins to modify other users through\
+    \ v4 endpoints.\n\nIf you have any questions about the API v3 deprecation, or about migrating from v3 to v4, [join our\
+    \ daily build server at community.mattermost.com](https://community.mattermost.com) and ask questions in the [APIv4 channel](https://community.mattermost.com/core/channels/apiv4).\n"
+  name: APIv3 Deprecation
+- description: 'Endpoints for creating, getting and interacting with users.
+
+
+    When using endpoints that require a user id, the string `me` can be used in place of the user id to indicate the action
+    is to be taken for the logged in user.
+
+    '
+  name: users
+- description: Endpoints for creating, getting and updating bot users.
+  name: bots
+- description: Endpoints for creating, getting and interacting with teams.
+  name: teams
+- description: Endpoints for creating, getting and interacting with channels.
+  name: channels
+- description: Endpoints for creating, getting and interacting with posts.
+  name: posts
+- description: Endpoints for uploading and interacting with files.
+  name: files
+- description: Endpoints for creating and performing file uploads.
+  name: uploads
+- description: Endpoints for saving and modifying user preferences.
+  name: preferences
+- description: Endpoints for getting and updating user statuses.
+  name: status
+- description: Endpoints for creating, getting and interacting with emojis.
+  name: emoji
+- description: Endpoints for creating, getting and removing emoji reactions.
+  name: reactions
+- description: Endpoints for creating, getting and updating webhooks.
+  name: webhooks
+- description: Endpoints for creating, getting and updating slash commands.
+  name: commands
+- description: Endpoint for getting Open Graph metadata.
+  name: OpenGraph
+- description: General endpoints for interacting with the server, such as configuration and logging.
+  name: system
+- description: Endpoints related to custom branding and white-labeling. See [our branding documentation](https://docs.mattermost.com/administration/branding.html)
+    for more information.
+  name: brand
+- description: Endpoints for configuring and interacting with Mattermost as an OAuth 2.0 service provider.
+  name: OAuth
+- description: Endpoints for configuring and interacting with SAML.
+  name: SAML
+- description: Endpoints for configuring and interacting with LDAP.
+  name: LDAP
+- description: Endpoints related to LDAP groups.
+  name: groups
+- description: Endpoints for creating, getting and downloading compliance reports.
+  name: compliance
+- description: Endpoints for configuring and interacting with high availability clusters.
+  name: cluster
+- description: Endpoints for configuring and interacting with Elasticsearch.
+  name: elasticsearch
+- description: Endpoint for getting data retention policy settings.
+  name: data retention
+- description: Endpoints related to various background jobs that can be run by the server or separately by job servers.
+  name: jobs
+- description: Endpoints related to uploading and managing plugins.
+  name: plugins
+- description: Endpoints for creating, getting and updating roles.
+  name: roles
+- description: Endpoints for creating, getting and updating and deleting schemes.
+  name: schemes
+- description: Endpoints for interactive actions for use by integrations.
+  name: integration_actions
+- description: Endpoints for getting information about shared channels.
+  name: shared channels
+- description: Endpoints for getting insights into teams and users.
+  name: insights
+- description: Endpoints for getting and updating custom terms of service.
+  name: terms of service
+- description: Endpoints related to import files.
+  name: imports
+- description: Endpoints related to export files.
+  name: exports
+- description: Playbooks
+  name: Playbooks
+- description: Playbook runs
+  name: PlaybookRuns
+- description: Internal endpoints
+  name: Internal
+- description: Timeline
+  name: Timeline
+- description: Playbook Autofollows
+  name: PlaybookAutofollows
+x-tagGroups:
+- name: Overview
+  tags:
+  - introduction
+  - schema
+  - APIv3 Deprecation
+- name: Standard Features
+  tags:
+  - drivers
+  - authentication
+  - errors
+  - rate limiting
+  - WebSocket
+- name: Endpoints
+  tags:
+  - users
+  - bots
+  - teams
+  - channels
+  - posts
+  - threads
+  - files
+  - uploads
+  - preferences
+  - status
+  - emoji
+  - reactions
+  - webhooks
+  - commands
+  - OpenGraph
+  - system
+  - brand
+  - OAuth
+  - SAML
+  - LDAP
+  - groups
+  - compliance
+  - cluster
+  - cloud
+  - elasticsearch
+  - bleve
+  - data retention
+  - jobs
+  - plugins
+  - roles
+  - schemes
+  - integration_actions
+  - shared channels
+  - insights
+  - terms of service
+  - imports
+  - permissions
+  - exports
+  - usage
+- name: Playbooks
+  tags:
+  - Playbooks
+  - PlaybookRuns
+  - PlaybookAutofollows
+  - Timeline
+  - Internal

--- a/spec/mattermost-openapi-small.yaml
+++ b/spec/mattermost-openapi-small.yaml
@@ -1,0 +1,6528 @@
+components:
+  responses:
+    '400':
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+      description: The request is malformed.
+    '403':
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+      description: Access to the resource is forbidden for this user.
+    '404':
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+      description: Resource requested not found.
+    '500':
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+      description: There was an internal error in the server.
+    BadRequest:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AppError'
+      description: Invalid or missing parameters in URL or request body
+    Forbidden:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AppError'
+      description: Do not have appropriate permissions
+    InternalServerError:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AppError'
+      description: Something went wrong with the server
+    NotFound:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AppError'
+      description: Resource not found
+    NotImplemented:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AppError'
+      description: Feature is disabled
+    TooLarge:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AppError'
+      description: Content too large
+    TooManyRequests:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AppError'
+      description: Too many requests
+    Unauthorized:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AppError'
+      description: No access token provided
+  schemas:
+    AddOn:
+      properties:
+        display_name:
+          type: string
+        id:
+          type: string
+        name:
+          type: string
+        price_per_seat:
+          type: string
+      type: object
+    Address:
+      properties:
+        city:
+          type: string
+        country:
+          type: string
+        line1:
+          type: string
+        line2:
+          type: string
+        postal_code:
+          type: string
+        state:
+          type: string
+      type: object
+    AppError:
+      properties:
+        id:
+          type: string
+        message:
+          type: string
+        request_id:
+          type: string
+        status_code:
+          type: integer
+      type: object
+    Audit:
+      properties:
+        action:
+          type: string
+        create_at:
+          description: The time in milliseconds a audit was created
+          format: int64
+          type: integer
+        extra_info:
+          type: string
+        id:
+          type: string
+        ip_address:
+          type: string
+        session_id:
+          type: string
+        user_id:
+          type: string
+      type: object
+    AutocompleteSuggestion:
+      properties:
+        Complete:
+          description: Completed suggestion
+          type: string
+        Description:
+          description: Description of the suggested command
+          type: string
+        Hint:
+          description: Hint about suggested input
+          type: string
+        IconData:
+          description: Base64 encoded svg image
+          type: string
+        Suggestion:
+          description: Predicted text user might want to input
+          type: string
+      type: object
+    BoardsLimits:
+      properties:
+        cards:
+          nullable: true
+          type: integer
+        views:
+          nullable: true
+          type: integer
+      type: object
+    Bot:
+      description: A bot account
+      properties:
+        create_at:
+          description: The time in milliseconds a bot was created
+          format: int64
+          type: integer
+        delete_at:
+          description: The time in milliseconds a bot was deleted
+          format: int64
+          type: integer
+        description:
+          type: string
+        display_name:
+          type: string
+        owner_id:
+          description: The user id of the user that currently owns this bot.
+          type: string
+        update_at:
+          description: The time in milliseconds a bot was last updated
+          format: int64
+          type: integer
+        user_id:
+          description: The user id of the associated user entry.
+          type: string
+        username:
+          type: string
+      type: object
+    Channel:
+      properties:
+        create_at:
+          description: The time in milliseconds a channel was created
+          format: int64
+          type: integer
+        creator_id:
+          type: string
+        delete_at:
+          description: The time in milliseconds a channel was deleted
+          format: int64
+          type: integer
+        display_name:
+          type: string
+        extra_update_at:
+          description: Deprecated in Mattermost 5.0 release
+          format: int64
+          type: integer
+        header:
+          type: string
+        id:
+          type: string
+        last_post_at:
+          description: The time in milliseconds of the last post of a channel
+          format: int64
+          type: integer
+        name:
+          type: string
+        purpose:
+          type: string
+        team_id:
+          type: string
+        total_msg_count:
+          type: integer
+        type:
+          type: string
+        update_at:
+          description: The time in milliseconds a channel was last updated
+          format: int64
+          type: integer
+      type: object
+    ChannelData:
+      properties:
+        channel:
+          $ref: '#/components/schemas/Channel'
+        member:
+          $ref: '#/components/schemas/ChannelMember'
+      type: object
+    ChannelListWithTeamData:
+      items:
+        $ref: '#/components/schemas/ChannelWithTeamData'
+      type: array
+    ChannelMember:
+      properties:
+        channel_id:
+          type: string
+        last_update_at:
+          description: The time in milliseconds the channel member was last updated
+          format: int64
+          type: integer
+        last_viewed_at:
+          description: The time in milliseconds the channel was last viewed by the user
+          format: int64
+          type: integer
+        mention_count:
+          type: integer
+        msg_count:
+          type: integer
+        notify_props:
+          $ref: '#/components/schemas/ChannelNotifyProps'
+        roles:
+          type: string
+        user_id:
+          type: string
+      type: object
+    ChannelMemberCountByGroup:
+      description: An object describing group member information in a channel
+      properties:
+        channel_member_count:
+          description: Total number of group members in the channel
+          type: number
+        channel_member_timezones_count:
+          description: Total number of unique timezones for the group members in the channel
+          type: number
+        group_id:
+          description: ID of the group
+          type: string
+      type: object
+    ChannelMemberWithTeamData:
+      allOf:
+      - $ref: '#/components/schemas/ChannelMember'
+      - properties:
+          team_display_name:
+            description: The display name of the team to which this channel belongs.
+            type: string
+          team_name:
+            description: The name of the team to which this channel belongs.
+            type: string
+          team_update_at:
+            description: The time at which the team to which this channel belongs was last updated.
+            type: integer
+        type: object
+    ChannelModeratedRole:
+      properties:
+        enabled:
+          type: boolean
+        value:
+          type: boolean
+      type: object
+    ChannelModeratedRoles:
+      properties:
+        guests:
+          $ref: '#/components/schemas/ChannelModeratedRole'
+        members:
+          $ref: '#/components/schemas/ChannelModeratedRole'
+      type: object
+    ChannelModeratedRolesPatch:
+      properties:
+        guests:
+          type: boolean
+        members:
+          type: boolean
+      type: object
+    ChannelModeration:
+      properties:
+        name:
+          type: string
+        roles:
+          $ref: '#/components/schemas/ChannelModeratedRoles'
+      type: object
+    ChannelModerationPatch:
+      properties:
+        name:
+          type: string
+        roles:
+          $ref: '#/components/schemas/ChannelModeratedRolesPatch'
+      type: object
+    ChannelNotifyProps:
+      properties:
+        desktop:
+          description: Set to "all" to receive desktop notifications for all activity, "mention" for mentions and direct messages
+            only, "none" to disable, or "default" to use the global user notification setting.
+          type: string
+        email:
+          description: Set to "true" to enable email notifications, "false" to disable, or "default" to use the global user
+            notification setting.
+          type: string
+        mark_unread:
+          description: Set to "all" to mark the channel unread for any new message, "mention" to mark unread for new mentions
+            only. Defaults to "all".
+          type: string
+        push:
+          description: Set to "all" to receive push notifications for all activity, "mention" for mentions and direct messages
+            only, "none" to disable, or "default" to use the global user notification setting.
+          type: string
+      type: object
+    ChannelStats:
+      properties:
+        channel_id:
+          type: string
+        member_count:
+          type: integer
+      type: object
+    ChannelUnread:
+      properties:
+        channel_id:
+          type: string
+        mention_count:
+          type: integer
+        msg_count:
+          type: integer
+        team_id:
+          type: string
+      type: object
+    ChannelUnreadAt:
+      properties:
+        channel_id:
+          description: The ID of the channel the user has access to..
+          type: string
+        last_viewed_at:
+          description: time in milliseconds when the user last viewed the channel.
+          type: integer
+        mention_count:
+          description: No. of mentions the user has within the unread posts of the channel.
+          type: integer
+        msg_count:
+          description: No. of messages the user has already read.
+          type: integer
+        team_id:
+          description: The ID of the team the channel belongs to.
+          type: string
+      type: object
+    ChannelWithTeamData:
+      allOf:
+      - $ref: '#/components/schemas/Channel'
+      - properties:
+          policy_id:
+            description: The data retention policy to which this team has been assigned. If no such policy exists, or the
+              caller does not have the `sysconsole_read_compliance_data_retention` permission, this field will be null.
+            type: string
+          team_display_name:
+            description: The display name of the team to which this channel belongs.
+            type: string
+          team_name:
+            description: The name of the team to which this channel belongs.
+            type: string
+          team_update_at:
+            description: The time at which the team to which this channel belongs was last updated.
+            type: integer
+        type: object
+    Checklist:
+      properties:
+        id:
+          description: A unique, 26 characters long, alphanumeric identifier for the checklist.
+          example: 6f6nsgxzoq84fqh1dnlyivgafd
+          type: string
+        items:
+          description: The list of tasks to do.
+          items:
+            $ref: '#/components/schemas/ChecklistItem'
+          type: array
+        title:
+          description: The title of the checklist.
+          example: Triage issue
+          type: string
+      type: object
+    ChecklistItem:
+      properties:
+        assignee_id:
+          description: The identifier of the user that has been assigned to complete this item. If the item has no assignee,
+            this is an empty string.
+          example: pisdatkjtdlkdhht2v4inxuzx1
+          type: string
+        assignee_modified:
+          description: The timestamp for the latest modification of the item's assignee, formatted as the number of milliseconds
+            since the Unix epoch. It equals 0 if the item never got an assignee.
+          example: 1608897821125
+          format: int64
+          type: integer
+        command:
+          description: The slash command associated with this item. If the item has no slash command associated, this is an
+            empty string
+          example: /opsgenie on-call
+          type: string
+        command_last_run:
+          description: The timestamp for the latest execution of the item's command, formatted as the number of milliseconds
+            since the Unix epoch. It equals 0 if the command was never executed.
+          example: 1608552221019
+          format: int64
+          type: integer
+        condition_action:
+          description: A string that represents the action created as a result of a condition evaluation. Empty string means
+            no action, 'hidden' means the item is hidden due to condition not being met, 'shown_because_modified' means the
+            item is shown despite condition not being met because it was recently modified.
+          enum:
+          - ''
+          - hidden
+          - shown_because_modified
+          example: hidden
+          type: string
+        condition_id:
+          description: The ID of the condition that created this checklist item, if any. Empty string if the item was not
+            created by a condition.
+          example: 6f6nsgxzoq84fqh1dnlyivgafd
+          type: string
+        condition_reason:
+          description: A string representation of the condition that affects this checklist item. Empty string if no condition
+            is associated with this item.
+          example: Severity is Critical AND Status is not Closed
+          type: string
+        delete_at:
+          description: The timestamp for the last time the item was skipped, formatted as the number of milliseconds since
+            the Unix epoch. It equals 0 if the item was never skipped.
+          example: 1607774621321
+          format: int64
+          type: integer
+        description:
+          description: A detailed description of the checklist item, formatted with Markdown.
+          example: Ask the customer for more information in [Zendesk](https://www.zendesk.com/).
+          type: string
+        due_date:
+          description: The timestamp for the due date of the checklist item, formatted as the number of milliseconds since
+            the Unix epoch. It equals 0 if not set. For playbooks, this is a relative timestamp; for runs, this is an absolute
+            timestamp.
+          example: 1607774621321
+          format: int64
+          type: integer
+        id:
+          description: A unique, 26 characters long, alphanumeric identifier for the checklist item.
+          example: 6f6nsgxzoq84fqh1dnlyivgafd
+          type: string
+        state:
+          description: The state of the checklist item. An empty string means that the item is not done.
+          enum:
+          - ''
+          - in_progress
+          - closed
+          example: closed
+          type: string
+        state_modified:
+          description: The timestamp for the latest modification of the item's state, formatted as the number of milliseconds
+            since the Unix epoch. It equals 0 if the item was never modified.
+          example: 1607774621321
+          format: int64
+          type: integer
+        task_actions:
+          description: An array of all the task actions associated with this task.
+          items:
+            properties:
+              actions:
+                description: The actions to be executed when the trigger is activated.
+                items:
+                  type: object
+                type: array
+              trigger:
+                description: The trigger configuration for the task action.
+                type: object
+            type: object
+          type: array
+        title:
+          description: The title of the checklist item.
+          example: Gather information from customer.
+          type: string
+        update_at:
+          description: The timestamp for when this checklist item was last modified, formatted as the number of milliseconds
+            since the Unix epoch.
+          example: 1607774621321
+          format: int64
+          type: integer
+      type: object
+    CloudCustomer:
+      properties:
+        billing_address:
+          $ref: '#/components/schemas/Address'
+        company_address:
+          $ref: '#/components/schemas/Address'
+        contact_first_name:
+          type: string
+        contact_last_name:
+          type: string
+        create_at:
+          format: int64
+          type: integer
+        creator_id:
+          type: string
+        email:
+          type: string
+        id:
+          type: string
+        name:
+          type: string
+        num_employees:
+          type: string
+        payment_method:
+          $ref: '#/components/schemas/PaymentMethod'
+      type: object
+    ClusterInfo:
+      properties:
+        config_hash:
+          description: The hash of the configuartion file the node is using
+          type: string
+        hostname:
+          description: The hostname for this node
+          type: string
+        id:
+          description: The unique ID for the node
+          type: string
+        internode_url:
+          description: The URL used to communicate with those node from other nodes
+          type: string
+        is_alive:
+          description: Whether or not the node is alive and well
+          type: boolean
+        last_ping:
+          description: The time of the last ping to this node
+          type: integer
+        version:
+          description: The server version the node is on
+          type: string
+      type: object
+    Command:
+      properties:
+        auto_complete:
+          description: Use auto complete for this command
+          type: boolean
+        auto_complete_desc:
+          description: The description for this command shown when selecting the command
+          type: string
+        auto_complete_hint:
+          description: The hint for this command
+          type: string
+        create_at:
+          description: The time in milliseconds the command was created
+          type: integer
+        creator_id:
+          description: The user id for the commands creator
+          type: string
+        delete_at:
+          description: The time in milliseconds the command was deleted, 0 if never deleted
+          format: int64
+          type: integer
+        description:
+          description: Description for this command
+          type: string
+        display_name:
+          description: Display name for the command
+          type: string
+        icon_url:
+          description: The url to find the icon for this users avatar
+          type: string
+        id:
+          description: The ID of the slash command
+          type: string
+        method:
+          description: Is the trigger done with HTTP Get ('G') or HTTP Post ('P')
+          type: string
+        team_id:
+          description: The team id for which this command is configured
+          type: string
+        token:
+          description: The token which is used to verify the source of the payload
+          type: string
+        trigger:
+          description: The string that triggers this command
+          type: string
+        update_at:
+          description: The time in milliseconds the command was last updated
+          format: int64
+          type: integer
+        url:
+          description: The URL that is triggered
+          type: string
+        username:
+          description: What is the username for the response post
+          type: string
+      type: object
+    CommandResponse:
+      properties:
+        Attachments:
+          items:
+            $ref: '#/components/schemas/SlackAttachment'
+          type: array
+        GotoLocation:
+          type: string
+        IconURL:
+          type: string
+        ResponseType:
+          description: The response type either in_channel or ephemeral
+          type: string
+        Text:
+          type: string
+        Username:
+          type: string
+      type: object
+    ComparisonCondition:
+      properties:
+        field_id:
+          description: The identifier of the field to compare against.
+          example: status
+          type: string
+        value:
+          description: The value to compare with. Format depends on the field type. Stored as JSON.
+          example: '"active"'
+      required:
+      - field_id
+      - value
+      type: object
+    Compliance:
+      properties:
+        count:
+          type: integer
+        create_at:
+          format: int64
+          type: integer
+        desc:
+          type: string
+        emails:
+          type: string
+        end_at:
+          format: int64
+          type: integer
+        id:
+          type: string
+        keywords:
+          type: string
+        start_at:
+          format: int64
+          type: integer
+        status:
+          type: string
+        type:
+          type: string
+        user_id:
+          type: string
+      type: object
+    Condition:
+      properties:
+        condition_expr:
+          $ref: '#/components/schemas/ConditionExprV1'
+        create_at:
+          description: The condition creation timestamp, formatted as the number of milliseconds since the Unix epoch.
+          example: 1606807976289
+          format: int64
+          type: integer
+        id:
+          description: A unique, 26 characters long, alphanumeric identifier for the condition.
+          example: abc123def456ghi789
+          type: string
+        playbook_id:
+          description: The identifier of the playbook this condition belongs to.
+          example: iz0g457ikesz55dhxcfa0fk9yy
+          type: string
+        run_id:
+          description: If this is a run condition (read-only snapshot), the identifier of the run. Empty for playbook conditions.
+          example: mx3xyzdojfgyfdx8sc8of1gdme
+          type: string
+        update_at:
+          description: The condition update timestamp, formatted as the number of milliseconds since the Unix epoch.
+          example: 1606807976289
+          format: int64
+          type: integer
+        version:
+          description: Version number of the condition expression format. Currently only version 1 is supported.
+          example: 1
+          format: int32
+          type: integer
+      required:
+      - version
+      - condition_expr
+      type: object
+    ConditionExprV1:
+      description: A logical condition expression that can combine multiple conditions using AND/OR operators, or perform
+        field comparisons using Is/IsNot operators.
+      example:
+        and:
+        - is:
+            field_id: status
+            value: '"active"'
+        - or:
+          - is:
+              field_id: priority
+              value: '"high"'
+          - is:
+              field_id: priority
+              value: '"critical"'
+      properties:
+        and:
+          description: Logical AND operation. All conditions in the array must be true.
+          items:
+            $ref: '#/components/schemas/ConditionExprV1'
+          type: array
+        is:
+          $ref: '#/components/schemas/ComparisonCondition'
+        isNot:
+          $ref: '#/components/schemas/ComparisonCondition'
+        or:
+          description: Logical OR operation. At least one condition in the array must be true.
+          items:
+            $ref: '#/components/schemas/ConditionExprV1'
+          type: array
+      type: object
+    ConditionList:
+      properties:
+        has_more:
+          description: A boolean describing whether there are more pages after the currently returned.
+          example: false
+          type: boolean
+        items:
+          description: The conditions in this page.
+          items:
+            $ref: '#/components/schemas/Condition'
+          type: array
+        page_count:
+          description: The total number of pages. This depends on the total number of conditions and the per_page parameter.
+          example: 1
+          format: int32
+          type: integer
+        total_count:
+          description: The total number of conditions in the list, regardless of paging.
+          example: 10
+          format: int32
+          type: integer
+      type: object
+    Config:
+      properties:
+        AnalyticsSettings:
+          properties:
+            MaxUsersForStatistics:
+              type: integer
+          type: object
+        ClusterSettings:
+          properties:
+            Enable:
+              type: boolean
+            InterNodeListenAddress:
+              type: string
+            InterNodeUrls:
+              items:
+                type: string
+              type: array
+          type: object
+        ComplianceSettings:
+          properties:
+            Directory:
+              type: string
+            Enable:
+              type: boolean
+            EnableDaily:
+              type: boolean
+          type: object
+        EmailSettings:
+          properties:
+            ConnectionSecurity:
+              type: string
+            EmailBatchingBufferSize:
+              type: integer
+            EmailBatchingInterval:
+              type: integer
+            EnableEmailBatching:
+              type: boolean
+            EnableSignInWithEmail:
+              type: boolean
+            EnableSignInWithUsername:
+              type: boolean
+            EnableSignUpWithEmail:
+              type: boolean
+            FeedbackEmail:
+              type: string
+            FeedbackName:
+              type: string
+            FeedbackOrganization:
+              type: string
+            InviteSalt:
+              type: string
+            PasswordResetSalt:
+              type: string
+            PushNotificationContents:
+              type: string
+            PushNotificationServer:
+              type: string
+            RequireEmailVerification:
+              type: boolean
+            SMTPPassword:
+              type: string
+            SMTPPort:
+              type: string
+            SMTPServer:
+              type: string
+            SMTPUsername:
+              type: string
+            SendEmailNotifications:
+              type: boolean
+            SendPushNotifications:
+              type: boolean
+          type: object
+        FileSettings:
+          properties:
+            AmazonS3AccessKeyId:
+              type: string
+            AmazonS3Bucket:
+              type: string
+            AmazonS3Endpoint:
+              type: string
+            AmazonS3Region:
+              type: string
+            AmazonS3SSL:
+              type: boolean
+            AmazonS3SecretAccessKey:
+              type: string
+            Directory:
+              type: string
+            DriverName:
+              type: string
+            EnablePublicLink:
+              type: boolean
+            InitialFont:
+              type: string
+            MaxFileSize:
+              type: integer
+            PreviewHeight:
+              type: integer
+            PreviewWidth:
+              type: integer
+            ProfileHeight:
+              type: integer
+            ProfileWidth:
+              type: integer
+            PublicLinkSalt:
+              type: string
+            ThumbnailHeight:
+              type: integer
+            ThumbnailWidth:
+              type: integer
+          type: object
+        GitLabSettings:
+          properties:
+            AuthEndpoint:
+              type: string
+            Enable:
+              type: boolean
+            Id:
+              type: string
+            Scope:
+              type: string
+            Secret:
+              type: string
+            TokenEndpoint:
+              type: string
+            UserApiEndpoint:
+              type: string
+          type: object
+        GoogleSettings:
+          properties:
+            AuthEndpoint:
+              type: string
+            Enable:
+              type: boolean
+            Id:
+              type: string
+            Scope:
+              type: string
+            Secret:
+              type: string
+            TokenEndpoint:
+              type: string
+            UserApiEndpoint:
+              type: string
+          type: object
+        LdapSettings:
+          properties:
+            BaseDN:
+              type: string
+            BindPassword:
+              type: string
+            BindUsername:
+              type: string
+            ConnectionSecurity:
+              type: string
+            EmailAttribute:
+              type: string
+            Enable:
+              type: boolean
+            FirstNameAttribute:
+              type: string
+            IdAttribute:
+              type: string
+            LastNameAttribute:
+              type: string
+            LdapPort:
+              type: integer
+            LdapServer:
+              type: string
+            LoginFieldName:
+              type: string
+            MaxPageSize:
+              type: integer
+            NicknameAttribute:
+              type: string
+            PositionAttribute:
+              type: string
+            QueryTimeout:
+              type: integer
+            SkipCertificateVerification:
+              type: boolean
+            SyncIntervalMinutes:
+              type: integer
+            UserFilter:
+              type: string
+            UsernameAttribute:
+              type: string
+          type: object
+        LocalizationSettings:
+          properties:
+            AvailableLocales:
+              type: string
+            DefaultClientLocale:
+              type: string
+            DefaultServerLocale:
+              type: string
+          type: object
+        LogSettings:
+          properties:
+            ConsoleLevel:
+              type: string
+            EnableConsole:
+              type: boolean
+            EnableDiagnostics:
+              type: boolean
+            EnableFile:
+              type: boolean
+            EnableWebhookDebugging:
+              type: boolean
+            FileLevel:
+              type: string
+            FileLocation:
+              type: string
+          type: object
+        MetricsSettings:
+          properties:
+            BlockProfileRate:
+              type: integer
+            Enable:
+              type: boolean
+            ListenAddress:
+              type: string
+          type: object
+        NativeAppSettings:
+          properties:
+            AndroidAppDownloadLink:
+              type: string
+            AppDownloadLink:
+              type: string
+            IosAppDownloadLink:
+              type: string
+          type: object
+        Office365Settings:
+          properties:
+            AuthEndpoint:
+              type: string
+            Enable:
+              type: boolean
+            Id:
+              type: string
+            Scope:
+              type: string
+            Secret:
+              type: string
+            TokenEndpoint:
+              type: string
+            UserApiEndpoint:
+              type: string
+          type: object
+        PasswordSettings:
+          properties:
+            Lowercase:
+              type: boolean
+            MinimumLength:
+              type: integer
+            Number:
+              type: boolean
+            Symbol:
+              type: boolean
+            Uppercase:
+              type: boolean
+          type: object
+        PrivacySettings:
+          properties:
+            ShowEmailAddress:
+              type: boolean
+            ShowFullName:
+              type: boolean
+          type: object
+        RateLimitSettings:
+          properties:
+            Enable:
+              type: boolean
+            MaxBurst:
+              type: integer
+            MemoryStoreSize:
+              type: integer
+            PerSec:
+              type: integer
+            VaryByHeader:
+              type: string
+            VaryByRemoteAddr:
+              type: boolean
+          type: object
+        SamlSettings:
+          properties:
+            AssertionConsumerServiceURL:
+              type: string
+            EmailAttribute:
+              type: string
+            Enable:
+              type: boolean
+            Encrypt:
+              type: boolean
+            FirstNameAttribute:
+              type: string
+            IdpCertificateFile:
+              type: string
+            IdpDescriptorUrl:
+              type: string
+            IdpUrl:
+              type: string
+            LastNameAttribute:
+              type: string
+            LocaleAttribute:
+              type: string
+            LoginButtonText:
+              type: string
+            NicknameAttribute:
+              type: string
+            PositionAttribute:
+              type: string
+            PrivateKeyFile:
+              type: string
+            PublicCertificateFile:
+              type: string
+            UsernameAttribute:
+              type: string
+            Verify:
+              type: boolean
+          type: object
+        ServiceSettings:
+          properties:
+            AllowCorsFrom:
+              type: string
+            ConnectionSecurity:
+              type: string
+            EnableCommands:
+              type: boolean
+            EnableCustomEmoji:
+              type: boolean
+            EnableDeveloper:
+              type: boolean
+            EnableIncomingWebhooks:
+              type: boolean
+            EnableInsecureOutgoingConnections:
+              type: boolean
+            EnableMultifactorAuthentication:
+              type: boolean
+            EnableOAuthServiceProvider:
+              type: boolean
+            EnableOnlyAdminIntegrations:
+              type: boolean
+            EnableOutgoingWebhooks:
+              type: boolean
+            EnablePostIconOverride:
+              type: boolean
+            EnablePostUsernameOverride:
+              type: boolean
+            EnableSecurityFixAlert:
+              type: boolean
+            EnableTesting:
+              type: boolean
+            EnforceMultifactorAuthentication:
+              type: boolean
+            Forward80To443:
+              type: boolean
+            GoogleDeveloperKey:
+              type: string
+            LetsEncryptCertificateCacheFile:
+              type: string
+            ListenAddress:
+              type: string
+            MaximumLoginAttempts:
+              type: integer
+            ReadTimeout:
+              type: integer
+            RestrictCustomEmojiCreation:
+              type: string
+            SegmentDeveloperKey:
+              type: string
+            SessionCacheInMinutes:
+              type: integer
+            SessionLengthMobileInDays:
+              type: integer
+            SessionLengthSSOInDays:
+              type: integer
+            SessionLengthWebInDays:
+              type: integer
+            SiteURL:
+              type: string
+            TLSCertFile:
+              type: string
+            TLSKeyFile:
+              type: string
+            UseLetsEncrypt:
+              type: boolean
+            WebserverMode:
+              type: string
+            WebsocketPort:
+              type: integer
+            WebsocketSecurePort:
+              type: integer
+            WriteTimeout:
+              type: integer
+          type: object
+        SqlSettings:
+          properties:
+            AtRestEncryptKey:
+              type: string
+            DataSource:
+              type: string
+            DataSourceReplicas:
+              items:
+                type: string
+              type: array
+            DriverName:
+              type: string
+            MaxIdleConns:
+              type: integer
+            MaxOpenConns:
+              type: integer
+            Trace:
+              type: boolean
+          type: object
+        SupportSettings:
+          properties:
+            AboutLink:
+              type: string
+            HelpLink:
+              type: string
+            PrivacyPolicyLink:
+              type: string
+            ReportAProblemLink:
+              type: string
+            SupportEmail:
+              type: string
+            TermsOfServiceLink:
+              type: string
+          type: object
+        TeamSettings:
+          properties:
+            CustomBrandText:
+              type: string
+            CustomDescriptionText:
+              type: string
+            EnableCustomBrand:
+              type: boolean
+            EnableOpenServer:
+              type: boolean
+            EnableTeamCreation:
+              type: boolean
+            EnableUserCreation:
+              type: boolean
+            MaxChannelsPerTeam:
+              type: integer
+            MaxNotificationsPerChannel:
+              type: integer
+            MaxUsersPerTeam:
+              type: integer
+            RestrictCreationToDomains:
+              type: string
+            RestrictDirectMessage:
+              type: string
+            RestrictPrivateChannelCreation:
+              type: string
+            RestrictPrivateChannelDeletion:
+              type: string
+            RestrictPrivateChannelManagement:
+              type: string
+            RestrictPublicChannelCreation:
+              type: string
+            RestrictPublicChannelDeletion:
+              type: string
+            RestrictPublicChannelManagement:
+              type: string
+            RestrictTeamInvite:
+              type: string
+            SiteName:
+              type: string
+            UserStatusAwayTimeout:
+              type: integer
+          type: object
+      type: object
+    DataRetentionPolicy:
+      allOf:
+      - $ref: '#/components/schemas/DataRetentionPolicyWithoutId'
+      - properties:
+          id:
+            description: The ID of this retention policy.
+            type: string
+        type: object
+    DataRetentionPolicyCreate:
+      allOf:
+      - $ref: '#/components/schemas/DataRetentionPolicyWithTeamAndChannelIds'
+      required:
+      - display_name
+      - post_duration
+    DataRetentionPolicyForChannel:
+      properties:
+        channel_id:
+          description: The channel ID.
+          type: string
+        post_duration:
+          description: The number of days a message will be retained before being deleted by this policy.
+          type: integer
+      type: object
+    DataRetentionPolicyForTeam:
+      properties:
+        post_duration:
+          description: The number of days a message will be retained before being deleted by this policy.
+          type: integer
+        team_id:
+          description: The team ID.
+          type: string
+      type: object
+    DataRetentionPolicyWithTeamAndChannelCounts:
+      allOf:
+      - $ref: '#/components/schemas/DataRetentionPolicy'
+      - properties:
+          channel_count:
+            description: The number of channels to which this policy is applied.
+            type: integer
+          team_count:
+            description: The number of teams to which this policy is applied.
+            type: integer
+        type: object
+    DataRetentionPolicyWithTeamAndChannelIds:
+      allOf:
+      - $ref: '#/components/schemas/DataRetentionPolicyWithoutId'
+      - properties:
+          channel_ids:
+            description: The IDs of the channels to which this policy should be applied.
+            items:
+              type: string
+            type: array
+          team_ids:
+            description: The IDs of the teams to which this policy should be applied.
+            items:
+              type: string
+            type: array
+        type: object
+    DataRetentionPolicyWithoutId:
+      properties:
+        display_name:
+          description: The display name for this retention policy.
+          type: string
+        post_duration:
+          description: 'The number of days a message will be retained before being deleted by this policy. If this value is
+            less than 0, the policy has infinite retention (i.e. messages are never deleted).
+
+            '
+          type: integer
+      type: object
+    Emoji:
+      properties:
+        create_at:
+          description: The time in milliseconds the emoji was made
+          format: int64
+          type: integer
+        creator_id:
+          description: The ID of the user that made the emoji
+          type: string
+        delete_at:
+          description: The time in milliseconds the emoji was deleted
+          format: int64
+          type: integer
+        id:
+          description: The ID of the emoji
+          type: string
+        name:
+          description: The name of the emoji
+          type: string
+        update_at:
+          description: The time in milliseconds the emoji was last updated
+          format: int64
+          type: integer
+      type: object
+    EnvironmentConfig:
+      properties:
+        AnalyticsSettings:
+          properties:
+            MaxUsersForStatistics:
+              type: boolean
+          type: object
+        ClusterSettings:
+          properties:
+            Enable:
+              type: boolean
+            InterNodeListenAddress:
+              type: boolean
+            InterNodeUrls:
+              type: boolean
+          type: object
+        ComplianceSettings:
+          properties:
+            Directory:
+              type: boolean
+            Enable:
+              type: boolean
+            EnableDaily:
+              type: boolean
+          type: object
+        EmailSettings:
+          properties:
+            ConnectionSecurity:
+              type: boolean
+            EmailBatchingBufferSize:
+              type: boolean
+            EmailBatchingInterval:
+              type: boolean
+            EnableEmailBatching:
+              type: boolean
+            EnableSignInWithEmail:
+              type: boolean
+            EnableSignInWithUsername:
+              type: boolean
+            EnableSignUpWithEmail:
+              type: boolean
+            FeedbackEmail:
+              type: boolean
+            FeedbackName:
+              type: boolean
+            FeedbackOrganization:
+              type: boolean
+            InviteSalt:
+              type: boolean
+            PasswordResetSalt:
+              type: boolean
+            PushNotificationContents:
+              type: boolean
+            PushNotificationServer:
+              type: boolean
+            RequireEmailVerification:
+              type: boolean
+            SMTPPassword:
+              type: boolean
+            SMTPPort:
+              type: boolean
+            SMTPServer:
+              type: boolean
+            SMTPUsername:
+              type: boolean
+            SendEmailNotifications:
+              type: boolean
+            SendPushNotifications:
+              type: boolean
+          type: object
+        FileSettings:
+          properties:
+            AmazonS3AccessKeyId:
+              type: boolean
+            AmazonS3Bucket:
+              type: boolean
+            AmazonS3Endpoint:
+              type: boolean
+            AmazonS3Region:
+              type: boolean
+            AmazonS3SSL:
+              type: boolean
+            AmazonS3SecretAccessKey:
+              type: boolean
+            Directory:
+              type: boolean
+            DriverName:
+              type: boolean
+            EnablePublicLink:
+              type: boolean
+            InitialFont:
+              type: boolean
+            MaxFileSize:
+              type: boolean
+            PreviewHeight:
+              type: boolean
+            PreviewWidth:
+              type: boolean
+            ProfileHeight:
+              type: boolean
+            ProfileWidth:
+              type: boolean
+            PublicLinkSalt:
+              type: boolean
+            ThumbnailHeight:
+              type: boolean
+            ThumbnailWidth:
+              type: boolean
+          type: object
+        GitLabSettings:
+          properties:
+            AuthEndpoint:
+              type: boolean
+            Enable:
+              type: boolean
+            Id:
+              type: boolean
+            Scope:
+              type: boolean
+            Secret:
+              type: boolean
+            TokenEndpoint:
+              type: boolean
+            UserApiEndpoint:
+              type: boolean
+          type: object
+        GoogleSettings:
+          properties:
+            AuthEndpoint:
+              type: boolean
+            Enable:
+              type: boolean
+            Id:
+              type: boolean
+            Scope:
+              type: boolean
+            Secret:
+              type: boolean
+            TokenEndpoint:
+              type: boolean
+            UserApiEndpoint:
+              type: boolean
+          type: object
+        LdapSettings:
+          properties:
+            BaseDN:
+              type: boolean
+            BindPassword:
+              type: boolean
+            BindUsername:
+              type: boolean
+            ConnectionSecurity:
+              type: boolean
+            EmailAttribute:
+              type: boolean
+            Enable:
+              type: boolean
+            FirstNameAttribute:
+              type: boolean
+            IdAttribute:
+              type: boolean
+            LastNameAttribute:
+              type: boolean
+            LdapPort:
+              type: boolean
+            LdapServer:
+              type: boolean
+            LoginFieldName:
+              type: boolean
+            MaxPageSize:
+              type: boolean
+            NicknameAttribute:
+              type: boolean
+            PositionAttribute:
+              type: boolean
+            QueryTimeout:
+              type: boolean
+            SkipCertificateVerification:
+              type: boolean
+            SyncIntervalMinutes:
+              type: boolean
+            UserFilter:
+              type: boolean
+            UsernameAttribute:
+              type: boolean
+          type: object
+        LocalizationSettings:
+          properties:
+            AvailableLocales:
+              type: boolean
+            DefaultClientLocale:
+              type: boolean
+            DefaultServerLocale:
+              type: boolean
+          type: object
+        LogSettings:
+          properties:
+            ConsoleLevel:
+              type: boolean
+            EnableConsole:
+              type: boolean
+            EnableDiagnostics:
+              type: boolean
+            EnableFile:
+              type: boolean
+            EnableWebhookDebugging:
+              type: boolean
+            FileLevel:
+              type: boolean
+            FileLocation:
+              type: boolean
+          type: object
+        MetricsSettings:
+          properties:
+            BlockProfileRate:
+              type: boolean
+            Enable:
+              type: boolean
+            ListenAddress:
+              type: boolean
+          type: object
+        NativeAppSettings:
+          properties:
+            AndroidAppDownloadLink:
+              type: boolean
+            AppDownloadLink:
+              type: boolean
+            IosAppDownloadLink:
+              type: boolean
+          type: object
+        Office365Settings:
+          properties:
+            AuthEndpoint:
+              type: boolean
+            Enable:
+              type: boolean
+            Id:
+              type: boolean
+            Scope:
+              type: boolean
+            Secret:
+              type: boolean
+            TokenEndpoint:
+              type: boolean
+            UserApiEndpoint:
+              type: boolean
+          type: object
+        PasswordSettings:
+          properties:
+            Lowercase:
+              type: boolean
+            MinimumLength:
+              type: boolean
+            Number:
+              type: boolean
+            Symbol:
+              type: boolean
+            Uppercase:
+              type: boolean
+          type: object
+        PrivacySettings:
+          properties:
+            ShowEmailAddress:
+              type: boolean
+            ShowFullName:
+              type: boolean
+          type: object
+        RateLimitSettings:
+          properties:
+            Enable:
+              type: boolean
+            MaxBurst:
+              type: boolean
+            MemoryStoreSize:
+              type: boolean
+            PerSec:
+              type: boolean
+            VaryByHeader:
+              type: boolean
+            VaryByRemoteAddr:
+              type: boolean
+          type: object
+        SamlSettings:
+          properties:
+            AssertionConsumerServiceURL:
+              type: boolean
+            EmailAttribute:
+              type: boolean
+            Enable:
+              type: boolean
+            Encrypt:
+              type: boolean
+            FirstNameAttribute:
+              type: boolean
+            IdpCertificateFile:
+              type: boolean
+            IdpDescriptorUrl:
+              type: boolean
+            IdpUrl:
+              type: boolean
+            LastNameAttribute:
+              type: boolean
+            LocaleAttribute:
+              type: boolean
+            LoginButtonText:
+              type: boolean
+            NicknameAttribute:
+              type: boolean
+            PositionAttribute:
+              type: boolean
+            PrivateKeyFile:
+              type: boolean
+            PublicCertificateFile:
+              type: boolean
+            UsernameAttribute:
+              type: boolean
+            Verify:
+              type: boolean
+          type: object
+        ServiceSettings:
+          properties:
+            AllowCorsFrom:
+              type: boolean
+            ConnectionSecurity:
+              type: boolean
+            EnableCommands:
+              type: boolean
+            EnableCustomEmoji:
+              type: boolean
+            EnableDeveloper:
+              type: boolean
+            EnableIncomingWebhooks:
+              type: boolean
+            EnableInsecureOutgoingConnections:
+              type: boolean
+            EnableMultifactorAuthentication:
+              type: boolean
+            EnableOAuthServiceProvider:
+              type: boolean
+            EnableOnlyAdminIntegrations:
+              type: boolean
+            EnableOutgoingWebhooks:
+              type: boolean
+            EnablePostIconOverride:
+              type: boolean
+            EnablePostUsernameOverride:
+              type: boolean
+            EnableSecurityFixAlert:
+              type: boolean
+            EnableTesting:
+              type: boolean
+            EnforceMultifactorAuthentication:
+              type: boolean
+            Forward80To443:
+              type: boolean
+            GoogleDeveloperKey:
+              type: boolean
+            LetsEncryptCertificateCacheFile:
+              type: boolean
+            ListenAddress:
+              type: boolean
+            MaximumLoginAttempts:
+              type: boolean
+            ReadTimeout:
+              type: boolean
+            RestrictCustomEmojiCreation:
+              type: boolean
+            SegmentDeveloperKey:
+              type: boolean
+            SessionCacheInMinutes:
+              type: boolean
+            SessionLengthMobileInDays:
+              type: boolean
+            SessionLengthSSOInDays:
+              type: boolean
+            SessionLengthWebInDays:
+              type: boolean
+            SiteURL:
+              type: boolean
+            TLSCertFile:
+              type: boolean
+            TLSKeyFile:
+              type: boolean
+            UseLetsEncrypt:
+              type: boolean
+            WebserverMode:
+              type: boolean
+            WebsocketPort:
+              type: boolean
+            WebsocketSecurePort:
+              type: boolean
+            WriteTimeout:
+              type: boolean
+          type: object
+        SqlSettings:
+          properties:
+            AtRestEncryptKey:
+              type: boolean
+            DataSource:
+              type: boolean
+            DataSourceReplicas:
+              type: boolean
+            DriverName:
+              type: boolean
+            MaxIdleConns:
+              type: boolean
+            MaxOpenConns:
+              type: boolean
+            Trace:
+              type: boolean
+          type: object
+        SupportSettings:
+          properties:
+            AboutLink:
+              type: boolean
+            HelpLink:
+              type: boolean
+            PrivacyPolicyLink:
+              type: boolean
+            ReportAProblemLink:
+              type: boolean
+            SupportEmail:
+              type: boolean
+            TermsOfServiceLink:
+              type: boolean
+          type: object
+        TeamSettings:
+          properties:
+            CustomBrandText:
+              type: boolean
+            CustomDescriptionText:
+              type: boolean
+            EnableCustomBrand:
+              type: boolean
+            EnableOpenServer:
+              type: boolean
+            EnableTeamCreation:
+              type: boolean
+            EnableUserCreation:
+              type: boolean
+            MaxChannelsPerTeam:
+              type: boolean
+            MaxNotificationsPerChannel:
+              type: boolean
+            MaxUsersPerTeam:
+              type: boolean
+            RestrictCreationToDomains:
+              type: boolean
+            RestrictDirectMessage:
+              type: boolean
+            RestrictPrivateChannelCreation:
+              type: boolean
+            RestrictPrivateChannelDeletion:
+              type: boolean
+            RestrictPrivateChannelManagement:
+              type: boolean
+            RestrictPublicChannelCreation:
+              type: boolean
+            RestrictPublicChannelDeletion:
+              type: boolean
+            RestrictPublicChannelManagement:
+              type: boolean
+            RestrictTeamInvite:
+              type: boolean
+            SiteName:
+              type: boolean
+            UserStatusAwayTimeout:
+              type: boolean
+          type: object
+      type: object
+    Error:
+      properties:
+        details:
+          description: Further details on where and why this error happened.
+          example: Specific details about the error, depending on the case.
+          type: string
+        error:
+          description: A message with the error description.
+          example: Error retrieving the resource.
+          type: string
+      required:
+      - error
+      - details
+      type: object
+    FileInfo:
+      properties:
+        create_at:
+          description: The time in milliseconds a file was created
+          format: int64
+          type: integer
+        delete_at:
+          description: The time in milliseconds a file was deleted
+          format: int64
+          type: integer
+        extension:
+          description: The extension at the end of the file name
+          type: string
+        has_preview_image:
+          description: If this file is an image, whether or not it has a preview-sized version
+          type: boolean
+        height:
+          description: If this file is an image, the height of the file
+          type: integer
+        id:
+          description: The unique identifier for this file
+          type: string
+        mime_type:
+          description: The MIME type of the file
+          type: string
+        name:
+          description: The name of the file
+          type: string
+        post_id:
+          description: If this file is attached to a post, the ID of that post
+          type: string
+        size:
+          description: The size of the file in bytes
+          type: integer
+        update_at:
+          description: The time in milliseconds a file was last updated
+          format: int64
+          type: integer
+        user_id:
+          description: The ID of the user that uploaded this file
+          type: string
+        width:
+          description: If this file is an image, the width of the file
+          type: integer
+      type: object
+    FileInfoList:
+      properties:
+        file_infos:
+          additionalProperties:
+            $ref: '#/components/schemas/FileInfo'
+          type: object
+        next_file_id:
+          description: The ID of next file info. Not omitted when empty or not relevant.
+          type: string
+        order:
+          example:
+          - file_info_id1
+          - file_info_id2
+          items:
+            type: string
+          type: array
+        prev_file_id:
+          description: The ID of previous file info. Not omitted when empty or not relevant.
+          type: string
+      type: object
+    FilesLimits:
+      properties:
+        total_storage:
+          format: int64
+          nullable: true
+          type: integer
+      type: object
+    GlobalDataRetentionPolicy:
+      properties:
+        file_deletion_enabled:
+          description: Indicates whether data retention policy deletion of file attachments is enabled globally.
+          type: boolean
+        file_retention_cutoff:
+          description: The current server timestamp before which files should be deleted.
+          type: integer
+        message_deletion_enabled:
+          description: Indicates whether data retention policy deletion of messages is enabled globally.
+          type: boolean
+        message_retention_cutoff:
+          description: The current server timestamp before which messages should be deleted.
+          type: integer
+      type: object
+    Group:
+      properties:
+        create_at:
+          format: int64
+          type: integer
+        delete_at:
+          format: int64
+          type: integer
+        description:
+          type: string
+        display_name:
+          type: string
+        has_syncables:
+          type: boolean
+        id:
+          type: string
+        name:
+          type: string
+        remote_id:
+          type: string
+        source:
+          type: string
+        update_at:
+          format: int64
+          type: integer
+      type: object
+    GroupSyncableChannel:
+      properties:
+        auto_add:
+          type: boolean
+        channel_id:
+          type: string
+        create_at:
+          format: int64
+          type: integer
+        delete_at:
+          format: int64
+          type: integer
+        group_id:
+          type: string
+        update_at:
+          format: int64
+          type: integer
+      type: object
+    GroupSyncableChannels:
+      properties:
+        auto_add:
+          type: boolean
+        channel_display_name:
+          type: string
+        channel_id:
+          type: string
+        channel_type:
+          type: string
+        create_at:
+          format: int64
+          type: integer
+        delete_at:
+          format: int64
+          type: integer
+        group_id:
+          type: string
+        team_display_name:
+          type: string
+        team_id:
+          type: string
+        team_type:
+          type: string
+        update_at:
+          format: int64
+          type: integer
+      type: object
+    GroupSyncableTeam:
+      properties:
+        auto_add:
+          type: boolean
+        create_at:
+          format: int64
+          type: integer
+        delete_at:
+          format: int64
+          type: integer
+        group_id:
+          type: string
+        team_id:
+          type: string
+        update_at:
+          format: int64
+          type: integer
+      type: object
+    GroupSyncableTeams:
+      properties:
+        auto_add:
+          type: boolean
+        create_at:
+          format: int64
+          type: integer
+        delete_at:
+          format: int64
+          type: integer
+        group_id:
+          type: string
+        team_display_name:
+          type: string
+        team_id:
+          type: string
+        team_type:
+          type: string
+        update_at:
+          format: int64
+          type: integer
+      type: object
+    GroupWithSchemeAdmin:
+      description: group augmented with scheme admin information
+      properties:
+        group:
+          $ref: '#/components/schemas/Group'
+        scheme_admin:
+          type: boolean
+      type: object
+    GroupsAssociatedToChannels:
+      additionalProperties:
+        items:
+          $ref: '#/components/schemas/GroupWithSchemeAdmin'
+        type: array
+      description: a map of channel id(s) to the set of groups that constrain the corresponding channel in a team
+      type: object
+    IncomingWebhook:
+      properties:
+        channel_id:
+          description: The ID of a public channel or private group that receives the webhook payloads
+          type: string
+        create_at:
+          description: The time in milliseconds a incoming webhook was created
+          format: int64
+          type: integer
+        delete_at:
+          description: The time in milliseconds a incoming webhook was deleted
+          format: int64
+          type: integer
+        description:
+          description: The description for this incoming webhook
+          type: string
+        display_name:
+          description: The display name for this incoming webhook
+          type: string
+        id:
+          description: The unique identifier for this incoming webhook
+          type: string
+        update_at:
+          description: The time in milliseconds a incoming webhook was last updated
+          format: int64
+          type: integer
+      type: object
+    InsightUserInformation:
+      properties:
+        create_at:
+          format: int64
+          type: integer
+        first_name:
+          type: string
+        id:
+          type: string
+        last_name:
+          type: string
+        last_picture_update:
+          type: string
+        nickname:
+          type: string
+        username:
+          type: string
+      type: object
+    IntegrationsLimits:
+      properties:
+        enabled:
+          nullable: true
+          type: integer
+      type: object
+    IntegrityCheckResult:
+      description: an object with the result of the integrity check.
+      properties:
+        data:
+          $ref: '#/components/schemas/RelationalIntegrityCheckData'
+        err:
+          description: a string value set in case of error.
+          type: string
+      type: object
+    Invoice:
+      properties:
+        create_at:
+          format: int64
+          type: integer
+        id:
+          type: string
+        item:
+          items:
+            $ref: '#/components/schemas/InvoiceLineItem'
+          type: array
+        number:
+          type: string
+        period_end:
+          format: int64
+          type: integer
+        period_start:
+          format: int64
+          type: integer
+        status:
+          type: string
+        subscription_id:
+          type: string
+        tax:
+          format: int64
+          type: integer
+        total:
+          format: int64
+          type: integer
+      type: object
+    InvoiceLineItem:
+      properties:
+        description:
+          type: string
+        metadata:
+          items:
+            type: string
+          type: array
+        price_id:
+          type: string
+        price_per_unit:
+          format: int64
+          type: integer
+        quantity:
+          format: int64
+          type: integer
+        total:
+          format: int64
+          type: integer
+      type: object
+    Job:
+      properties:
+        create_at:
+          description: The time at which the job was created
+          format: int64
+          type: integer
+        data:
+          description: A freeform data field containing additional information about the job
+          type: object
+        id:
+          description: The unique id of the job
+          type: string
+        last_activity_at:
+          description: The last time at which the job had activity
+          format: int64
+          type: integer
+        progress:
+          description: The progress (as a percentage) of the job
+          type: integer
+        start_at:
+          description: The time at which the job was started
+          format: int64
+          type: integer
+        status:
+          description: The status of the job
+          type: string
+        type:
+          description: The type of job
+          type: string
+      type: object
+    KnownUsers:
+      properties:
+        items:
+          type: string
+      type: array
+    LDAPGroup:
+      description: A LDAP group
+      properties:
+        has_syncables:
+          type: boolean
+        mattermost_group_id:
+          type: string
+        name:
+          type: string
+        primary_key:
+          type: string
+      type: object
+    LDAPGroupsPaged:
+      description: A paged list of LDAP groups
+      properties:
+        count:
+          description: Total number of groups
+          type: number
+        groups:
+          items:
+            $ref: '#/components/schemas/LDAPGroup'
+          type: array
+      type: object
+    LicenseRenewalLink:
+      properties:
+        renewal_link:
+          description: License renewal link
+          type: string
+      type: object
+    MarketplacePlugin:
+      properties:
+        download_url:
+          description: URL to download the plugin.
+          type: string
+        homepage_url:
+          description: URL that leads to the homepage of the plugin.
+          type: string
+        icon_data:
+          description: Base64 encoding of a plugin icon SVG.
+          type: string
+        installed_version:
+          description: Version number of the already installed plugin, if any.
+          type: string
+        labels:
+          description: A list of the plugin labels.
+          items:
+            type: string
+          type: array
+        manifest:
+          $ref: '#/components/schemas/PluginManifest'
+        release_notes_url:
+          description: URL that leads to the release notes of the plugin.
+          type: string
+        signature:
+          description: Base64 encoded signature of the plugin.
+          type: string
+      type: object
+    MessagesLimits:
+      properties:
+        history:
+          nullable: true
+          type: integer
+      type: object
+    NewTeamMember:
+      properties:
+        create_at:
+          description: The creation timestamp of the team member record.
+          type: integer
+        first_name:
+          type: string
+        id:
+          description: The user's ID.
+          type: string
+        last_name:
+          type: string
+        nickname:
+          type: string
+        position:
+          description: The user's position field value.
+          type: string
+        username:
+          type: string
+      type: object
+    NewTeamMembersList:
+      properties:
+        has_next:
+          description: Indicates if there is another page of new team members that can be fetched.
+          type: boolean
+        items:
+          description: List of new team members.
+          items:
+            $ref: '#/components/schemas/NewTeamMember'
+          type: array
+        total_count:
+          description: The total count of new team members for the given time range.
+          type: integer
+      type: object
+    Notice:
+      properties:
+        action:
+          description: Optional action to perform on action button click. (defaults to closing the notice)
+          type: string
+        actionParam:
+          description: "Optional action parameter. \nExample: {\"action\": \"url\", actionParam: \"/console/some-page\"}"
+          type: string
+        actionText:
+          description: Optional override for the action button text (defaults to OK)
+          type: string
+        description:
+          description: Notice content. Use {{Mattermost}} instead of plain text to support white-labeling. Text supports Markdown.
+          type: string
+        id:
+          description: Notice ID
+          type: string
+        image:
+          description: URL of image to display
+          type: string
+        sysAdminOnly:
+          description: Does this notice apply only to sysadmins
+          type: boolean
+        teamAdminOnly:
+          description: Does this notice apply only to team admins
+          type: boolean
+        title:
+          description: Notice title. Use {{Mattermost}} instead of plain text to support white-labeling. Text supports Markdown.
+          type: string
+      type: object
+    OAuthApp:
+      properties:
+        callback_urls:
+          description: A list of callback URLs for the appliation
+          items:
+            type: string
+          type: array
+        client_secret:
+          description: The client secret of the application
+          type: string
+        create_at:
+          description: The time of registration for the application
+          format: int64
+          type: integer
+        description:
+          description: A short description of the application
+          type: string
+        homepage:
+          description: A link to the website of the application
+          type: string
+        icon_url:
+          description: A URL to an icon to display with the application
+          type: string
+        id:
+          description: The client id of the application
+          type: string
+        is_trusted:
+          description: Set this to `true` to skip asking users for permission
+          type: boolean
+        name:
+          description: The name of the client application
+          type: string
+        update_at:
+          description: The last time of update for the application
+          format: int64
+          type: integer
+      type: object
+    OpenGraph:
+      description: OpenGraph metadata of a webpage
+      properties:
+        article:
+          description: Article object used in OpenGraph metadata of a webpage, if type is article
+          properties:
+            authors:
+              items:
+                properties:
+                  first_name:
+                    type: string
+                  gender:
+                    type: string
+                  last_name:
+                    type: string
+                  username:
+                    type: string
+                type: object
+              type: array
+            expiration_time:
+              type: string
+            modified_time:
+              type: string
+            published_time:
+              type: string
+            section:
+              type: string
+            tags:
+              items:
+                type: string
+              type: array
+          type: object
+        audios:
+          items:
+            description: Audio object used in OpenGraph metadata of a webpage
+            properties:
+              secure_url:
+                type: string
+              type:
+                type: string
+              url:
+                type: string
+            type: object
+          type: array
+        book:
+          description: Book object used in OpenGraph metadata of a webpage, if type is book
+          properties:
+            authors:
+              items:
+                properties:
+                  first_name:
+                    type: string
+                  gender:
+                    type: string
+                  last_name:
+                    type: string
+                  username:
+                    type: string
+                type: object
+              type: array
+            isbn:
+              type: string
+            release_date:
+              type: string
+            tags:
+              items:
+                type: string
+              type: array
+          type: object
+        description:
+          type: string
+        determiner:
+          type: string
+        images:
+          items:
+            description: Image object used in OpenGraph metadata of a webpage
+            properties:
+              height:
+                type: integer
+              secure_url:
+                type: string
+              type:
+                type: string
+              url:
+                type: string
+              width:
+                type: integer
+            type: object
+          type: array
+        locale:
+          type: string
+        locales_alternate:
+          items:
+            type: string
+          type: array
+        profile:
+          properties:
+            first_name:
+              type: string
+            gender:
+              type: string
+            last_name:
+              type: string
+            username:
+              type: string
+          type: object
+        site_name:
+          type: string
+        title:
+          type: string
+        type:
+          type: string
+        url:
+          type: string
+        videos:
+          items:
+            description: Video object used in OpenGraph metadata of a webpage
+            properties:
+              height:
+                type: integer
+              secure_url:
+                type: string
+              type:
+                type: string
+              url:
+                type: string
+              width:
+                type: integer
+            type: object
+          type: array
+      type: object
+    OrderedSidebarCategories:
+      description: List of user's categories with their channels
+      properties:
+        categories:
+          items:
+            $ref: '#/components/schemas/SidebarCategoryWithChannels'
+          type: array
+        order:
+          items:
+            type: string
+          type: array
+      type: object
+    OrphanedRecord:
+      description: an object containing information about an orphaned record.
+      properties:
+        child_id:
+          description: the id of the child relation (table) entry.
+          type: string
+        parent_id:
+          description: the id of the parent relation (table) entry.
+          type: string
+      type: object
+    OutgoingWebhook:
+      properties:
+        callback_urls:
+          description: The URLs to POST the payloads to when the webhook is triggered
+          items:
+            type: string
+          type: array
+        channel_id:
+          description: The ID of a public channel that the webhook watchs
+          type: string
+        content_type:
+          default: application/x-www-form-urlencoded
+          description: The format to POST the data in, either `application/json` or `application/x-www-form-urlencoded`
+          type: string
+        create_at:
+          description: The time in milliseconds a outgoing webhook was created
+          format: int64
+          type: integer
+        creator_id:
+          description: The Id of the user who created the webhook
+          type: string
+        delete_at:
+          description: The time in milliseconds a outgoing webhook was deleted
+          format: int64
+          type: integer
+        description:
+          description: The description for this outgoing webhook
+          type: string
+        display_name:
+          description: The display name for this outgoing webhook
+          type: string
+        id:
+          description: The unique identifier for this outgoing webhook
+          type: string
+        team_id:
+          description: The ID of the team that the webhook watchs
+          type: string
+        trigger_when:
+          description: When to trigger the webhook, `0` when a trigger word is present at all and `1` if the message starts
+            with a trigger word
+          type: integer
+        trigger_words:
+          description: List of words for the webhook to trigger on
+          items:
+            type: string
+          type: array
+        update_at:
+          description: The time in milliseconds a outgoing webhook was last updated
+          format: int64
+          type: integer
+      type: object
+    OwnerInfo:
+      properties:
+        user_id:
+          description: A unique, 26 characters long, alphanumeric identifier for the owner.
+          example: ahz0s61gh275i7z2ag4g1ntvjm
+          type: string
+        username:
+          description: Owner's username.
+          example: aaron.medina
+          type: string
+      required:
+      - user_id
+      - username
+      type: object
+    PaymentMethod:
+      properties:
+        card_brand:
+          type: string
+        exp_month:
+          type: integer
+        exp_year:
+          type: integer
+        last_four:
+          type: integer
+        name:
+          type: string
+        type:
+          type: string
+      type: object
+    PaymentSetupIntent:
+      properties:
+        client_secret:
+          type: string
+        id:
+          type: string
+      type: object
+    Playbook:
+      properties:
+        checklists:
+          description: The stages defined in this playbook.
+          items:
+            $ref: '#/components/schemas/Checklist'
+          type: array
+        create_at:
+          description: The playbook creation timestamp, formatted as the number of milliseconds since the Unix epoch.
+          example: 1602235338837
+          format: int64
+          type: integer
+        create_public_playbook_run:
+          description: A boolean indicating whether the playbook runs created from this playbook should be public or private.
+          example: true
+          type: boolean
+        delete_at:
+          description: The playbook deletion timestamp, formatted as the number of milliseconds since the Unix epoch. It equals
+            0 if the playbook is not deleted.
+          example: 0
+          format: int64
+          type: integer
+        description:
+          description: The description of the playbook.
+          example: A playbook to follow when there is a playbook run regarding the availability of the cloud service.
+          type: string
+        id:
+          description: A unique, 26 characters long, alphanumeric identifier for the playbook.
+          example: iz0g457ikesz55dhxcfa0fk9yy
+          type: string
+        member_ids:
+          description: The identifiers of all the users that are members of this playbook.
+          items:
+            description: User ID of the playbook member.
+            example: ilh6s1j4yefbdhxhtlzt179i6m
+            type: string
+          type: array
+        num_stages:
+          description: The number of stages defined in this playbook.
+          example: 3
+          format: int64
+          type: integer
+        num_steps:
+          description: The total number of steps from all the stages defined in this playbook.
+          example: 18
+          format: int64
+          type: integer
+        team_id:
+          description: The identifier of the team where the playbook is in.
+          example: p03rbi6viyztysbqnkvcqyel2i
+          type: string
+        title:
+          description: The title of the playbook.
+          example: Cloud PlaybookRuns
+          type: string
+      type: object
+    PlaybookAutofollows:
+      properties:
+        items:
+          description: The user IDs of who marked this playbook to auto-follow.
+          items:
+            type: string
+          type: array
+        total_count:
+          description: The total number of users who marked this playbook to auto-follow runs.
+          example: 12
+          format: int32
+          type: integer
+      type: object
+    PlaybookList:
+      properties:
+        has_more:
+          description: A boolean describing whether there are more pages after the currently returned.
+          example: true
+          type: boolean
+        items:
+          description: The playbooks in this page.
+          items:
+            $ref: '#/components/schemas/Playbook'
+          type: array
+        page_count:
+          description: The total number of pages. This depends on the total number of playbooks in the database and the per_page
+            parameter sent with the request.
+          example: 2
+          format: int32
+          type: integer
+        total_count:
+          description: The total number of playbooks in the list, regardless of the paging.
+          example: 305
+          format: int32
+          type: integer
+      type: object
+    PlaybookRun:
+      properties:
+        active_stage:
+          description: Zero-based index of the currently active stage.
+          example: 1
+          format: int32
+          type: integer
+        active_stage_title:
+          description: The title of the currently active stage.
+          example: Triage issue
+          type: string
+        channel_id:
+          description: The identifier of the playbook run's channel.
+          example: hwrmiyzj3kadcilh3ukfcnsbt6
+          type: string
+        checklists:
+          items:
+            $ref: '#/components/schemas/Checklist'
+          type: array
+        create_at:
+          description: The playbook run creation timestamp, formatted as the number of milliseconds since the Unix epoch.
+          example: 1606807976289
+          format: int64
+          type: integer
+        delete_at:
+          description: The playbook run deletion timestamp, formatted as the number of milliseconds since the Unix epoch.
+            It equals 0 if the playbook run is not deleted.
+          example: 0
+          format: int64
+          type: integer
+        end_at:
+          description: The playbook run finish timestamp, formatted as the number of milliseconds since the Unix epoch. It
+            equals 0 if the playbook run is not finished.
+          example: 0
+          format: int64
+          type: integer
+        id:
+          description: A unique, 26 characters long, alphanumeric identifier for the playbook run.
+          example: mx3xyzdojfgyfdx8sc8of1gdme
+          type: string
+        is_active:
+          description: True if the playbook run is ongoing; false if the playbook run is ended.
+          example: false
+          type: boolean
+        name:
+          description: The name of the playbook run.
+          example: Server down in EU cluster
+          type: string
+        owner_user_id:
+          description: The identifier of the user that is commanding the playbook run.
+          example: bqnbdf8uc0a8yz4i39qrpgkvtg
+          type: string
+        playbook_id:
+          description: The identifier of the playbook with from which this playbook run was created.
+          example: 0y4a0ntte97cxvfont8y84wa7x
+          type: string
+        post_id:
+          description: If the playbook run was created from a post, this field contains the identifier of such post. If not,
+            this field is empty.
+          example: b2ntfcrl4ujivl456ab4b3aago
+          type: string
+        summary:
+          description: The summary of the playbook run.
+          example: There is one server in the EU cluster that is not responding since April 12.
+          type: string
+        team_id:
+          description: The identifier of the team where the playbook run's channel is in.
+          example: 61ji2mpflefup3cnuif80r5rde
+          type: string
+      type: object
+    PlaybookRunList:
+      properties:
+        has_more:
+          description: A boolean describing whether there are more pages after the currently returned.
+          example: true
+          type: boolean
+        items:
+          description: The playbook runs in this page.
+          items:
+            $ref: '#/components/schemas/PlaybookRun'
+          type: array
+        page_count:
+          description: The total number of pages. This depends on the total number of playbook runs in the database and the
+            per_page parameter sent with the request.
+          example: 2
+          format: int32
+          type: integer
+        total_count:
+          description: The total number of playbook runs in the list, regardless of the paging.
+          example: 305
+          format: int32
+          type: integer
+      type: object
+    PlaybookRunMetadata:
+      properties:
+        channel_display_name:
+          description: Display name of the channel associated to the playbook run.
+          example: Server down in EU cluster
+          type: string
+        channel_name:
+          description: Name of the channel associated to the playbook run.
+          example: server-down-in-eu-cluster
+          type: string
+        num_members:
+          description: Number of users that have been members of the playbook run at any point.
+          example: 25
+          format: int64
+          type: integer
+        team_name:
+          description: Name of the team the playbook run is in.
+          example: sre-staff
+          type: string
+        total_posts:
+          description: Number of posts in the channel associated to the playbook run.
+          example: 202
+          format: int64
+          type: integer
+      type: object
+    PluginManifest:
+      properties:
+        backend:
+          description: Deprecated in Mattermost 5.2 release.
+          properties:
+            executable:
+              description: Path to the executable binary.
+              type: string
+          type: object
+        description:
+          description: Description of what the plugin is and does.
+          type: string
+        id:
+          description: Globally unique identifier that represents the plugin.
+          type: string
+        min_server_version:
+          description: 'The minimum Mattermost server version required for the plugin.
+
+
+            Available as server version 5.6.
+
+            '
+          type: string
+        name:
+          description: Name of the plugin.
+          type: string
+        server:
+          properties:
+            executable:
+              description: Path to the executable binary.
+              type: string
+            executables:
+              description: Paths to executable binaries, specifying multiple entry points for different platforms when bundled
+                together in a single plugin.
+              properties:
+                darwin-amd64:
+                  type: string
+                linux-amd64:
+                  type: string
+                windows-amd64:
+                  type: string
+              type: object
+          type: object
+        settings_schema:
+          description: Settings schema used to define the System Console UI for the plugin.
+          type: object
+        version:
+          description: Version number of the plugin.
+          type: string
+        webapp:
+          properties:
+            bundle_path:
+              description: Path to the webapp JavaScript bundle.
+              type: string
+          type: object
+      type: object
+    PluginManifestWebapp:
+      properties:
+        id:
+          description: Globally unique identifier that represents the plugin.
+          type: string
+        version:
+          description: Version number of the plugin.
+          type: string
+        webapp:
+          properties:
+            bundle_path:
+              description: Path to the webapp JavaScript bundle.
+              type: string
+          type: object
+      type: object
+    PluginStatus:
+      properties:
+        cluster_id:
+          description: ID of the cluster in which plugin is running
+          type: string
+        description:
+          description: Description of what the plugin is and does.
+          type: string
+        name:
+          description: Name of the plugin.
+          type: string
+        plugin_id:
+          description: Globally unique identifier that represents the plugin.
+          type: string
+        plugin_path:
+          description: Path to the plugin on the server
+          type: string
+        state:
+          description: State of the plugin
+          enum:
+          - NotRunning
+          - Starting
+          - Running
+          - FailedToStart
+          - FailedToStayRunning
+          - Stopping
+          type: number
+        version:
+          description: Version number of the plugin.
+          type: string
+      type: object
+    Post:
+      properties:
+        channel_id:
+          type: string
+        create_at:
+          description: The time in milliseconds a post was created
+          format: int64
+          type: integer
+        delete_at:
+          description: The time in milliseconds a post was deleted
+          format: int64
+          type: integer
+        edit_at:
+          format: int64
+          type: integer
+        file_ids:
+          items:
+            type: string
+          type: array
+        hashtag:
+          type: string
+        id:
+          type: string
+        message:
+          type: string
+        metadata:
+          $ref: '#/components/schemas/PostMetadata'
+        original_id:
+          type: string
+        pending_post_id:
+          type: string
+        props:
+          type: object
+        root_id:
+          type: string
+        type:
+          type: string
+        update_at:
+          description: The time in milliseconds a post was last updated
+          format: int64
+          type: integer
+        user_id:
+          type: string
+      type: object
+    PostAcknowledgement:
+      properties:
+        acknowledged_at:
+          description: The time in milliseconds in which this acknowledgement was made.
+          format: int64
+          type: integer
+        post_id:
+          description: The ID of the post to which this acknowledgement was made.
+          type: string
+        user_id:
+          description: The ID of the user that made this acknowledgement.
+          type: string
+      type: object
+    PostIdToReactionsMap:
+      additionalProperties:
+        items:
+          $ref: '#/components/schemas/Reaction'
+        type: array
+      type: object
+    PostList:
+      properties:
+        has_next:
+          description: Whether there are more items after this page.
+          type: boolean
+        next_post_id:
+          description: The ID of next post. Not omitted when empty or not relevant.
+          type: string
+        order:
+          example:
+          - post_id1
+          - post_id12
+          items:
+            type: string
+          type: array
+        posts:
+          additionalProperties:
+            $ref: '#/components/schemas/Post'
+          type: object
+        prev_post_id:
+          description: The ID of previous post. Not omitted when empty or not relevant.
+          type: string
+      type: object
+    PostListWithSearchMatches:
+      properties:
+        matches:
+          additionalProperties:
+            items:
+              type: string
+            type: array
+          description: A mapping of post IDs to a list of matched terms within the post. This field will only be populated
+            on servers running version 5.1 or greater with Elasticsearch enabled.
+          example:
+            post_id1:
+            - search match 1
+            - search match 2
+          type: object
+        order:
+          example:
+          - post_id1
+          - post_id12
+          items:
+            type: string
+          type: array
+        posts:
+          additionalProperties:
+            $ref: '#/components/schemas/Post'
+          type: object
+      type: object
+    PostMetadata:
+      description: Additional information used to display a post.
+      properties:
+        acknowledgements:
+          description: 'Any acknowledgements made to this point.
+
+            '
+          items:
+            $ref: '#/components/schemas/PostAcknowledgement'
+          type: array
+        embeds:
+          description: 'Information about content embedded in the post including OpenGraph previews, image link previews,
+            and message attachments. This field will be null if the post does not contain embedded content.
+
+            '
+          items:
+            properties:
+              data:
+                description: 'Any additional information about the embedded content. Only used at this time to store OpenGraph
+                  metadata.
+
+                  This field will be null for non-OpenGraph embeds.
+
+                  '
+                type: object
+              type:
+                description: The type of content that is embedded in this point.
+                enum:
+                - image
+                - message_attachment
+                - opengraph
+                - link
+                type: string
+              url:
+                description: The URL of the embedded content, if one exists.
+                type: string
+            type: object
+          type: array
+        emojis:
+          description: 'The custom emojis that appear in this point or have been used in reactions to this post. This field
+            will be null if the post does not contain custom emojis.
+
+            '
+          items:
+            $ref: '#/components/schemas/Emoji'
+          type: array
+        files:
+          description: 'The FileInfo objects for any files attached to the post. This field will be null if the post does
+            not have any file attachments.
+
+            '
+          items:
+            $ref: '#/components/schemas/FileInfo'
+          type: array
+        images:
+          description: 'An object mapping the URL of an external image to an object containing the dimensions of that image.
+            This field will be null if the post or its embedded content does not reference any external images.
+
+            '
+          items:
+            properties:
+              height:
+                type: integer
+              width:
+                type: integer
+            type: object
+          type: object
+        priority:
+          description: 'Post priority set for this post. This field will be null if no priority metadata has been set.
+
+            '
+          properties:
+            priority:
+              description: The priority label of a post, could be either empty, important, or urgent.
+              type: string
+            requested_ack:
+              description: Whether the post author has requested for acknowledgements or not.
+              type: boolean
+          type: object
+        reactions:
+          description: 'Any reactions made to this point. This field will be null if no reactions have been made to this post.
+
+            '
+          items:
+            $ref: '#/components/schemas/Reaction'
+          type: array
+      type: object
+    PostsUsage:
+      properties:
+        count:
+          description: Total no. of posts
+          type: number
+      type: object
+    Preference:
+      properties:
+        category:
+          type: string
+        name:
+          type: string
+        user_id:
+          description: The ID of the user that owns this preference
+          type: string
+        value:
+          type: string
+      type: object
+    Product:
+      properties:
+        add_ons:
+          items:
+            $ref: '#/components/schemas/AddOn'
+          type: array
+        description:
+          type: string
+        id:
+          type: string
+        name:
+          type: string
+        price_per_seat:
+          type: string
+      type: object
+    ProductLimits:
+      properties:
+        boards:
+          $ref: '#/components/schemas/BoardsLimits'
+          nullable: true
+        files:
+          $ref: '#/components/schemas/FilesLimits'
+          nullable: true
+        integrations:
+          $ref: '#/components/schemas/IntegrationsLimits'
+          nullable: true
+        messages:
+          $ref: '#/components/schemas/MessagesLimits'
+          nullable: true
+        teams:
+          $ref: '#/components/schemas/TeamsLimits'
+          nullable: true
+      type: object
+    PropertyField:
+      properties:
+        attrs:
+          additionalProperties: true
+          description: Additional attributes for the property field (options for select fields, visibility, etc.).
+          example:
+            options:
+            - color: '#ff0000'
+              id: opt1
+              name: High
+            sortOrder: 1
+            visibility: when_set
+          type: object
+        create_at:
+          description: The property field creation timestamp, formatted as the number of milliseconds since the Unix epoch.
+          example: 1602235338837
+          format: int64
+          type: integer
+        delete_at:
+          description: The property field deletion timestamp, formatted as the number of milliseconds since the Unix epoch.
+            It equals 0 if not deleted.
+          example: 0
+          format: int64
+          type: integer
+        description:
+          description: The description of the property field.
+          example: Issue priority level
+          type: string
+        id:
+          description: A unique, 26 characters long, alphanumeric identifier for the property field.
+          example: p7fj3k2l5m8n9q1r4s6t8v0w2x
+          type: string
+        name:
+          description: The name of the property field.
+          example: Priority
+          type: string
+        type:
+          description: The type of the property field.
+          enum:
+          - text
+          - select
+          - multiselect
+          example: select
+          type: string
+        update_at:
+          description: The property field update timestamp, formatted as the number of milliseconds since the Unix epoch.
+          example: 1602235338837
+          format: int64
+          type: integer
+      type: object
+    PropertyFieldRequest:
+      properties:
+        attrs:
+          additionalProperties: true
+          description: Additional attributes for the property field.
+          properties:
+            options:
+              description: Available options for select/multiselect fields.
+              items:
+                properties:
+                  color:
+                    description: Color associated with the option.
+                    example: '#ff0000'
+                    type: string
+                  id:
+                    description: Option ID (generated if not provided).
+                    example: opt1
+                    type: string
+                  name:
+                    description: Display name of the option.
+                    example: High
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            parentID:
+              description: Parent field ID for hierarchical fields.
+              example: parent_field_id
+              type: string
+            sortOrder:
+              description: Display order of the field.
+              example: 1
+              type: number
+            visibility:
+              description: When to show this field.
+              enum:
+              - hidden
+              - when_set
+              - always
+              example: when_set
+              type: string
+          type: object
+        name:
+          description: The name of the property field.
+          example: Priority
+          type: string
+        type:
+          description: The type of the property field.
+          enum:
+          - text
+          - select
+          - multiselect
+          example: select
+          type: string
+      required:
+      - name
+      - type
+      type: object
+    PropertyValue:
+      properties:
+        create_at:
+          description: The property value creation timestamp, formatted as the number of milliseconds since the Unix epoch.
+          example: 1602235338837
+          format: int64
+          type: integer
+        delete_at:
+          description: The property value deletion timestamp, formatted as the number of milliseconds since the Unix epoch.
+            It equals 0 if not deleted.
+          example: 0
+          format: int64
+          type: integer
+        field_id:
+          description: The identifier of the property field this value belongs to.
+          example: p7fj3k2l5m8n9q1r4s6t8v0w2x
+          type: string
+        id:
+          description: A unique, 26 characters long, alphanumeric identifier for the property value.
+          example: v8z9a1b2c3d4e5f6g7h8i9j0k1l
+          type: string
+        update_at:
+          description: The property value update timestamp, formatted as the number of milliseconds since the Unix epoch.
+          example: 1602235338837
+          format: int64
+          type: integer
+        value:
+          description: The JSON-encoded value of the property.
+          example: '"High Priority"'
+          format: json
+          type: string
+      type: object
+    PropertyValueRequest:
+      properties:
+        value:
+          description: The JSON-encoded value to set for the property.
+          example: '"High Priority Issue"'
+          format: json
+          type: string
+      required:
+      - value
+      type: object
+    PushNotification:
+      properties:
+        ack_id:
+          type: string
+        badge:
+          type: number
+        category:
+          type: string
+        channel_id:
+          type: string
+        channel_name:
+          type: string
+        cont_ava:
+          type: number
+        device_id:
+          type: string
+        from_webhook:
+          type: string
+        is_id_loaded:
+          type: boolean
+        message:
+          type: string
+        override_icon_url:
+          type: string
+        override_username:
+          type: string
+        platform:
+          type: string
+        post_id:
+          type: string
+        root_id:
+          type: string
+        sender_id:
+          type: string
+        sender_name:
+          type: string
+        server_id:
+          type: string
+        sound:
+          type: string
+        team_id:
+          type: string
+        type:
+          type: string
+        version:
+          type: string
+      type: object
+    Reaction:
+      properties:
+        create_at:
+          description: The time in milliseconds this reaction was made
+          format: int64
+          type: integer
+        emoji_name:
+          description: The name of the emoji that was used for this reaction
+          type: string
+        post_id:
+          description: The ID of the post to which this reaction was made
+          type: string
+        user_id:
+          description: The ID of the user that made this reaction
+          type: string
+      type: object
+    RelationalIntegrityCheckData:
+      description: an object containing the results of a relational integrity check.
+      properties:
+        child_id_attr:
+          description: the name of the attribute (column) containing the child id.
+          type: string
+        child_name:
+          description: the name of the child relation (table).
+          type: string
+        parent_id_attr:
+          description: the name of the attribute (column) containing the parent id.
+          type: string
+        parent_name:
+          description: the name of the parent relation (table).
+          type: string
+        records:
+          description: the list of orphaned records found.
+          items:
+            $ref: '#/components/schemas/OrphanedRecord'
+          type: array
+      type: object
+    RemoteClusterInfo:
+      properties:
+        create_at:
+          description: The time in milliseconds a remote cluster was created
+          format: int64
+          type: integer
+        display_name:
+          description: The display name for the remote cluster
+          type: string
+        last_ping_at:
+          description: The time in milliseconds a remote cluster was last pinged successfully
+          format: int64
+          type: integer
+      type: object
+    RetentionPolicyForChannelList:
+      properties:
+        policies:
+          description: The list of channel policies.
+          items:
+            $ref: '#/components/schemas/DataRetentionPolicyForChannel'
+          type: array
+        total_count:
+          description: The total number of channel policies.
+          type: integer
+      type: object
+    RetentionPolicyForTeamList:
+      properties:
+        policies:
+          description: The list of team policies.
+          items:
+            $ref: '#/components/schemas/DataRetentionPolicyForTeam'
+          type: array
+        total_count:
+          description: The total number of team policies.
+          type: integer
+      type: object
+    Role:
+      properties:
+        description:
+          description: A human readable description of the role.
+          type: string
+        display_name:
+          description: The human readable name for the role.
+          type: string
+        id:
+          description: The unique identifier of the role.
+          type: string
+        name:
+          description: The unique name of the role, used when assigning roles to users/groups in contexts.
+          type: string
+        permissions:
+          description: A list of the unique names of the permissions this role grants.
+          items:
+            type: string
+          type: array
+        scheme_managed:
+          description: indicates if this role is managed by a scheme (true), or is a custom stand-alone role (false).
+          type: boolean
+      type: object
+    SamlCertificateStatus:
+      properties:
+        idp_certificate_file:
+          description: Status is good when `true`
+          type: boolean
+        private_key_file:
+          description: Status is good when `true`
+          type: boolean
+        public_certificate_file:
+          description: Status is good when `true`
+          type: boolean
+      type: object
+    Scheme:
+      properties:
+        create_at:
+          description: The time at which the scheme was created.
+          format: int64
+          type: integer
+        default_channel_admin_role:
+          description: The id of the default channel admin role for this scheme.
+          type: string
+        default_channel_user_role:
+          description: The id of the default channel user role for this scheme.
+          type: string
+        default_team_admin_role:
+          description: The id of the default team admin role for this scheme.
+          type: string
+        default_team_user_role:
+          description: The id of the default team user role for this scheme.
+          type: string
+        delete_at:
+          description: The time at which the scheme was deleted.
+          format: int64
+          type: integer
+        description:
+          description: A human readable description of the scheme.
+          type: string
+        id:
+          description: The unique identifier of the scheme.
+          type: string
+        name:
+          description: The human readable name for the scheme.
+          type: string
+        scope:
+          description: The scope to which this scheme can be applied, either "team" or "channel".
+          type: string
+        update_at:
+          description: The time at which the scheme was last updated.
+          format: int64
+          type: integer
+      type: object
+    Server_Busy:
+      properties:
+        busy:
+          description: True if the server is marked as busy (under high load)
+          type: boolean
+        expires:
+          description: timestamp - number of seconds since Jan 1, 1970 UTC.
+          format: int64
+          type: integer
+      type: object
+    Session:
+      properties:
+        create_at:
+          description: The time in milliseconds a session was created
+          format: int64
+          type: integer
+        device_id:
+          type: string
+        expires_at:
+          description: The time in milliseconds a session will expire
+          format: int64
+          type: integer
+        id:
+          type: string
+        is_oauth:
+          type: boolean
+        last_activity_at:
+          description: The time in milliseconds of the last activity of a session
+          format: int64
+          type: integer
+        props:
+          type: object
+        roles:
+          type: string
+        team_members:
+          items:
+            $ref: '#/components/schemas/TeamMember'
+          type: array
+        token:
+          type: string
+        user_id:
+          type: string
+      type: object
+    SharedChannel:
+      properties:
+        create_at:
+          description: Time in milliseconds that the channel was shared
+          type: integer
+        creator_id:
+          description: Id of the user that shared the channel
+          type: string
+        display_name:
+          description: Channel display name as it appears locally
+          type: string
+        header:
+          type: string
+        home:
+          description: Is this the home cluster for the shared channel
+          type: boolean
+        id:
+          description: Channel id of the shared channel
+          type: string
+        name:
+          description: Channel name as it is shared (may be different than original channel name)
+          type: string
+        purpose:
+          type: string
+        readonly:
+          description: Is this shared channel shared as read only
+          type: boolean
+        remote_id:
+          description: Id of the remote cluster where the shared channel is homed
+          type: string
+        team_id:
+          type: string
+        update_at:
+          description: Time in milliseconds that the shared channel record was last updated
+          type: integer
+      type: object
+    SidebarCategory:
+      description: User's sidebar category
+      properties:
+        display_name:
+          type: string
+        id:
+          type: string
+        team_id:
+          type: string
+        type:
+          enum:
+          - channels
+          - custom
+          - direct_messages
+          - favorites
+          type: string
+        user_id:
+          type: string
+      type: object
+    SidebarCategoryWithChannels:
+      description: User's sidebar category with it's channels
+      properties:
+        channel_ids:
+          items:
+            type: string
+          type: array
+        display_name:
+          type: string
+        id:
+          type: string
+        team_id:
+          type: string
+        type:
+          enum:
+          - channels
+          - custom
+          - direct_messages
+          - favorites
+          type: string
+        user_id:
+          type: string
+      type: object
+    SlackAttachment:
+      properties:
+        AuthorIcon:
+          type: string
+        AuthorLink:
+          type: string
+        AuthorName:
+          type: string
+        Color:
+          type: string
+        Fallback:
+          type: string
+        Fields:
+          items:
+            $ref: '#/components/schemas/SlackAttachmentField'
+          type: array
+        Footer:
+          type: string
+        FooterIcon:
+          type: string
+        Id:
+          type: string
+        ImageURL:
+          type: string
+        Pretext:
+          type: string
+        Text:
+          type: string
+        ThumbURL:
+          type: string
+        Timestamp:
+          description: The timestamp of the slack attachment, either type of string or integer
+          type: string
+        Title:
+          type: string
+        TitleLink:
+          type: string
+      type: object
+    SlackAttachmentField:
+      properties:
+        Short:
+          type: boolean
+        Title:
+          type: string
+        Value:
+          description: The value of the attachment, set as string but capable with golang interface
+          type: string
+      type: object
+    Status:
+      properties:
+        last_activity_at:
+          format: int64
+          type: integer
+        manual:
+          type: boolean
+        status:
+          type: string
+        user_id:
+          type: string
+      type: object
+    StatusOK:
+      properties:
+        status:
+          description: Will contain "ok" if the request was successful and there was nothing else to return
+          type: string
+      type: object
+    StorageUsage:
+      properties:
+        bytes:
+          description: Total file storage usage for the instance in bytes rounded down to the most significant digit
+          type: number
+      type: object
+    Subscription:
+      properties:
+        add_ons:
+          items:
+            type: string
+          type: array
+        create_at:
+          format: int64
+          type: integer
+        customer_id:
+          type: string
+        dns:
+          type: string
+        end_at:
+          format: int64
+          type: integer
+        id:
+          type: string
+        product_id:
+          type: string
+        seats:
+          type: integer
+        start_at:
+          format: int64
+          type: integer
+      type: object
+    SubscriptionStats:
+      properties:
+        is_paid_tier:
+          type: string
+        remaining_seats:
+          type: integer
+      type: object
+    System:
+      properties:
+        name:
+          description: System property name
+          type: string
+        value:
+          description: System property value
+          type: string
+      type: object
+    SystemStatusResponse:
+      properties:
+        AndroidLatestVersion:
+          description: Latest Android version supported
+          type: string
+        AndroidMinVersion:
+          description: Minimum Android version supported
+          type: string
+        CanReceiveNotifications:
+          description: Whether the device id provided can receive notifications ("true", "false" or "unknown"). Included when
+            device_id parameter set.
+          type: string
+        DesktopLatestVersion:
+          description: Latest desktop version supported
+          type: string
+        DesktopMinVersion:
+          description: Minimum desktop version supported
+          type: string
+        IosLatestVersion:
+          description: Latest iOS version supported
+          type: string
+        IosMinVersion:
+          description: Minimum iOS version supported
+          type: string
+        database_status:
+          description: Status of database ("OK" or "UNHEALTHY"). Included when get_server_status parameter set.
+          type: string
+        filestore_status:
+          description: Status of filestore ("OK" or "UNHEALTHY"). Included when get_server_status parameter set.
+          type: string
+        status:
+          description: Status of server ("OK" or "UNHEALTHY"). Included when get_server_status parameter set.
+          type: string
+      type: object
+    Team:
+      properties:
+        allow_open_invite:
+          type: boolean
+        allowed_domains:
+          type: string
+        create_at:
+          description: The time in milliseconds a team was created
+          format: int64
+          type: integer
+        delete_at:
+          description: The time in milliseconds a team was deleted
+          format: int64
+          type: integer
+        description:
+          type: string
+        display_name:
+          type: string
+        email:
+          type: string
+        id:
+          type: string
+        invite_id:
+          type: string
+        name:
+          type: string
+        policy_id:
+          description: The data retention policy to which this team has been assigned. If no such policy exists, or the caller
+            does not have the `sysconsole_read_compliance_data_retention` permission, this field will be null.
+          type: string
+        type:
+          type: string
+        update_at:
+          description: The time in milliseconds a team was last updated
+          format: int64
+          type: integer
+      type: object
+    TeamExists:
+      properties:
+        exists:
+          type: boolean
+      type: object
+    TeamMap:
+      description: A mapping of teamIds to teams.
+      properties:
+        team_id:
+          $ref: '#/components/schemas/Team'
+      type: object
+    TeamMember:
+      properties:
+        delete_at:
+          description: The time in milliseconds that this team member was deleted.
+          type: integer
+        explicit_roles:
+          description: The list of roles explicitly assigned to this team member, as a space separated list of role names.
+            This list does *not* include any roles granted implicitly through permissions schemes.
+          type: string
+        roles:
+          description: The complete list of roles assigned to this team member, as a space-separated list of role names, including
+            any roles granted implicitly through permissions schemes.
+          type: string
+        scheme_admin:
+          description: Whether this team member holds the default admin role defined by the team's permissions scheme.
+          type: boolean
+        scheme_user:
+          description: Whether this team member holds the default user role defined by the team's permissions scheme.
+          type: boolean
+        team_id:
+          description: The ID of the team this member belongs to.
+          type: string
+        user_id:
+          description: The ID of the user this member relates to.
+          type: string
+      type: object
+    TeamStats:
+      properties:
+        active_member_count:
+          type: integer
+        team_id:
+          type: string
+        total_member_count:
+          type: integer
+      type: object
+    TeamUnread:
+      properties:
+        mention_count:
+          type: integer
+        msg_count:
+          type: integer
+        team_id:
+          type: string
+      type: object
+    TeamsLimits:
+      properties:
+        active:
+          nullable: true
+          type: integer
+      type: object
+    TermsOfService:
+      properties:
+        create_at:
+          description: The time at which the terms of service was created.
+          format: int64
+          type: integer
+        id:
+          description: The unique identifier of the terms of service.
+          type: string
+        text:
+          description: The text of terms of service. Supports Markdown.
+          type: string
+        user_id:
+          description: The unique identifier of the user who created these terms of service.
+          type: string
+      type: object
+    Timezone:
+      properties:
+        automaticTimezone:
+          description: This value is set automatically when the "useAutomaticTimezone" is set to "true".
+          type: string
+        manualTimezone:
+          description: Value when setting manually the timezone, i.e. "Europe/Berlin".
+          type: string
+        useAutomaticTimezone:
+          description: Set to "true" to use the browser/system timezone, "false" to set manually. Defaults to "true".
+          type: boolean
+      type: object
+    TopChannel:
+      properties:
+        display_name:
+          type: string
+        id:
+          type: string
+        message_count:
+          description: The number of messages posted in the channel by users over the given time period (not including messages
+            posted by bots).
+          type: string
+        name:
+          type: string
+        team_id:
+          type: string
+        type:
+          type: string
+      type: object
+    TopChannelList:
+      properties:
+        has_next:
+          description: Indicates if there is another page of channels that can be fetched.
+          type: boolean
+        items:
+          description: List of channels.
+          items:
+            $ref: '#/components/schemas/TopChannel'
+          type: array
+      type: object
+    TopDM:
+      properties:
+        outgoing_message_count:
+          format: int64
+          type: integer
+        post_count:
+          format: int64
+          type: integer
+        second_participant:
+          $ref: '#/components/schemas/TopDMInsightUserInformation'
+      type: object
+    TopDMInsightUserInformation:
+      allOf:
+      - $ref: '#/components/schemas/InsightUserInformation'
+      - properties:
+          position:
+            type: string
+        type: object
+    TopDMList:
+      properties:
+        has_next:
+          description: Indicates if there is another page of top DMs that can be fetched.
+          type: boolean
+        items:
+          description: List of top DMs.
+          items:
+            $ref: '#/components/schemas/TopDM'
+          type: array
+      type: object
+    TopReaction:
+      properties:
+        count:
+          description: The number of the times this emoji has been used.
+          format: int64
+          type: integer
+        emoji_name:
+          description: The name of the emoji used for this reaction.
+          type: string
+      type: object
+    TopReactionList:
+      properties:
+        has_next:
+          description: Indicates if there is another page of reactions that can be fetched.
+          type: boolean
+        items:
+          description: List of reactions.
+          items:
+            $ref: '#/components/schemas/TopReaction'
+          type: array
+      type: object
+    TopThread:
+      properties:
+        Participants:
+          items:
+            type: string
+          type: array
+        channel_display_name:
+          type: string
+        channel_id:
+          type: string
+        channel_name:
+          type: string
+        post:
+          $ref: '#/components/schemas/Post'
+        user_information:
+          $ref: '#/components/schemas/InsightUserInformation'
+          description: User who created the post
+      type: object
+    TopThreadList:
+      properties:
+        has_next:
+          description: Indicates if there is another page of top threads that can be fetched.
+          type: boolean
+        items:
+          description: List of top threads.
+          items:
+            $ref: '#/components/schemas/TopThread'
+          type: array
+      type: object
+    TriggerIdReturn:
+      properties:
+        trigger_id:
+          description: The trigger_id returned by the slash command.
+          example: ceenjwsg6tgdzjpofxqemy1aio
+          type: string
+      required:
+      - trigger_id
+      type: object
+    UploadSession:
+      description: an object containing information used to keep track of a file upload.
+      properties:
+        channel_id:
+          description: The ID of the channel to upload to.
+          type: string
+        create_at:
+          description: The time the upload was created in milliseconds.
+          format: int64
+          type: integer
+        file_offset:
+          description: The amount of data uploaded in bytes.
+          format: int64
+          type: integer
+        file_size:
+          description: The size of the file to upload in bytes.
+          format: int64
+          type: integer
+        filename:
+          description: The name of the file to upload.
+          type: string
+        id:
+          description: The unique identifier for the upload.
+          type: string
+        type:
+          description: The type of the upload.
+          enum:
+          - attachment
+          - import
+          type: string
+        user_id:
+          description: The ID of the user performing the upload.
+          type: string
+      type: object
+    User:
+      properties:
+        auth_service:
+          type: string
+        create_at:
+          description: The time in milliseconds a user was created
+          format: int64
+          type: integer
+        delete_at:
+          description: The time in milliseconds a user was deleted
+          format: int64
+          type: integer
+        email:
+          type: string
+        email_verified:
+          type: boolean
+        failed_attempts:
+          type: integer
+        first_name:
+          type: string
+        id:
+          type: string
+        last_name:
+          type: string
+        last_password_update:
+          format: int64
+          type: integer
+        last_picture_update:
+          format: int64
+          type: integer
+        locale:
+          type: string
+        mfa_active:
+          type: boolean
+        nickname:
+          type: string
+        notify_props:
+          $ref: '#/components/schemas/UserNotifyProps'
+        props:
+          type: object
+        roles:
+          type: string
+        terms_of_service_create_at:
+          description: The time in milliseconds the user accepted the terms of service
+          format: int64
+          type: integer
+        terms_of_service_id:
+          description: ID of accepted terms of service, if any. This field is not present if empty.
+          type: string
+        timezone:
+          $ref: '#/components/schemas/Timezone'
+        update_at:
+          description: The time in milliseconds a user was last updated
+          format: int64
+          type: integer
+        username:
+          type: string
+      type: object
+    UserAccessToken:
+      properties:
+        description:
+          description: A description of the token usage
+          type: string
+        id:
+          description: Unique identifier for the token
+          type: string
+        token:
+          description: The token used for authentication
+          type: string
+        user_id:
+          description: The user the token authenticates for
+          type: string
+      type: object
+    UserAccessTokenSanitized:
+      properties:
+        description:
+          description: A description of the token usage
+          type: string
+        id:
+          description: Unique identifier for the token
+          type: string
+        is_active:
+          description: Indicates whether the token is active
+          type: boolean
+        user_id:
+          description: The user the token authenticates for
+          type: string
+      type: object
+    UserAuthData:
+      properties:
+        auth_data:
+          description: Service-specific authentication data
+          type: string
+        auth_service:
+          description: The authentication service such as "email", "gitlab", or "ldap"
+          type: string
+      required:
+      - auth_data
+      - auth_service
+      type: object
+    UserAutocomplete:
+      properties:
+        out_of_channel:
+          description: A special case list of users returned when autocompleting in a specific channel. Omitted when empty
+            or not relevant
+          items:
+            $ref: '#/components/schemas/User'
+          type: array
+        users:
+          description: A list of users that are the main result of the query
+          items:
+            $ref: '#/components/schemas/User'
+          type: array
+      type: object
+    UserAutocompleteInChannel:
+      properties:
+        in_channel:
+          description: A list of user objects in the channel
+          items:
+            $ref: '#/components/schemas/User'
+          type: array
+        out_of_channel:
+          description: A list of user objects not in the channel
+          items:
+            $ref: '#/components/schemas/User'
+          type: array
+      type: object
+    UserAutocompleteInTeam:
+      properties:
+        in_team:
+          description: A list of user objects in the team
+          items:
+            $ref: '#/components/schemas/User'
+          type: array
+      type: object
+    UserNotifyProps:
+      properties:
+        channel:
+          description: Set to "true" to enable channel-wide notifications (@channel, @all, etc.), "false" to disable. Defaults
+            to "true".
+          type: string
+        desktop:
+          description: Set to "all" to receive desktop notifications for all activity, "mention" for mentions and direct messages
+            only, and "none" to disable. Defaults to "all".
+          type: string
+        desktop_sound:
+          description: Set to "true" to enable sound on desktop notifications, "false" to disable. Defaults to "true".
+          type: string
+        email:
+          description: Set to "true" to enable email notifications, "false" to disable. Defaults to "true".
+          type: string
+        first_name:
+          description: Set to "true" to enable mentions for first name. Defaults to "true" if a first name is set, "false"
+            otherwise.
+          type: string
+        mention_keys:
+          description: A comma-separated list of words to count as mentions. Defaults to username and @username.
+          type: string
+        push:
+          description: Set to "all" to receive push notifications for all activity, "mention" for mentions and direct messages
+            only, and "none" to disable. Defaults to "mention".
+          type: string
+      type: object
+    UserTermsOfService:
+      properties:
+        create_at:
+          description: The time in milliseconds that this action was performed.
+          format: int64
+          type: integer
+        terms_of_service_id:
+          description: The unique identifier of the terms of service the action was performed on.
+          type: string
+        user_id:
+          description: The unique identifier of the user who performed this terms of service action.
+          type: string
+      type: object
+    UserThread:
+      description: a thread that user is following
+      properties:
+        id:
+          description: ID of the post that is this thread's root
+          type: string
+        last_reply_at:
+          description: timestamp of the last post to this thread
+          format: int64
+          type: integer
+        last_viewed_at:
+          description: timestamp of the last time the user viewed this thread
+          format: int64
+          type: integer
+        participants:
+          description: list of users participating in this thread. only includes IDs unless 'extended' was set to 'true'
+          items:
+            $ref: '#/components/schemas/Post'
+          type: array
+        post:
+          $ref: '#/components/schemas/Post'
+        reply_count:
+          description: number of replies in this thread
+          type: integer
+      type: object
+    UserThreads:
+      properties:
+        threads:
+          description: Array of threads
+          items:
+            $ref: '#/components/schemas/UserThread'
+          type: array
+        total:
+          description: Total number of threads (used for paging)
+          type: integer
+      type: object
+    UsersStats:
+      properties:
+        total_users_count:
+          type: integer
+      type: object
+    WebhookOnCreationPayload:
+      allOf:
+      - $ref: '#/components/schemas/PlaybookRun'
+      - properties:
+          channel_url:
+            description: Absolute URL to the playbook run's channel.
+            example: https://example.com/ad-1/channels/channel-name
+            type: string
+          details_url:
+            description: Absolute URL to the playbook run's details.
+            example: https://example.com/ad-1/playbooks/runs/playbookRunID
+            type: string
+        type: object
+    WebhookOnStatusUpdatePayload:
+      allOf:
+      - $ref: '#/components/schemas/PlaybookRun'
+      - properties:
+          channel_url:
+            description: Absolute URL to the playbook run's channel.
+            example: https://example.com/ad-1/channels/channel-name
+            type: string
+          details_url:
+            description: Absolute URL to the playbook run's details.
+            example: https://example.com/ad-1/playbooks/runs/playbookRunID
+            type: string
+        type: object
+  securitySchemes:
+    BearerAuth:
+      scheme: bearer
+      type: http
+    bearerAuth:
+      bearerFormat: Token
+      scheme: bearer
+      type: http
+externalDocs:
+  description: Find out more about Mattermost
+  url: https://about.mattermost.com
+info:
+  contact:
+    email: feedback@mattermost.com
+  description: 'There is also a work-in-progress [Postman API reference](https://documenter.getpostman.com/view/4508214/RW8FERUn).
+
+    '
+  termsOfService: https://about.mattermost.com/default-terms/
+  title: Mattermost API Reference
+  version: 4.0.0
+  x-logo:
+    backgroundColor: '#FFFFFF'
+    url: https://mattermost.com/wp-content/uploads/2022/02/logoHorizontal.png
+openapi: 3.0.0
+paths:
+  /api/v4/bots:
+    get:
+      description: 'Get a page of a list of bots.
+
+        ##### Permissions
+
+        Must have `read_bots` permission for bots you are managing, and `read_others_bots` permission for bots others are
+        managing.
+
+        __Minimum server version__: 5.10
+
+        '
+      operationId: GetBots
+      parameters:
+      - description: The page to select.
+        in: query
+        name: page
+        schema:
+          default: 0
+          type: integer
+      - description: The number of users per page. There is a maximum limit of 200 users per page.
+        in: query
+        name: per_page
+        schema:
+          default: 60
+          type: integer
+      - description: If deleted bots should be returned.
+        in: query
+        name: include_deleted
+        schema:
+          type: boolean
+      - description: When true, only orphaned bots will be returned. A bot is consitered orphaned if it's owner has been deactivated.
+        in: query
+        name: only_orphaned
+        schema:
+          type: boolean
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/Bot'
+                type: array
+          description: Bot page retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Get bots
+      tags:
+      - bots
+      x-code-samples:
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$resp = $driver->getBotModel()->getBots([\n    \"page\" => 0,\n    \"per_page\" => 60,\n    \"include_deleted\"\
+          \ => true,\n    \"only_orphaned\" => true,\n]);\n\nif ($resp->getStatusCode() == 200) {\n    $bots = json_decode($resp->getBody());\n\
+          }\n"
+    post:
+      description: 'Create a new bot account on the system. Username is required.
+
+        ##### Permissions
+
+        Must have `create_bot` permission.
+
+        __Minimum server version__: 5.10
+
+        '
+      operationId: CreateBot
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                description:
+                  type: string
+                display_name:
+                  type: string
+                username:
+                  type: string
+              required:
+              - username
+              type: object
+        description: Bot to be created
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Bot'
+          description: Bot creation successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Create a bot
+      tags:
+      - bots
+      x-code-samples:
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$resp = $driver->getBotModel()->createBot([\n    \"username\" => \"userbot\",\n    \"display_name\" => \"AwesomeBot\"\
+          ,\n    \"description\" => \"test bot\"\n]);\n\nif ($resp->getStatusCode() == 200) {\n    $createdBot = json_decode($resp->getBody());\n\
+          }\n"
+  /api/v4/bots/{bot_user_id}:
+    get:
+      description: 'Get a bot specified by its bot id.
+
+        ##### Permissions
+
+        Must have `read_bots` permission for bots you are managing, and `read_others_bots` permission for bots others are
+        managing.
+
+        __Minimum server version__: 5.10
+
+        '
+      operationId: GetBot
+      parameters:
+      - description: Bot user ID
+        in: path
+        name: bot_user_id
+        required: true
+        schema:
+          type: string
+      - description: If deleted bots should be returned.
+        in: query
+        name: include_deleted
+        schema:
+          type: boolean
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Bot'
+          description: Bot successfully retrieved.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Get a bot
+      tags:
+      - bots
+      x-code-samples:
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$botUserID = \"4xp9fdt77pncbef59f4k1qe83o\";\n\n$resp = $driver->getBotModel()->getBot($botUserID, [\n    \"include_deleted\"\
+          \ => true,\n]);\n\nif ($resp->getStatusCode() == 200) {\n    $bot = json_decode($resp->getBody());\n}\n"
+    put:
+      description: "Partially update a bot by providing only the fields you want to update. Omitted fields will not be updated.\
+        \ The fields that can be updated are defined in the request body, all other provided fields will be ignored.\n#####\
+        \ Permissions\nMust have `manage_bots` permission. \n__Minimum server version__: 5.10\n"
+      operationId: PatchBot
+      parameters:
+      - description: Bot user ID
+        in: path
+        name: bot_user_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                description:
+                  type: string
+                display_name:
+                  type: string
+                username:
+                  type: string
+              required:
+              - username
+              type: object
+        description: Bot to be created
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Bot'
+          description: Bot patch successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Patch a bot
+      tags:
+      - bots
+      x-code-samples:
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$botUserID = \"4xp9fdt77pncbef59f4k1qe83o\";\n\n$resp = $driver->getBotModel()->patchBot($botUserID, [\n    \"\
+          username\" => \"userbot2\",\n    \"display_name\" => \"AwesomeBot2\",\n    \"description\" => \"test bot2\"\n]);\n\
+          \nif ($resp->getStatusCode() == 200) {\n    $bot = json_decode($resp->getBody());\n}\n"
+  /api/v4/bots/{bot_user_id}/assign/{user_id}:
+    post:
+      description: "Assign a bot to a specified user.\n##### Permissions\nMust have `manage_bots` permission. \n__Minimum\
+        \ server version__: 5.10\n"
+      operationId: AssignBot
+      parameters:
+      - description: Bot user ID
+        in: path
+        name: bot_user_id
+        required: true
+        schema:
+          type: string
+      - description: The user ID to assign the bot to.
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Bot'
+          description: Bot successfully assigned.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Assign a bot to a user
+      tags:
+      - bots
+      x-code-samples:
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$botUserID = \"4xp9fdt77pncbef59f4k1qe83o\";\n$userID = \"adWv1qPZmHdtxk7Lmqh6RtxWxS\";\n\n$resp = $driver->getBotModel()->assignBotToUser($botUserID,\
+          \ $userID);\n\nif ($resp->getStatusCode() == 200) {\n    $assignedBot = json_decode($resp->getBody());\n}\n"
+  /api/v4/bots/{bot_user_id}/convert_to_user:
+    post:
+      description: 'Convert a bot into a user.
+
+
+        __Minimum server version__: 5.26
+
+
+        ##### Permissions
+
+        Must have `manage_system` permission.
+
+        '
+      operationId: ConvertBotToUser
+      parameters:
+      - description: Bot user ID
+        in: path
+        name: bot_user_id
+        required: true
+        schema:
+          type: string
+      - description: Whether to give the user the system admin role.
+        in: query
+        name: set_system_admin
+        schema:
+          default: false
+          type: boolean
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                email:
+                  type: string
+                first_name:
+                  type: string
+                last_name:
+                  type: string
+                locale:
+                  type: string
+                nickname:
+                  type: string
+                notify_props:
+                  $ref: '#/components/schemas/UserNotifyProps'
+                password:
+                  type: string
+                position:
+                  type: string
+                props:
+                  type: object
+                username:
+                  type: string
+              type: object
+        description: Data to be used in the user creation
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: Bot successfully converted
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Convert a bot into a user
+      tags:
+      - bots
+      - users
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+
+          userId := "BbaYBYDV5IDOZFiJGBSzkw1k5u"
+
+          patch := &model.UserPatch{}
+
+          patch.Email = model.NewString("test@domain.com")
+
+          patch.Username = model.NewString("testUsername")
+
+          patch.Password = model.NewString("password")
+
+
+          user, resp := Client.ConvertBotToUser(userId, userPatch, false)
+
+          '
+  /api/v4/bots/{bot_user_id}/disable:
+    post:
+      description: "Disable a bot.\n##### Permissions\nMust have `manage_bots` permission. \n__Minimum server version__: 5.10\n"
+      operationId: DisableBot
+      parameters:
+      - description: Bot user ID
+        in: path
+        name: bot_user_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Bot'
+          description: Bot successfully disabled.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Disable a bot
+      tags:
+      - bots
+      x-code-samples:
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$botUserID = \"4xp9fdt77pncbef59f4k1qe83o\";\n\n$resp = $driver->getBotModel()->disableBot($botUserID);\n\nif\
+          \ ($resp->getStatusCode() == 200) {\n    $disabledBot = json_decode($resp->getBody());\n}\n"
+  /api/v4/bots/{bot_user_id}/enable:
+    post:
+      description: "Enable a bot.\n##### Permissions\nMust have `manage_bots` permission. \n__Minimum server version__: 5.10\n"
+      operationId: EnableBot
+      parameters:
+      - description: Bot user ID
+        in: path
+        name: bot_user_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Bot'
+          description: Bot successfully enabled.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Enable a bot
+      tags:
+      - bots
+      x-code-samples:
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$botUserID = \"4xp9fdt77pncbef59f4k1qe83o\";\n\n$resp = $driver->getBotModel()->enableBot($botUserID);\n\nif ($resp->getStatusCode()\
+          \ == 200) {\n    $enabledBot = json_decode($resp->getBody());\n}\n"
+  /api/v4/bots/{bot_user_id}/icon:
+    delete:
+      description: 'Delete bot''s LHS icon image based on bot_user_id string parameter.
+
+        ##### Permissions
+
+        Must have `manage_bots` permission.
+
+        __Minimum server version__: 5.14
+
+        '
+      operationId: DeleteBotIconImage
+      parameters:
+      - description: Bot user ID
+        in: path
+        name: bot_user_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: Icon image deletion successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+      summary: Delete bot's LHS icon image
+      tags:
+      - bots
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          botUserID := "4xp9fdt77pncbef59f4k1qe83o"
+
+
+          ok, resp := Client.DeleteBotIconImage(botUserID)
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$botUserID = \"4xp9fdt77pncbef59f4k1qe83o\";\n\n$resp = $driver->getBotModel()->deleteBotIcon($botUserID);\n\n\
+          if ($resp->getStatusCode() == 200) {\n    $ok = json_decode($resp->getBody())->status;\n}\n"
+    get:
+      description: 'Get a bot''s LHS icon image based on bot_user_id string parameter.
+
+        ##### Permissions
+
+        Must be logged in.
+
+        __Minimum server version__: 5.14
+
+        '
+      operationId: GetBotIconImage
+      parameters:
+      - description: Bot user ID
+        in: path
+        name: bot_user_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Bot's LHS icon image
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+      summary: Get bot's LHS icon
+      tags:
+      - bots
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          botUserID := "4xp9fdt77pncbef59f4k1qe83o"
+
+
+          data, resp := Client.GetBotIconImage(botUserID)
+
+          '
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$botUserID = \"4xp9fdt77pncbef59f4k1qe83o\";\n\n$resp = $driver->getBotModel()->getBotIcon($botUserID);\n\nif\
+          \ ($resp->getStatusCode() == 200) {\n    $data = json_decode($resp->getBody());\n}\n"
+    post:
+      description: 'Set a bot''s LHS icon image based on bot_user_id string parameter. Icon image must be SVG format, all
+        other formats are rejected.
+
+        ##### Permissions
+
+        Must have `manage_bots` permission.
+
+        __Minimum server version__: 5.14
+
+        '
+      operationId: SetBotIconImage
+      parameters:
+      - description: Bot user ID
+        in: path
+        name: bot_user_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              properties:
+                image:
+                  description: SVG icon image to be uploaded
+                  format: binary
+                  type: string
+              required:
+              - image
+              type: object
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: SVG icon image set successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '413':
+          $ref: '#/components/responses/TooLarge'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+      summary: Set bot's LHS icon image
+      tags:
+      - bots
+      x-code-samples:
+      - lang: Go
+        source: "import (\n  \"io/ioutil\"\n  \"log\"\n\n  \"github.com/mattermost/mattermost-server/v5/model\"\n)\n\nClient\
+          \ := model.NewAPIv4Client(\"https://your-mattermost-url.com\")\nClient.Login(\"email@domain.com\", \"Password1\"\
+          )\n\ndata, err := ioutil.ReadFile(\"icon_image.svg\")\nif err != nil {\n  log.Fatal(err)\n}\n\nbotUserID := \"4xp9fdt77pncbef59f4k1qe83o\"\
+          \n\nok, resp := Client.SetBotIconImage(botUserID, data)\n"
+      - lang: PHP
+        source: "require 'vendor/autoload.php';\n\nuse \\Gnello\\Mattermost\\Driver;\n\n$container = new \\Pimple\\Container([\n\
+          \    \"driver\" => [\n        \"url\" => \"https://your-mattermost-url.com\",\n        \"login_id\" => \"email@domain.com\"\
+          ,\n        \"password\" => \"Password1\",\n    ]\n]);\n\n$driver = new Driver($container);\n$driver->authenticate();\n\
+          \n$botUserID = \"4xp9fdt77pncbef59f4k1qe83o\";\n$resource = fopen(\"icon_image.svg\", 'rb');\n\nif ($resource ===\
+          \ false) {\n    throw new \\Exeption(\"Failure.\");\n}\n\n$data = new \\GuzzleHttp\\Psr7\\Stream($resource);\n\n\
+          $resp = $driver->getBotModel()->setBotIcon($botUserID, [\n    \"image\" => $data,\n]);\n\nfclose($resource);\n\n\
+          if ($resp->getStatusCode() == 200) {\n    $ok = json_decode($resp->getBody())->status;\n}\n"
+  /api/v4/channels:
+    get:
+      description: '##### Permissions
+
+        `manage_system`
+
+        '
+      operationId: GetAllChannels
+      parameters:
+      - description: A group id to exclude channels that are associated with that group via GroupChannel records. This can
+          also be left blank with `not_associated_to_group=`.
+        in: query
+        name: not_associated_to_group
+        schema:
+          type: string
+      - description: The page to select.
+        in: query
+        name: page
+        schema:
+          default: 0
+          type: integer
+      - description: The number of channels per page.
+        in: query
+        name: per_page
+        schema:
+          default: 0
+          type: integer
+      - description: Whether to exclude default channels (ex Town Square, Off-Topic) from the results.
+        in: query
+        name: exclude_default_channels
+        schema:
+          default: false
+          type: boolean
+      - description: Include channels that have been archived. This correlates to the `DeleteAt` flag being set in the database.
+        in: query
+        name: include_deleted
+        schema:
+          default: false
+          type: boolean
+      - description: 'Appends a total count of returned channels inside the response object - ex: `{ "channels": [], "total_count"
+          : 0 }`.      '
+        in: query
+        name: include_total_count
+        schema:
+          default: false
+          type: boolean
+      - description: 'If set to true, channels which are part of a data retention policy will be excluded. The `sysconsole_read_compliance`
+          permission is required to use this parameter.
+
+          __Minimum server version__: 5.35'
+        in: query
+        name: exclude_policy_constrained
+        schema:
+          default: false
+          type: boolean
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChannelListWithTeamData'
+          description: Channel list retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Get a list of all channels
+      tags:
+      - channels
+    post:
+      description: 'Create a new channel.
+
+        ##### Permissions
+
+        If creating a public channel, `create_public_channel` permission is required. If creating a private channel, `create_private_channel`
+        permission is required.
+
+        '
+      operationId: CreateChannel
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                display_name:
+                  description: The non-unique UI name for the channel
+                  type: string
+                header:
+                  description: Markdown-formatted text to display in the header of the channel
+                  type: string
+                name:
+                  description: The unique handle for the channel, will be present in the channel URL
+                  type: string
+                purpose:
+                  description: A short description of the purpose of the channel
+                  type: string
+                team_id:
+                  description: The team ID of the team to create the channel on
+                  type: string
+                type:
+                  description: '''O'' for a public channel, ''P'' for a private channel'
+                  type: string
+              required:
+              - name
+              - display_name
+              - type
+              - team_id
+              type: object
+        description: Channel object to be created
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Channel'
+          description: Channel creation successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Create a channel
+      tags:
+      - channels
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          channel := &model.Channel{DisplayName: <YOUR CHANNEL DISPLAYNAME>, Name: <YOUR CHANNEL NAME>, Type: <CHANNEL TYPE
+          OPEN/PRIVATE>, TeamId: <YOUR TEAM ID>}
+
+
+          // CreateChannel
+
+          rchannel, resp := Client.CreateChannel(channel)
+
+          '
+  /api/v4/channels/direct:
+    post:
+      description: 'Create a new direct message channel between two users.
+
+        ##### Permissions
+
+        Must be one of the two users and have `create_direct_channel` permission. Having the `manage_system` permission voids
+        the previous requirements.
+
+        '
+      operationId: CreateDirectChannel
+      requestBody:
+        content:
+          application/json:
+            schema:
+              items:
+                type: string
+              maxItems: 2
+              minItems: 2
+              type: array
+        description: The two user ids to be in the direct message
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Channel'
+          description: Direct channel creation successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Create a direct message channel
+      tags:
+      - channels
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          // CreateDirectChannel
+
+          dm, resp := Client.CreateDirectChannel(<ID OF User1>, <ID OF User2>)
+
+          '
+  /api/v4/channels/group:
+    post:
+      description: 'Create a new group message channel to group of users. If the logged in user''s id is not included in the
+        list, it will be appended to the end.
+
+        ##### Permissions
+
+        Must have `create_group_channel` permission.
+
+        '
+      operationId: CreateGroupChannel
+      requestBody:
+        content:
+          application/json:
+            schema:
+              items:
+                type: string
+              type: array
+        description: User ids to be in the group message channel
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Channel'
+          description: Group channel creation successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Create a group message channel
+      tags:
+      - channels
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          userIds := []string{<ID OF User1>, <ID OF User2>, <ID OF User3> ...}
+
+
+          // CreateGroupChannel
+
+          rgc, resp := Client.CreateGroupChannel(userIds)
+
+          '
+  /api/v4/channels/group/search:
+    post:
+      description: 'Get a list of group channels for a user which members'' usernames match the search term.
+
+
+        __Minimum server version__: 5.14
+
+        '
+      operationId: SearchGroupChannels
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                term:
+                  description: The search term to match against the members' usernames of the group channels
+                  type: string
+              required:
+              - term
+              type: object
+        description: Search criteria
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/Channel'
+                type: array
+          description: Channels search successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+      summary: Search Group Channels
+      tags:
+      - channels
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          search := &model.ChannelSearch{Term: <MEMBER USERNAME>}
+
+
+          // SearchGroupChannels
+
+          channels, resp := Client.SearchGroupChannels(search)
+
+          '
+  /api/v4/channels/members/{user_id}/view:
+    post:
+      description: 'Perform all the actions involved in viewing a channel. This includes marking channels as read, clearing
+        push notifications, and updating the active channel.
+
+        ##### Permissions
+
+        Must be logged in as user or have `edit_other_users` permission.
+
+
+        __Response only includes `last_viewed_at_times` in Mattermost server 4.3 and newer.__
+
+        '
+      operationId: ViewChannel
+      parameters:
+      - description: User ID to perform the view action for
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                channel_id:
+                  description: The channel ID that is being viewed. Use a blank string to indicate that all channels have
+                    lost focus.
+                  type: string
+                prev_channel_id:
+                  description: The channel ID of the previous channel, used when switching channels. Providing this ID will
+                    cause push notifications to clear on the channel being switched to.
+                  type: string
+              required:
+              - channel_id
+              type: object
+        description: Paremeters affecting how and which channels to view
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  last_viewed_at_times:
+                    description: A JSON object mapping channel IDs to the channel view times
+                    type: object
+                  status:
+                    description: Value should be "OK" if successful
+                    type: string
+                type: object
+          description: Channel view successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: View channel
+      tags:
+      - channels
+      x-code-samples:
+      - lang: Go
+        source: "import \"github.com/mattermost/mattermost-server/v5/model\"\nClient := model.NewAPIv4Client(\"https://your-mattermost-url.com\"\
+          )\nClient.Login(\"email@domain.com\", \"Password1\")\n\nview := &model.ChannelView{\n  ChannelId: <CHANNELID>,\n\
+          }\n// ViewChannel\npass, resp := Client.ViewChannel(<USERID>, view)\n"
+  /api/v4/channels/search:
+    post:
+      description: 'Returns all private and open type channels where ''term'' matches on the name, display name, or purpose
+        of
+
+        the channel.
+
+
+        Configured ''default'' channels (ex Town Square and Off-Topic) can be excluded from the results
+
+        with the `exclude_default_channels` boolean parameter.
+
+
+        Channels that are associated (via GroupChannel records) to a given group can be excluded from the results
+
+        with the `not_associated_to_group` parameter and a group id string.
+
+        '
+      operationId: SearchAllChannels
+      parameters:
+      - description: 'Is the request from system_console. If this is set to true, it filters channels by the logged in user.
+
+          '
+        in: query
+        name: system_console
+        required: false
+        schema:
+          default: true
+          type: boolean
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                deleted:
+                  description: 'Filters results to only return deleted / archived channels
+
+
+                    __Minimum server version__: 5.26
+
+                    '
+                  type: boolean
+                exclude_default_channels:
+                  description: Exclude default channels from the results by setting this parameter to true.
+                  type: boolean
+                exclude_group_constrained:
+                  description: 'Filters results to exclude channels constrained to a group
+
+
+                    __Minimum server version__: 5.26
+
+                    '
+                  type: boolean
+                exclude_policy_constrained:
+                  default: false
+                  description: 'If set to true, only channels which do not have a granular retention policy assigned to them
+                    will be returned. The `sysconsole_read_compliance_data_retention` permission is required to use this parameter.
+
+                    __Minimum server version__: 5.35
+
+                    '
+                  type: boolean
+                group_constrained:
+                  description: 'Filters results to only return channels constrained to a group
+
+
+                    __Minimum server version__: 5.26
+
+                    '
+                  type: boolean
+                include_search_by_id:
+                  default: false
+                  description: 'If set to true, returns channels where given search ''term'' matches channel ID.
+
+                    __Minimum server version__: 5.35
+
+                    '
+                  type: boolean
+                not_associated_to_group:
+                  description: A group id to exclude channels that are associated to that group via GroupChannel records.
+                  type: string
+                page:
+                  description: The page number to return, if paginated. If this parameter is not present with the `per_page`
+                    parameter then the results will be returned un-paged.
+                  type: string
+                per_page:
+                  description: The number of entries to return per page, if paginated. If this parameter is not present with
+                    the `page` parameter then the results will be returned un-paged.
+                  type: string
+                private:
+                  description: 'Filters results to only return Private channels, can be used in conjunction with `public`
+                    to return both `private` and `public` channels
+
+
+                    __Minimum server version__: 5.26
+
+                    '
+                  type: boolean
+                public:
+                  description: 'Filters results to only return Public / Open channels, can be used in conjunction with `private`
+                    to return both `public` and `private` channels
+
+
+                    __Minimum server version__: 5.26
+
+                    '
+                  type: boolean
+                team_ids:
+                  description: 'Filters results to channels belonging to the given team ids
+
+
+                    __Minimum server version__: 5.26
+
+                    '
+                  items:
+                    type: string
+                  type: array
+                term:
+                  description: The string to search in the channel name, display name, and purpose.
+                  type: string
+              required:
+              - term
+              type: object
+        description: The search terms and logic to use in the search.
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  channels:
+                    description: The channels that matched the query.
+                    items:
+                      $ref: '#/components/schemas/Channel'
+                    type: array
+                  total_count:
+                    description: The total number of results, regardless of page and per_page requested.
+                    type: number
+                type: object
+          description: Paginated channel response. (Note that the non-paginated response—returned if the request body does
+            not contain both `page` and `per_page` fields—is a simple array of channels.)
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+      summary: Search all private and open type channels across all teams
+      tags:
+      - channels
+  /api/v4/channels/{channel_id}:
+    delete:
+      description: 'Archives a channel. This will set the `deleteAt` to the current timestamp in the database. Soft deleted
+        channels may not be accessible in the user interface. They can be viewed and unarchived in the **System Console >
+        User Management > Channels** based on your license. Direct and group message channels cannot be deleted.
+
+
+        As of server version 5.28, optionally use the `permanent=true` query parameter to permanently delete the channel for
+        compliance reasons. To use this feature `ServiceSettings.EnableAPIChannelDeletion` must be set to `true` in the server''s
+        configuration.  If you permanently delete a channel this action is not recoverable outside of a database backup.
+
+
+        ##### Permissions
+
+        `delete_public_channel` permission if the channel is public,
+
+        `delete_private_channel` permission if the channel is private,
+
+        or have `manage_system` permission.
+
+        '
+      operationId: DeleteChannel
+      parameters:
+      - description: Channel GUID
+        in: path
+        name: channel_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: Channel deletion successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Delete a channel
+      tags:
+      - channels
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          // DeleteChannel
+
+          pass, resp := Client.DeleteChannel(<CHANNELID>)
+
+          '
+    get:
+      description: 'Get channel from the provided channel id string.
+
+        ##### Permissions
+
+        `read_channel` permission for the channel.
+
+        '
+      operationId: GetChannel
+      parameters:
+      - description: Channel GUID
+        in: path
+        name: channel_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Channel'
+          description: Channel retrieval successful
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Get a channel
+      tags:
+      - channels
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          // GetChannel
+
+          channel, resp := Client.GetChannel(<CHANNELID>, "")
+
+          '
+    put:
+      description: 'Update a channel. The fields that can be updated are listed as parameters. Omitted fields will be treated
+        as blanks.
+
+        ##### Permissions
+
+        If updating a public channel, `manage_public_channel_members` permission is required. If updating a private channel,
+        `manage_private_channel_members` permission is required.
+
+        '
+      operationId: UpdateChannel
+      parameters:
+      - description: Channel GUID
+        in: path
+        name: channel_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                display_name:
+                  description: The non-unique UI name for the channel
+                  type: string
+                header:
+                  description: Markdown-formatted text to display in the header of the channel
+                  type: string
+                id:
+                  description: The channel's id, not updatable
+                  type: string
+                name:
+                  description: The unique handle for the channel, will be present in the channel URL
+                  type: string
+                purpose:
+                  description: A short description of the purpose of the channel
+                  type: string
+              required:
+              - id
+              type: object
+        description: Channel object to be updated
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Channel'
+          description: Channel update successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Update a channel
+      tags:
+      - channels
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          channel := &model.Channel{DisplayName: <YOUR CHANNEL NEW DISPLAYNAME>, ChannelId: <CHANNELID>, TeamId: <YOUR TEAM
+          ID>}
+
+
+          // UpdateChannel
+
+          updatedChannel, resp := Client.UpdateChannel(channel)
+
+          '
+  /api/v4/channels/{channel_id}/groups:
+    get:
+      description: 'Retrieve the list of groups associated with a given channel.
+
+
+        ##### Permissions
+
+        Must have `manage_system` permission.
+
+
+        __Minimum server version__: 5.11
+
+        '
+      operationId: GetGroupsByChannel
+      parameters:
+      - description: Channel GUID
+        in: path
+        name: channel_id
+        required: true
+        schema:
+          type: string
+      - description: The page to select.
+        in: query
+        name: page
+        schema:
+          default: 0
+          type: integer
+      - description: The number of groups per page.
+        in: query
+        name: per_page
+        schema:
+          default: 60
+          type: integer
+      - description: Boolean which filters the group entries with the `allow_reference` attribute set.
+        in: query
+        name: filter_allow_reference
+        schema:
+          default: false
+          type: boolean
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/Group'
+                type: array
+          description: Group list retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+      summary: Get channel groups
+      tags:
+      - groups
+  /api/v4/channels/{channel_id}/member_counts_by_group:
+    get:
+      description: 'Returns a set of ChannelMemberCountByGroup objects which contain a `group_id`, `channel_member_count`
+        and a `channel_member_timezones_count`.
+
+        ##### Permissions
+
+        Must have `read_channel` permission for the given channel.
+
+        __Minimum server version__: 5.24
+
+        '
+      operationId: GetChannelMemberCountsByGroup
+      parameters:
+      - description: Channel GUID
+        in: path
+        name: channel_id
+        required: true
+        schema:
+          type: string
+      - description: Defines if member timezone counts should be returned or not
+        in: query
+        name: include_timezones
+        schema:
+          default: false
+          type: boolean
+      responses:
+        '200':
+          description: Successfully returns member counts by group for the given channel.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Channel members counts for each group that has atleast one member in the channel
+      tags:
+      - channels
+      x-code-samples:
+      - lang: curl
+        source: "curl -X GET \\\n  'http://your-mattermost-url.com/api/v4/channels/3wyp678obid8pggjmhmhwpah1r/member_counts_by_group?include_timezones=true'\
+          \ \\\n  -H 'Authorization: Bearer kno8tcdotpbx3dj1gzcbx9jrqy' \\\n  -H 'Content-Type: application/json' \\\n  -H\
+          \ 'X-Requested-With: XMLHttpRequest'\n"
+  /api/v4/channels/{channel_id}/members:
+    get:
+      description: 'Get a page of members for a channel.
+
+        ##### Permissions
+
+        `read_channel` permission for the channel.
+
+        '
+      operationId: GetChannelMembers
+      parameters:
+      - description: Channel GUID
+        in: path
+        name: channel_id
+        required: true
+        schema:
+          type: string
+      - description: The page to select.
+        in: query
+        name: page
+        schema:
+          default: 0
+          type: integer
+      - description: The number of members per page. There is a maximum limit of 200 members.
+        in: query
+        name: per_page
+        schema:
+          default: 60
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/ChannelMember'
+                type: array
+          description: Channel members retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Get channel members
+      tags:
+      - channels
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          // GetChannelMembers
+
+          members, resp := Client.GetChannelMembers(th.BasicChannel.Id, 0, 60, "")
+
+          '
+    post:
+      description: Add a user to a channel by creating a channel member object.
+      operationId: AddChannelMember
+      parameters:
+      - description: The channel ID
+        in: path
+        name: channel_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                post_root_id:
+                  description: The ID of root post where link to add channel member originates
+                  type: string
+                user_id:
+                  description: The ID of user to add into the channel
+                  type: string
+              required:
+              - user_id
+              type: object
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChannelMember'
+          description: Channel member creation successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Add user to channel
+      tags:
+      - channels
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          // AddChannelMember
+
+          cm, resp := Client.AddChannelMember(<CHANNEL ID>, <ID OF USER TO ADD>)
+
+
+          // AddChannelMemberWithRootId
+
+          cm, resp := Client.AddChannelMemberWithRootId(<CHANNEL ID>, <ID OF USER TO ADD>, <POST ROOT ID>)
+
+          '
+  /api/v4/channels/{channel_id}/members/ids:
+    post:
+      description: 'Get a list of channel members based on the provided user ids.
+
+        ##### Permissions
+
+        Must have the `read_channel` permission.
+
+        '
+      operationId: GetChannelMembersByIds
+      parameters:
+      - description: Channel GUID
+        in: path
+        name: channel_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              items:
+                type: string
+              type: array
+        description: List of user ids
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/ChannelMember'
+                type: array
+          description: Channel member list retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Get channel members by ids
+      tags:
+      - channels
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          usersIds := []string{<Id of User1>, <Id of User2>, ...}
+
+
+          // GetChannelMembersByIds
+
+          cm, resp := Client.GetChannelMembersByIds(<CHANNELID>, usersIds)
+
+          '
+  /api/v4/channels/{channel_id}/members/{user_id}:
+    delete:
+      description: 'Delete a channel member, effectively removing them from a channel.
+
+
+        In server version 5.3 and later, channel members can only be deleted from public or private channels.
+
+        ##### Permissions
+
+        `manage_public_channel_members` permission if the channel is public.
+
+        `manage_private_channel_members` permission if the channel is private.
+
+        '
+      operationId: RemoveUserFromChannel
+      parameters:
+      - description: Channel GUID
+        in: path
+        name: channel_id
+        required: true
+        schema:
+          type: string
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: Channel member deletion successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Remove user from channel
+      tags:
+      - channels
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          // RemoveUserFromChannel
+
+          pass, resp := Client.RemoveUserFromChannel(<CHANNELID>, <USERID>)
+
+          '
+    get:
+      description: 'Get a channel member.
+
+        ##### Permissions
+
+        `read_channel` permission for the channel.
+
+        '
+      operationId: GetChannelMember
+      parameters:
+      - description: Channel GUID
+        in: path
+        name: channel_id
+        required: true
+        schema:
+          type: string
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChannelMember'
+          description: Channel member retrieval successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      summary: Get channel member
+      tags:
+      - channels
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          // GetChannelMember
+
+          member, resp := Client.GetChannelMember(<CHANNELID>, <USERID>, "")
+
+          '
+  /api/v4/channels/{channel_id}/members/{user_id}/notify_props:
+    put:
+      description: 'Update a user''s notification properties for a channel. Only the provided fields are updated.
+
+        ##### Permissions
+
+        Must be logged in as the user or have `edit_other_users` permission.
+
+        '
+      operationId: UpdateChannelNotifyProps
+      parameters:
+      - description: Channel GUID
+        in: path
+        name: channel_id
+        required: true
+        schema:
+          type: string
+      - description: User GUID
+        in: path
+        name: user_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChannelNotifyProps'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusOK'
+          description: Channel notification properties update successful
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Update channel notifications
+      tags:
+      - channels
+      x-code-samples:
+      - lang: Go
+        source: 'import "github.com/mattermost/mattermost-server/v5/model"
+
+          Client := model.NewAPIv4Client("https://your-mattermost-url.com")
+
+          Client.Login("email@domain.com", "Password1")
+
+
+          props := map[string]string{}
+
+          props[model.DESKTOP_NOTIFY_PROP] = model.CHANNEL_NOTIFY_MENTION
+
+          props[model.MARK_UNREAD_NOTIFY_PROP] = model.CHANNEL_MARK_UNREAD_MENTION
+
+
+          // UpdateChannelNotifyProps
+
+          pass, resp := Client.UpdateChannelNotifyProps(<CHANNELID>, <USERID>, props)
+
+          '
+security:
+- bearerAuth: []
+servers:
+- url: http://your-mattermost-url.com
+- url: https://your-mattermost-url.com
+tags:
+- description: 'The Mattermost Web Services API is used by Mattermost clients and third party applications to interact with
+    the server. [JavaScript and Golang drivers for](/#tag/drivers) connecting to the APIs are also available.
+
+
+    ### Support
+
+
+    Mattermost core committers work with the community to keep the API documentation up-to-date.
+
+
+    If you have questions on API routes not listed in this reference, please [join the Mattermost community server](https://community.mattermost.com)
+    to ask questions in the Developers channel, [or post questions to our Developer Discussion forum](https://forum.mattermost.org/c/dev).
+
+
+    [Bug reports](https://github.com/mattermost/mattermost-api-reference/issues) in the documentation or the API are also
+    welcome, as are pull requests to fix the issues.
+
+
+    ### Contributing
+
+
+    When you have answers to API questions not addressed in our documentation we ask you to consider making a pull request
+    to improve our reference. [Small changes](https://github.com/mattermost/mattermost-api-reference/commit/d574c0c1e95dc2228dc96663afd562f1305e3ece)
+    and [larger changes](https://github.com/mattermost/mattermost-api-reference/commit/1ae3314f0935eebba8c885d8969dcad72f801501)
+    are all welcome.
+
+
+    We also have [Help Wanted tickets](https://github.com/mattermost/mattermost-api-reference/issues) available for community
+    members who would like to help others more easily use the APIs. We acknowledge everyone''s contribution in the [release
+    notes of our next version](https://docs.mattermost.com/administration/changelog.html#contributors).
+
+
+    The source code for this API reference is hosted at https://github.com/mattermost/mattermost-api-reference.
+
+    '
+  name: introduction
+- description: 'All API access is through HTTP(S) requests at `your-mattermost-url.com/api/v4`. All request and response bodies
+    are `application/json`.
+
+
+    When using endpoints that require a user id, the string `me` can be used in place of the user id to indicate the action
+    is to be taken for the logged in user.
+
+    '
+  name: schema
+- description: 'The easiest way to interact with the Mattermost Web Service API is through a language specific driver.
+
+
+    #### Official Drivers
+
+    * [Mattermost JavaScript Driver](https://github.com/mattermost/mattermost-redux/blob/master/src/client/client4.ts)
+
+    * [Mattermost Golang Driver](https://github.com/mattermost/mattermost/blob/master/server/public/model/client4.go)
+
+
+    #### Community-built Drivers
+
+    * [PHP Driver](https://github.com/gnello/php-mattermost-driver) - built by [@gnello](https://github.com/gnello) and [@prixone](https://github.com/prixone)
+
+    * [Python Driver](https://github.com/Vaelor/python-mattermost-driver) - built by [@Vaelor](https://github.com/Vaelor)
+
+
+    For other community-built drivers and API wrappers, see [our app directory](https://mattermost.com/marketplace/).
+
+    '
+  name: drivers
+- description: 'There are multiple ways to authenticate against the Mattermost API.
+
+
+    All examples assume there is a Mattermost instance running at http://localhost:8065.
+
+
+    #### Session Token
+
+
+    Make an HTTP POST to `your-mattermost-url.com/api/v4/users/login` with a JSON body indicating the user’s `login_id`, `password`
+    and optionally the MFA `token`. The `login_id` can be an email, username or an AD/LDAP ID depending on the system''s configuration.
+
+
+    ```
+
+    curl -i -d ''{"login_id":"someone@nowhere.com","password":"thisisabadpassword"}'' http://localhost:8065/api/v4/users/login
+
+    ```
+
+
+    NOTE: If you''re running cURL on windows, you will have to change the single quotes to double quotes, and escape the inner
+    double quotes with backslash, like below:
+
+
+    ```
+
+    curl -i -d "{\"login_id\":\"someone@nowhere.com\",\"password\":\"thisisabadpassword\"}" http://localhost:8065/api/v4/users/login
+
+    ```
+
+
+    If successful, the response will contain a `Token` header and a user object in the body.
+
+
+    ```
+
+    HTTP/1.1 200 OK
+
+    Set-Cookie: MMSID=hyr5dmb1mbb49c44qmx4whniso; Path=/; Max-Age=2592000; HttpOnly
+
+    Token: hyr5dmb1mbb49c44qmx4whniso
+
+    X-Ratelimit-Limit: 10
+
+    X-Ratelimit-Remaining: 9
+
+    X-Ratelimit-Reset: 1
+
+    X-Request-Id: smda55ckcfy89b6tia58shk5fh
+
+    X-Version-Id: developer
+
+    Date: Fri, 11 Sep 2015 13:21:14 GMT
+
+    Content-Length: 657
+
+    Content-Type: application/json; charset=utf-8
+
+
+    {{user object as json}}
+
+    ```
+
+
+    Include the `Token` as part of the `Authorization` header on your future API requests with the `Bearer` method.
+
+
+    ```
+
+    curl -i -H ''Authorization: Bearer hyr5dmb1mbb49c44qmx4whniso'' http://localhost:8065/api/v4/users/me
+
+    ```
+
+
+    You should now be able to access the API as the user you logged in as.
+
+
+    #### Personal Access Tokens
+
+
+    Using [personal access tokens](https://docs.mattermost.com/developer/personal-access-tokens.html) is very similar to using
+    a session token. The only real difference is that session tokens will expire, while personal access tokens will live until
+    they are manually revoked by the user or an admin.
+
+
+    Just like session tokens, include the personal access token as part of the `Authorization` header in your requests using
+    the `Bearer` method. Assuming our personal access token is `9xuqwrwgstrb3mzrxb83nb357a`, we could use it as shown below.
+
+
+    ```
+
+    curl -i -H ''Authorization: Bearer 9xuqwrwgstrb3mzrxb83nb357a'' http://localhost:8065/api/v4/users/me
+
+    ```
+
+
+    #### OAuth 2.0
+
+
+    Mattermost has the ability to act as an [OAuth 2.0](https://tools.ietf.org/html/rfc6749) service provider.
+
+
+    The official documentation for [using your Mattermost server as an OAuth 2.0 service provider can be found here.](https://docs.mattermost.com/developer/oauth-2-0-applications.html)
+
+
+    For an example on how to register an OAuth 2.0 app with your Mattermost instance, please see the [Mattermost-Zapier integration
+    documentation](https://docs.mattermost.com/integrations/zapier.html#register-zapier-as-an-oauth-2-0-application).
+
+    '
+  name: authentication
+- description: "All errors will return an appropriate HTTP response code along with the following JSON body:\n```\n{\n   \
+    \ \"id\": \"the.error.id\",\n    \"message\": \"Something went wrong\", // the reason for the error\n    \"request_id\"\
+    : \"\", // the ID of the request\n    \"status_code\": 0, // the HTTP status code\n    \"is_oauth\": false // whether\
+    \ the error is OAuth specific\n}\n```\n"
+  name: errors
+- description: 'Whenever you make an HTTP request to the Mattermost API you might notice the following headers included in
+    the response:
+
+    ```
+
+    X-Ratelimit-Limit: 10
+
+    X-Ratelimit-Remaining: 9
+
+    X-Ratelimit-Reset: 1441983590
+
+    ```
+
+
+    These headers are telling you your current rate limit status.
+
+
+    | Header | Description |
+
+    | ------ | ----------- |
+
+    | X-Ratelimit-Limit | The maximum number of requests you can make per second. |
+
+    | X-Ratelimit-Remaining | The number of requests remaining in the current window. |
+
+    | X-Ratelimit-Reset | The remaining UTC epoch seconds before the rate limit resets. |
+
+
+    If you exceed your rate limit for a window you will receive the following error in the body of the response:
+
+
+    ```
+
+    HTTP/1.1 429 Too Many Requests
+
+    Date: Tue, 10 Sep 2015 11:20:28 GMT
+
+    X-RateLimit-Limit: 10
+
+    X-RateLimit-Remaining: 0
+
+    X-RateLimit-Reset: 1
+
+
+    limit exceeded
+
+    ```
+
+    '
+  name: rate limiting
+- description: "In addition to the HTTP RESTful web service, Mattermost also offers a WebSocket event delivery system and\
+    \ some API functionality.\n\nTo connect to the WebSocket follow the standard opening handshake as [defined by the RFC\
+    \ specification](https://tools.ietf.org/html/rfc6455#section-1.3) to the `/api/v4/websocket` endpoint of Mattermost.\n\
+    \n#### Authentication\n\nThe Mattermost WebSocket can be authenticated using [the standard API authentication methods](/#tag/authentication)\
+    \ (by a cookie or with an explicit Authorization header) or through an authentication challenge. If you're authenticating\
+    \ from a browser and have logged in with the Mattermost API, your authentication cookie should already be set. This is\
+    \ how the Mattermost webapp authenticates with the WebSocket.\n\nTo authenticate with an authentication challenge, first\
+    \ connect the WebSocket and then send the following JSON over the connection:\n\n```\n{\n  \"seq\": 1,\n  \"action\":\
+    \ \"authentication_challenge\",\n  \"data\": {\n    \"token\": \"mattermosttokengoeshere\"\n  }\n}\n```\n\nIf successful,\
+    \ you will receive a standard OK response over the WebSocket connection:\n\n```\n{\n  \"status\": \"OK\",\n  \"seq_reply\"\
+    : 1\n}\n```\n\nOnce successfully authenticated, the server will pass a `hello` WebSocket event containing server version\
+    \ over the connection.\n\n#### Events\n\nWebSocket events are primarily used to alert the client to changes in Mattermost,\
+    \ such as delivering new posts or alerting the client that another user is typing in a channel.\n\nEvents on the WebSocket\
+    \ will have the form:\n\n```\n{\n  \"event\": \"hello\",\n  \"data\": {\n    \"server_version\": \"3.6.0.1451.1c38da627ebb4e3635677db6939e9195\"\
+    \n  },\n  \"broadcast\":{\n    \"omit_users\": null,\n    \"user_id\": \"ay5sq51sebfh58ktrce5ijtcwy\",\n    \"channel_id\"\
+    : \"\",\n    \"team_id\": \"\"\n  },\n  \"seq\": 0\n}\n```\n\nThe `event` field indicates the event type, `data` contains\
+    \ any data relevant to the event and `broadcast` contains information about who the event was sent to. For example, the\
+    \ above example has `user_id` set to \"ay5sq51sebfh58ktrce5ijtcwy\" meaning that only the user with that ID received this\
+    \ event broadcast. The `omit_users` field can contain an array of user IDs that were specifically omitted from receiving\
+    \ the event.\n\nThe list of Mattermost WebSocket events are:\n- added_to_team\n- authentication_challenge\n- channel_converted\n\
+    - channel_created\n- channel_deleted\n- channel_member_updated\n- channel_updated\n- channel_viewed\n- config_changed\n\
+    - delete_team\n- direct_added\n- emoji_added\n- ephemeral_message\n- group_added\n- hello\n- leave_team\n- license_changed\n\
+    - memberrole_updated\n- new_user\n- plugin_disabled\n- plugin_enabled\n- plugin_statuses_changed\n- post_deleted\n- post_edited\n\
+    - post_unread\n- posted\n- preference_changed\n- preferences_changed\n- preferences_deleted\n- reaction_added\n- reaction_removed\n\
+    - response\n- role_updated\n- status_change\n- typing\n- update_team\n- user_added\n- user_removed\n- user_role_updated\n\
+    - user_updated\n- dialog_opened\n- thread_updated\n- thread_follow_changed\n- thread_read_changed\n\n#### WebSocket API\n\
+    \nMattermost has some basic support for WebSocket APIs. A connected WebSocket can make requests by sending the following\
+    \ over the connection:\n\n```\n{\n  \"action\": \"user_typing\",\n  \"seq\": 2,\n  \"data\": {\n    \"channel_id\": \"\
+    nhze199c4j87ped4wannrjdt9c\",\n    \"parent_id\": \"\"\n  }\n}\n```\n\nThis is an example of making a `user_typing` request,\
+    \ with the purpose of alerting the server that the connected client has begun typing in a channel or thread. The `action`\
+    \ field indicates what is being requested, and performs a similar duty as the route in a HTTP API. The `data` field is\
+    \ used to add any additional data along with the request. The server supports binary websocket messages as well in case\
+    \ the client has such a requirement.\n\nThe `seq` or sequence number is set by the client and should be incremented with\
+    \ every use. It is used to distinguish responses to requests that come down the WebSocket. For example, a standard response\
+    \ to the above request would be:\n\n```\n{\n  \"status\": \"OK\",\n  \"seq_reply\": 2\n}\n```\n\nNotice `seq_reply` is\
+    \ 2, matching the `seq` of the original request. Using this a client can distinguish which request the response is meant\
+    \ for.\n\nIf there was any information to respond with, it would be encapsulated in a `data` field.\n\nIn the case of\
+    \ an error, the response would be:\n\n```\n{\n  \"status\": \"FAIL\",\n  \"seq_reply\": 2,\n  \"error\": {\n    \"id\"\
+    : \"some.error.id.here\",\n    \"message\": \"Some error message here\"\n  }\n}\n```\n\nThe list of WebSocket API actions\
+    \ is:\n- user_typing\n- get_statuses\n- get_statuses_by_ids\n\nTo see how these actions work, please refer to either the\
+    \ [Golang WebSocket driver](https://github.com/mattermost/mattermost-server/blob/master/model/websocket_client.go) or\
+    \ our [JavaScript WebSocket driver](https://github.com/mattermost/mattermost-redux/blob/master/src/client/websocket_client.ts).\n"
+  name: WebSocket
+- description: "Since Mattermost 4.6 released on January 16, 2018, API v3 has no longer been supported and it will be removed\
+    \ in Mattermost Server v5.0 on June 16, 2018. Follow these simple steps to migrate your integrations and apps to API v4.\
+    \ Otherwise your integrations may break once you upgrade to Mattermost 5.0\n\n1. Set your server's log level to `DEBUG`\
+    \ in **System Console > General > Logging > File Log Level** to print detailed logs for API requests.\n2. In **System\
+    \ Console > Logs**, search for requests hitting `/api/v3/` endpoints. Any requests hitting these endpoints are from integrations\
+    \ that should be migrated to API v4.\n  - For in-house or self-built integrations, update them to use v4 with the help\
+    \ of [this API reference](https://api.mattermost.com). Most v3 endpoints have direct counterparts in v4 and should be\
+    \ migrated easily.\n  - For third-party integrations, visit their homepage (on GitHub, GitLab, etc.). Check if they already\
+    \ have a version that uses the Mattermost v4 API. If they do not, consider opening an issue asking them if support is\
+    \ planned.\n3. Once all integrations have been migrated to API v4, review the server logs with log level set to `DEBUG`.\
+    \ Confirm no requests hit `/api/v3/` endpoints.\n4. Set **Allow use of API v3 endpoints** to `false` in **System Console\
+    \ > General > Configuration**, or set `EnableAPIv3` to `false` in `config.json`. This setting disables API v3 on your\
+    \ server. Any time a v3 endpoint is used, an error is logged in **System Console > Logs**.\n5. Set your server's log level\
+    \ back to `ERROR`. Use the error logs to help track down any remaining uses of API v3.\n\nBelow are the major changes\
+    \ made between v3 and v4:\n\n1. Endpoint URLs only require team IDs when necessary. For example, getting a channel by\
+    \ ID no longer requires a team ID in v4.\n2. Collection endpoints now generally return lists and include paging as part\
+    \ of the query string.\n3. User ID is now included in most user endpoints. This allows admins to modify other users through\
+    \ v4 endpoints.\n\nIf you have any questions about the API v3 deprecation, or about migrating from v3 to v4, [join our\
+    \ daily build server at community.mattermost.com](https://community.mattermost.com) and ask questions in the [APIv4 channel](https://community.mattermost.com/core/channels/apiv4).\n"
+  name: APIv3 Deprecation
+- description: 'Endpoints for creating, getting and interacting with users.
+
+
+    When using endpoints that require a user id, the string `me` can be used in place of the user id to indicate the action
+    is to be taken for the logged in user.
+
+    '
+  name: users
+- description: Endpoints for creating, getting and updating bot users.
+  name: bots
+- description: Endpoints for creating, getting and interacting with teams.
+  name: teams
+- description: Endpoints for creating, getting and interacting with channels.
+  name: channels
+- description: Endpoints for creating, getting and interacting with posts.
+  name: posts
+- description: Endpoints for uploading and interacting with files.
+  name: files
+- description: Endpoints for creating and performing file uploads.
+  name: uploads
+- description: Endpoints for saving and modifying user preferences.
+  name: preferences
+- description: Endpoints for getting and updating user statuses.
+  name: status
+- description: Endpoints for creating, getting and interacting with emojis.
+  name: emoji
+- description: Endpoints for creating, getting and removing emoji reactions.
+  name: reactions
+- description: Endpoints for creating, getting and updating webhooks.
+  name: webhooks
+- description: Endpoints for creating, getting and updating slash commands.
+  name: commands
+- description: Endpoint for getting Open Graph metadata.
+  name: OpenGraph
+- description: General endpoints for interacting with the server, such as configuration and logging.
+  name: system
+- description: Endpoints related to custom branding and white-labeling. See [our branding documentation](https://docs.mattermost.com/administration/branding.html)
+    for more information.
+  name: brand
+- description: Endpoints for configuring and interacting with Mattermost as an OAuth 2.0 service provider.
+  name: OAuth
+- description: Endpoints for configuring and interacting with SAML.
+  name: SAML
+- description: Endpoints for configuring and interacting with LDAP.
+  name: LDAP
+- description: Endpoints related to LDAP groups.
+  name: groups
+- description: Endpoints for creating, getting and downloading compliance reports.
+  name: compliance
+- description: Endpoints for configuring and interacting with high availability clusters.
+  name: cluster
+- description: Endpoints for configuring and interacting with Elasticsearch.
+  name: elasticsearch
+- description: Endpoint for getting data retention policy settings.
+  name: data retention
+- description: Endpoints related to various background jobs that can be run by the server or separately by job servers.
+  name: jobs
+- description: Endpoints related to uploading and managing plugins.
+  name: plugins
+- description: Endpoints for creating, getting and updating roles.
+  name: roles
+- description: Endpoints for creating, getting and updating and deleting schemes.
+  name: schemes
+- description: Endpoints for interactive actions for use by integrations.
+  name: integration_actions
+- description: Endpoints for getting information about shared channels.
+  name: shared channels
+- description: Endpoints for getting insights into teams and users.
+  name: insights
+- description: Endpoints for getting and updating custom terms of service.
+  name: terms of service
+- description: Endpoints related to import files.
+  name: imports
+- description: Endpoints related to export files.
+  name: exports
+- description: Playbooks
+  name: Playbooks
+- description: Playbook runs
+  name: PlaybookRuns
+- description: Internal endpoints
+  name: Internal
+- description: Timeline
+  name: Timeline
+- description: Playbook Autofollows
+  name: PlaybookAutofollows
+x-tagGroups:
+- name: Overview
+  tags:
+  - introduction
+  - schema
+  - APIv3 Deprecation
+- name: Standard Features
+  tags:
+  - drivers
+  - authentication
+  - errors
+  - rate limiting
+  - WebSocket
+- name: Endpoints
+  tags:
+  - users
+  - bots
+  - teams
+  - channels
+  - posts
+  - threads
+  - files
+  - uploads
+  - preferences
+  - status
+  - emoji
+  - reactions
+  - webhooks
+  - commands
+  - OpenGraph
+  - system
+  - brand
+  - OAuth
+  - SAML
+  - LDAP
+  - groups
+  - compliance
+  - cluster
+  - cloud
+  - elasticsearch
+  - bleve
+  - data retention
+  - jobs
+  - plugins
+  - roles
+  - schemes
+  - integration_actions
+  - shared channels
+  - insights
+  - terms of service
+  - imports
+  - permissions
+  - exports
+  - usage
+- name: Playbooks
+  tags:
+  - Playbooks
+  - PlaybookRuns
+  - PlaybookAutofollows
+  - Timeline
+  - Internal

--- a/src/Client/Dto/AddOn.php
+++ b/src/Client/Dto/AddOn.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class AddOn extends SpatieData
+{
+	public function __construct(
+		#[MapName('display_name')]
+		public ?string $displayName = null,
+		public ?string $id = null,
+		public ?string $name = null,
+		#[MapName('price_per_seat')]
+		public ?string $pricePerSeat = null,
+	) {
+	}
+}

--- a/src/Client/Dto/Address.php
+++ b/src/Client/Dto/Address.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class Address extends SpatieData
+{
+	public function __construct(
+		public ?string $city = null,
+		public ?string $country = null,
+		public ?string $line1 = null,
+		public ?string $line2 = null,
+		#[MapName('postal_code')]
+		public ?string $postalCode = null,
+		public ?string $state = null,
+	) {
+	}
+}

--- a/src/Client/Dto/AnalyticsSettings.php
+++ b/src/Client/Dto/AnalyticsSettings.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class AnalyticsSettings extends SpatieData
+{
+	public function __construct(
+		#[MapName('MaxUsersForStatistics')]
+		public ?int $maxUsersForStatistics = null,
+	) {
+	}
+}

--- a/src/Client/Dto/AppError.php
+++ b/src/Client/Dto/AppError.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class AppError extends SpatieData
+{
+	public function __construct(
+		public ?string $id = null,
+		public ?string $message = null,
+		#[MapName('request_id')]
+		public ?string $requestId = null,
+		#[MapName('status_code')]
+		public ?int $statusCode = null,
+	) {
+	}
+}

--- a/src/Client/Dto/Audit.php
+++ b/src/Client/Dto/Audit.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class Audit extends SpatieData
+{
+	public function __construct(
+		public ?string $action = null,
+		#[MapName('create_at')]
+		public ?int $createAt = null,
+		#[MapName('extra_info')]
+		public ?string $extraInfo = null,
+		public ?string $id = null,
+		#[MapName('ip_address')]
+		public ?string $ipAddress = null,
+		#[MapName('session_id')]
+		public ?string $sessionId = null,
+		#[MapName('user_id')]
+		public ?string $userId = null,
+	) {
+	}
+}

--- a/src/Client/Dto/AutocompleteSuggestion.php
+++ b/src/Client/Dto/AutocompleteSuggestion.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class AutocompleteSuggestion extends SpatieData
+{
+	public function __construct(
+		#[MapName('Complete')]
+		public ?string $complete = null,
+		#[MapName('Description')]
+		public ?string $description = null,
+		#[MapName('Hint')]
+		public ?string $hint = null,
+		#[MapName('IconData')]
+		public ?string $iconData = null,
+		#[MapName('Suggestion')]
+		public ?string $suggestion = null,
+	) {
+	}
+}

--- a/src/Client/Dto/BoardsLimits.php
+++ b/src/Client/Dto/BoardsLimits.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Data as SpatieData;
+
+class BoardsLimits extends SpatieData
+{
+	public function __construct(
+		public ?int $cards = null,
+		public ?int $views = null,
+	) {
+	}
+}

--- a/src/Client/Dto/Bot.php
+++ b/src/Client/Dto/Bot.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+/**
+ * A bot account
+ */
+class Bot extends SpatieData
+{
+	public function __construct(
+		#[MapName('create_at')]
+		public ?int $createAt = null,
+		#[MapName('delete_at')]
+		public ?int $deleteAt = null,
+		public ?string $description = null,
+		#[MapName('display_name')]
+		public ?string $displayName = null,
+		#[MapName('owner_id')]
+		public ?string $ownerId = null,
+		#[MapName('update_at')]
+		public ?int $updateAt = null,
+		#[MapName('user_id')]
+		public ?string $userId = null,
+		public ?string $username = null,
+	) {
+	}
+}

--- a/src/Client/Dto/Channel.php
+++ b/src/Client/Dto/Channel.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class Channel extends SpatieData
+{
+	public function __construct(
+		#[MapName('create_at')]
+		public ?int $createAt = null,
+		#[MapName('creator_id')]
+		public ?string $creatorId = null,
+		#[MapName('delete_at')]
+		public ?int $deleteAt = null,
+		#[MapName('display_name')]
+		public ?string $displayName = null,
+		#[MapName('extra_update_at')]
+		public ?int $extraUpdateAt = null,
+		public ?string $header = null,
+		public ?string $id = null,
+		#[MapName('last_post_at')]
+		public ?int $lastPostAt = null,
+		public ?string $name = null,
+		public ?string $purpose = null,
+		#[MapName('team_id')]
+		public ?string $teamId = null,
+		#[MapName('total_msg_count')]
+		public ?int $totalMsgCount = null,
+		public ?string $type = null,
+		#[MapName('update_at')]
+		public ?int $updateAt = null,
+	) {
+	}
+}

--- a/src/Client/Dto/ChannelData.php
+++ b/src/Client/Dto/ChannelData.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Data as SpatieData;
+
+class ChannelData extends SpatieData
+{
+	public function __construct(
+		public ?Channel $channel = null,
+		public ?ChannelMember $member = null,
+	) {
+	}
+}

--- a/src/Client/Dto/ChannelListWithTeamData.php
+++ b/src/Client/Dto/ChannelListWithTeamData.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Data as SpatieData;
+
+class ChannelListWithTeamData extends SpatieData
+{
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Dto/ChannelMember.php
+++ b/src/Client/Dto/ChannelMember.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class ChannelMember extends SpatieData
+{
+	public function __construct(
+		#[MapName('channel_id')]
+		public ?string $channelId = null,
+		#[MapName('last_update_at')]
+		public ?int $lastUpdateAt = null,
+		#[MapName('last_viewed_at')]
+		public ?int $lastViewedAt = null,
+		#[MapName('mention_count')]
+		public ?int $mentionCount = null,
+		#[MapName('msg_count')]
+		public ?int $msgCount = null,
+		#[MapName('notify_props')]
+		public ?ChannelNotifyProps $notifyProps = null,
+		public ?string $roles = null,
+		#[MapName('user_id')]
+		public ?string $userId = null,
+	) {
+	}
+}

--- a/src/Client/Dto/ChannelMemberCountByGroup.php
+++ b/src/Client/Dto/ChannelMemberCountByGroup.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+/**
+ * An object describing group member information in a channel
+ */
+class ChannelMemberCountByGroup extends SpatieData
+{
+	public function __construct(
+		#[MapName('channel_member_count')]
+		public int|float|null $channelMemberCount = null,
+		#[MapName('channel_member_timezones_count')]
+		public int|float|null $channelMemberTimezonesCount = null,
+		#[MapName('group_id')]
+		public ?string $groupId = null,
+	) {
+	}
+}

--- a/src/Client/Dto/ChannelMemberWithTeamData.php
+++ b/src/Client/Dto/ChannelMemberWithTeamData.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Data as SpatieData;
+
+class ChannelMemberWithTeamData extends SpatieData
+{
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Dto/ChannelModeratedRole.php
+++ b/src/Client/Dto/ChannelModeratedRole.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Data as SpatieData;
+
+class ChannelModeratedRole extends SpatieData
+{
+	public function __construct(
+		public ?bool $enabled = null,
+		public ?bool $value = null,
+	) {
+	}
+}

--- a/src/Client/Dto/ChannelModeratedRoles.php
+++ b/src/Client/Dto/ChannelModeratedRoles.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Data as SpatieData;
+
+class ChannelModeratedRoles extends SpatieData
+{
+	public function __construct(
+		public ?ChannelModeratedRole $guests = null,
+		public ?ChannelModeratedRole $members = null,
+	) {
+	}
+}

--- a/src/Client/Dto/ChannelModeratedRolesPatch.php
+++ b/src/Client/Dto/ChannelModeratedRolesPatch.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Data as SpatieData;
+
+class ChannelModeratedRolesPatch extends SpatieData
+{
+	public function __construct(
+		public ?bool $guests = null,
+		public ?bool $members = null,
+	) {
+	}
+}

--- a/src/Client/Dto/ChannelModeration.php
+++ b/src/Client/Dto/ChannelModeration.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Data as SpatieData;
+
+class ChannelModeration extends SpatieData
+{
+	public function __construct(
+		public ?string $name = null,
+		public ?ChannelModeratedRoles $roles = null,
+	) {
+	}
+}

--- a/src/Client/Dto/ChannelModerationPatch.php
+++ b/src/Client/Dto/ChannelModerationPatch.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Data as SpatieData;
+
+class ChannelModerationPatch extends SpatieData
+{
+	public function __construct(
+		public ?string $name = null,
+		public ?ChannelModeratedRolesPatch $roles = null,
+	) {
+	}
+}

--- a/src/Client/Dto/ChannelNotifyProps.php
+++ b/src/Client/Dto/ChannelNotifyProps.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class ChannelNotifyProps extends SpatieData
+{
+	public function __construct(
+		public ?string $desktop = null,
+		public ?string $email = null,
+		#[MapName('mark_unread')]
+		public ?string $markUnread = null,
+		public ?string $push = null,
+	) {
+	}
+}

--- a/src/Client/Dto/ChannelStats.php
+++ b/src/Client/Dto/ChannelStats.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class ChannelStats extends SpatieData
+{
+	public function __construct(
+		#[MapName('channel_id')]
+		public ?string $channelId = null,
+		#[MapName('member_count')]
+		public ?int $memberCount = null,
+	) {
+	}
+}

--- a/src/Client/Dto/ChannelUnread.php
+++ b/src/Client/Dto/ChannelUnread.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class ChannelUnread extends SpatieData
+{
+	public function __construct(
+		#[MapName('channel_id')]
+		public ?string $channelId = null,
+		#[MapName('mention_count')]
+		public ?int $mentionCount = null,
+		#[MapName('msg_count')]
+		public ?int $msgCount = null,
+		#[MapName('team_id')]
+		public ?string $teamId = null,
+	) {
+	}
+}

--- a/src/Client/Dto/ChannelUnreadAt.php
+++ b/src/Client/Dto/ChannelUnreadAt.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class ChannelUnreadAt extends SpatieData
+{
+	public function __construct(
+		#[MapName('channel_id')]
+		public ?string $channelId = null,
+		#[MapName('last_viewed_at')]
+		public ?int $lastViewedAt = null,
+		#[MapName('mention_count')]
+		public ?int $mentionCount = null,
+		#[MapName('msg_count')]
+		public ?int $msgCount = null,
+		#[MapName('team_id')]
+		public ?string $teamId = null,
+	) {
+	}
+}

--- a/src/Client/Dto/ChannelWithTeamData.php
+++ b/src/Client/Dto/ChannelWithTeamData.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Data as SpatieData;
+
+class ChannelWithTeamData extends SpatieData
+{
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Dto/Checklist.php
+++ b/src/Client/Dto/Checklist.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Data as SpatieData;
+
+class Checklist extends SpatieData
+{
+	public function __construct(
+		public ?string $id = null,
+		public ?array $items = null,
+		public ?string $title = null,
+	) {
+	}
+}

--- a/src/Client/Dto/ChecklistItem.php
+++ b/src/Client/Dto/ChecklistItem.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class ChecklistItem extends SpatieData
+{
+	public function __construct(
+		#[MapName('assignee_id')]
+		public ?string $assigneeId = null,
+		#[MapName('assignee_modified')]
+		public ?int $assigneeModified = null,
+		public ?string $command = null,
+		#[MapName('command_last_run')]
+		public ?int $commandLastRun = null,
+		#[MapName('condition_action')]
+		public ?string $conditionAction = null,
+		#[MapName('condition_id')]
+		public ?string $conditionId = null,
+		#[MapName('condition_reason')]
+		public ?string $conditionReason = null,
+		#[MapName('delete_at')]
+		public ?int $deleteAt = null,
+		public ?string $description = null,
+		#[MapName('due_date')]
+		public ?int $dueDate = null,
+		public ?string $id = null,
+		public ?string $state = null,
+		#[MapName('state_modified')]
+		public ?int $stateModified = null,
+		#[MapName('task_actions')]
+		public ?array $taskActions = null,
+		public ?string $title = null,
+		#[MapName('update_at')]
+		public ?int $updateAt = null,
+	) {
+	}
+}

--- a/src/Client/Dto/CloudCustomer.php
+++ b/src/Client/Dto/CloudCustomer.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class CloudCustomer extends SpatieData
+{
+	public function __construct(
+		#[MapName('billing_address')]
+		public ?Address $billingAddress = null,
+		#[MapName('company_address')]
+		public ?Address $companyAddress = null,
+		#[MapName('contact_first_name')]
+		public ?string $contactFirstName = null,
+		#[MapName('contact_last_name')]
+		public ?string $contactLastName = null,
+		#[MapName('create_at')]
+		public ?int $createAt = null,
+		#[MapName('creator_id')]
+		public ?string $creatorId = null,
+		public ?string $email = null,
+		public ?string $id = null,
+		public ?string $name = null,
+		#[MapName('num_employees')]
+		public ?string $numEmployees = null,
+		#[MapName('payment_method')]
+		public ?PaymentMethod $paymentMethod = null,
+	) {
+	}
+}

--- a/src/Client/Dto/ClusterInfo.php
+++ b/src/Client/Dto/ClusterInfo.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class ClusterInfo extends SpatieData
+{
+	public function __construct(
+		#[MapName('config_hash')]
+		public ?string $configHash = null,
+		public ?string $hostname = null,
+		public ?string $id = null,
+		#[MapName('internode_url')]
+		public ?string $internodeUrl = null,
+		#[MapName('is_alive')]
+		public ?bool $isAlive = null,
+		#[MapName('last_ping')]
+		public ?int $lastPing = null,
+		public ?string $version = null,
+	) {
+	}
+}

--- a/src/Client/Dto/Command.php
+++ b/src/Client/Dto/Command.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class Command extends SpatieData
+{
+	public function __construct(
+		#[MapName('auto_complete')]
+		public ?bool $autoComplete = null,
+		#[MapName('auto_complete_desc')]
+		public ?string $autoCompleteDesc = null,
+		#[MapName('auto_complete_hint')]
+		public ?string $autoCompleteHint = null,
+		#[MapName('create_at')]
+		public ?int $createAt = null,
+		#[MapName('creator_id')]
+		public ?string $creatorId = null,
+		#[MapName('delete_at')]
+		public ?int $deleteAt = null,
+		public ?string $description = null,
+		#[MapName('display_name')]
+		public ?string $displayName = null,
+		#[MapName('icon_url')]
+		public ?string $iconUrl = null,
+		public ?string $id = null,
+		public ?string $method = null,
+		#[MapName('team_id')]
+		public ?string $teamId = null,
+		public ?string $token = null,
+		public ?string $trigger = null,
+		#[MapName('update_at')]
+		public ?int $updateAt = null,
+		public ?string $url = null,
+		public ?string $username = null,
+	) {
+	}
+}

--- a/src/Client/Dto/CommandResponse.php
+++ b/src/Client/Dto/CommandResponse.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class CommandResponse extends SpatieData
+{
+	public function __construct(
+		#[MapName('Attachments')]
+		public ?array $attachments = null,
+		#[MapName('GotoLocation')]
+		public ?string $gotoLocation = null,
+		#[MapName('IconURL')]
+		public ?string $iconUrl = null,
+		#[MapName('ResponseType')]
+		public ?string $responseType = null,
+		#[MapName('Text')]
+		public ?string $text = null,
+		#[MapName('Username')]
+		public ?string $username = null,
+	) {
+	}
+}

--- a/src/Client/Dto/ComparisonCondition.php
+++ b/src/Client/Dto/ComparisonCondition.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class ComparisonCondition extends SpatieData
+{
+	public function __construct(
+		#[MapName('field_id')]
+		public ?string $fieldId = null,
+		public mixed $value = null,
+	) {
+	}
+}

--- a/src/Client/Dto/Compliance.php
+++ b/src/Client/Dto/Compliance.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class Compliance extends SpatieData
+{
+	public function __construct(
+		public ?int $count = null,
+		#[MapName('create_at')]
+		public ?int $createAt = null,
+		public ?string $desc = null,
+		public ?string $emails = null,
+		#[MapName('end_at')]
+		public ?int $endAt = null,
+		public ?string $id = null,
+		public ?string $keywords = null,
+		#[MapName('start_at')]
+		public ?int $startAt = null,
+		public ?string $status = null,
+		public ?string $type = null,
+		#[MapName('user_id')]
+		public ?string $userId = null,
+	) {
+	}
+}

--- a/src/Client/Dto/Condition.php
+++ b/src/Client/Dto/Condition.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class Condition extends SpatieData
+{
+	public function __construct(
+		#[MapName('condition_expr')]
+		public ?ConditionExprV1 $conditionExpr = null,
+		#[MapName('create_at')]
+		public ?int $createAt = null,
+		public ?string $id = null,
+		#[MapName('playbook_id')]
+		public ?string $playbookId = null,
+		#[MapName('run_id')]
+		public ?string $runId = null,
+		#[MapName('update_at')]
+		public ?int $updateAt = null,
+		public ?int $version = null,
+	) {
+	}
+}

--- a/src/Client/Dto/ConditionExprV1.php
+++ b/src/Client/Dto/ConditionExprV1.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Data as SpatieData;
+
+/**
+ * A logical condition expression that can combine multiple conditions using AND/OR operators, or
+ * perform field comparisons using Is/IsNot operators.
+ */
+class ConditionExprV1 extends SpatieData
+{
+	public function __construct(
+		public ?array $and = null,
+		public ?ComparisonCondition $is = null,
+		public ?ComparisonCondition $isNot = null,
+		public ?array $or = null,
+	) {
+	}
+}

--- a/src/Client/Dto/ConditionList.php
+++ b/src/Client/Dto/ConditionList.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class ConditionList extends SpatieData
+{
+	public function __construct(
+		#[MapName('has_more')]
+		public ?bool $hasMore = null,
+		public ?array $items = null,
+		#[MapName('page_count')]
+		public ?int $pageCount = null,
+		#[MapName('total_count')]
+		public ?int $totalCount = null,
+	) {
+	}
+}

--- a/src/Client/Dto/Config.php
+++ b/src/Client/Dto/Config.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class Config extends SpatieData
+{
+	public function __construct(
+		#[MapName('AnalyticsSettings')]
+		public ?object $analyticsSettings = null,
+		#[MapName('ClusterSettings')]
+		public ?object $clusterSettings = null,
+		#[MapName('ComplianceSettings')]
+		public ?object $complianceSettings = null,
+		#[MapName('EmailSettings')]
+		public ?object $emailSettings = null,
+		#[MapName('FileSettings')]
+		public ?object $fileSettings = null,
+		#[MapName('GitLabSettings')]
+		public ?object $gitLabSettings = null,
+		#[MapName('GoogleSettings')]
+		public ?object $googleSettings = null,
+		#[MapName('LdapSettings')]
+		public ?object $ldapSettings = null,
+		#[MapName('LocalizationSettings')]
+		public ?object $localizationSettings = null,
+		#[MapName('LogSettings')]
+		public ?object $logSettings = null,
+		#[MapName('MetricsSettings')]
+		public ?object $metricsSettings = null,
+		#[MapName('NativeAppSettings')]
+		public ?object $nativeAppSettings = null,
+		#[MapName('Office365Settings')]
+		public ?object $office365settings = null,
+		#[MapName('PasswordSettings')]
+		public ?object $passwordSettings = null,
+		#[MapName('PrivacySettings')]
+		public ?object $privacySettings = null,
+		#[MapName('RateLimitSettings')]
+		public ?object $rateLimitSettings = null,
+		#[MapName('SamlSettings')]
+		public ?object $samlSettings = null,
+		#[MapName('ServiceSettings')]
+		public ?object $serviceSettings = null,
+		#[MapName('SqlSettings')]
+		public ?object $sqlSettings = null,
+		#[MapName('SupportSettings')]
+		public ?object $supportSettings = null,
+		#[MapName('TeamSettings')]
+		public ?object $teamSettings = null,
+	) {
+	}
+}

--- a/src/Client/Dto/DataRetentionPolicy.php
+++ b/src/Client/Dto/DataRetentionPolicy.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Data as SpatieData;
+
+class DataRetentionPolicy extends SpatieData
+{
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Dto/DataRetentionPolicyCreate.php
+++ b/src/Client/Dto/DataRetentionPolicyCreate.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Data as SpatieData;
+
+class DataRetentionPolicyCreate extends SpatieData
+{
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Dto/DataRetentionPolicyForChannel.php
+++ b/src/Client/Dto/DataRetentionPolicyForChannel.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class DataRetentionPolicyForChannel extends SpatieData
+{
+	public function __construct(
+		#[MapName('channel_id')]
+		public ?string $channelId = null,
+		#[MapName('post_duration')]
+		public ?int $postDuration = null,
+	) {
+	}
+}

--- a/src/Client/Dto/DataRetentionPolicyForTeam.php
+++ b/src/Client/Dto/DataRetentionPolicyForTeam.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class DataRetentionPolicyForTeam extends SpatieData
+{
+	public function __construct(
+		#[MapName('post_duration')]
+		public ?int $postDuration = null,
+		#[MapName('team_id')]
+		public ?string $teamId = null,
+	) {
+	}
+}

--- a/src/Client/Dto/DataRetentionPolicyWithTeamAndChannelCounts.php
+++ b/src/Client/Dto/DataRetentionPolicyWithTeamAndChannelCounts.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Data as SpatieData;
+
+class DataRetentionPolicyWithTeamAndChannelCounts extends SpatieData
+{
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Dto/DataRetentionPolicyWithTeamAndChannelIds.php
+++ b/src/Client/Dto/DataRetentionPolicyWithTeamAndChannelIds.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Data as SpatieData;
+
+class DataRetentionPolicyWithTeamAndChannelIds extends SpatieData
+{
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Dto/DataRetentionPolicyWithoutId.php
+++ b/src/Client/Dto/DataRetentionPolicyWithoutId.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class DataRetentionPolicyWithoutId extends SpatieData
+{
+	public function __construct(
+		#[MapName('display_name')]
+		public ?string $displayName = null,
+		#[MapName('post_duration')]
+		public ?int $postDuration = null,
+	) {
+	}
+}

--- a/src/Client/Dto/Emoji.php
+++ b/src/Client/Dto/Emoji.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class Emoji extends SpatieData
+{
+	public function __construct(
+		#[MapName('create_at')]
+		public ?int $createAt = null,
+		#[MapName('creator_id')]
+		public ?string $creatorId = null,
+		#[MapName('delete_at')]
+		public ?int $deleteAt = null,
+		public ?string $id = null,
+		public ?string $name = null,
+		#[MapName('update_at')]
+		public ?int $updateAt = null,
+	) {
+	}
+}

--- a/src/Client/Dto/EnvironmentConfig.php
+++ b/src/Client/Dto/EnvironmentConfig.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class EnvironmentConfig extends SpatieData
+{
+	public function __construct(
+		#[MapName('AnalyticsSettings')]
+		public ?object $analyticsSettings = null,
+		#[MapName('ClusterSettings')]
+		public ?object $clusterSettings = null,
+		#[MapName('ComplianceSettings')]
+		public ?object $complianceSettings = null,
+		#[MapName('EmailSettings')]
+		public ?object $emailSettings = null,
+		#[MapName('FileSettings')]
+		public ?object $fileSettings = null,
+		#[MapName('GitLabSettings')]
+		public ?object $gitLabSettings = null,
+		#[MapName('GoogleSettings')]
+		public ?object $googleSettings = null,
+		#[MapName('LdapSettings')]
+		public ?object $ldapSettings = null,
+		#[MapName('LocalizationSettings')]
+		public ?object $localizationSettings = null,
+		#[MapName('LogSettings')]
+		public ?object $logSettings = null,
+		#[MapName('MetricsSettings')]
+		public ?object $metricsSettings = null,
+		#[MapName('NativeAppSettings')]
+		public ?object $nativeAppSettings = null,
+		#[MapName('Office365Settings')]
+		public ?object $office365settings = null,
+		#[MapName('PasswordSettings')]
+		public ?object $passwordSettings = null,
+		#[MapName('PrivacySettings')]
+		public ?object $privacySettings = null,
+		#[MapName('RateLimitSettings')]
+		public ?object $rateLimitSettings = null,
+		#[MapName('SamlSettings')]
+		public ?object $samlSettings = null,
+		#[MapName('ServiceSettings')]
+		public ?object $serviceSettings = null,
+		#[MapName('SqlSettings')]
+		public ?object $sqlSettings = null,
+		#[MapName('SupportSettings')]
+		public ?object $supportSettings = null,
+		#[MapName('TeamSettings')]
+		public ?object $teamSettings = null,
+	) {
+	}
+}

--- a/src/Client/Dto/Error.php
+++ b/src/Client/Dto/Error.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Data as SpatieData;
+
+class Error extends SpatieData
+{
+	public function __construct(
+		public ?string $details = null,
+		public ?string $error = null,
+	) {
+	}
+}

--- a/src/Client/Dto/FileInfo.php
+++ b/src/Client/Dto/FileInfo.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class FileInfo extends SpatieData
+{
+	public function __construct(
+		#[MapName('create_at')]
+		public ?int $createAt = null,
+		#[MapName('delete_at')]
+		public ?int $deleteAt = null,
+		public ?string $extension = null,
+		#[MapName('has_preview_image')]
+		public ?bool $hasPreviewImage = null,
+		public ?int $height = null,
+		public ?string $id = null,
+		#[MapName('mime_type')]
+		public ?string $mimeType = null,
+		public ?string $name = null,
+		#[MapName('post_id')]
+		public ?string $postId = null,
+		public ?int $size = null,
+		#[MapName('update_at')]
+		public ?int $updateAt = null,
+		#[MapName('user_id')]
+		public ?string $userId = null,
+		public ?int $width = null,
+	) {
+	}
+}

--- a/src/Client/Dto/FileInfoList.php
+++ b/src/Client/Dto/FileInfoList.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class FileInfoList extends SpatieData
+{
+	public function __construct(
+		#[MapName('file_infos')]
+		public ?object $fileInfos = null,
+		#[MapName('next_file_id')]
+		public ?string $nextFileId = null,
+		public ?array $order = null,
+		#[MapName('prev_file_id')]
+		public ?string $prevFileId = null,
+	) {
+	}
+}

--- a/src/Client/Dto/FilesLimits.php
+++ b/src/Client/Dto/FilesLimits.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class FilesLimits extends SpatieData
+{
+	public function __construct(
+		#[MapName('total_storage')]
+		public ?int $totalStorage = null,
+	) {
+	}
+}

--- a/src/Client/Dto/GlobalDataRetentionPolicy.php
+++ b/src/Client/Dto/GlobalDataRetentionPolicy.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class GlobalDataRetentionPolicy extends SpatieData
+{
+	public function __construct(
+		#[MapName('file_deletion_enabled')]
+		public ?bool $fileDeletionEnabled = null,
+		#[MapName('file_retention_cutoff')]
+		public ?int $fileRetentionCutoff = null,
+		#[MapName('message_deletion_enabled')]
+		public ?bool $messageDeletionEnabled = null,
+		#[MapName('message_retention_cutoff')]
+		public ?int $messageRetentionCutoff = null,
+	) {
+	}
+}

--- a/src/Client/Dto/Group.php
+++ b/src/Client/Dto/Group.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class Group extends SpatieData
+{
+	public function __construct(
+		#[MapName('create_at')]
+		public ?int $createAt = null,
+		#[MapName('delete_at')]
+		public ?int $deleteAt = null,
+		public ?string $description = null,
+		#[MapName('display_name')]
+		public ?string $displayName = null,
+		#[MapName('has_syncables')]
+		public ?bool $hasSyncables = null,
+		public ?string $id = null,
+		public ?string $name = null,
+		#[MapName('remote_id')]
+		public ?string $remoteId = null,
+		public ?string $source = null,
+		#[MapName('update_at')]
+		public ?int $updateAt = null,
+	) {
+	}
+}

--- a/src/Client/Dto/GroupSyncableChannel.php
+++ b/src/Client/Dto/GroupSyncableChannel.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class GroupSyncableChannel extends SpatieData
+{
+	public function __construct(
+		#[MapName('auto_add')]
+		public ?bool $autoAdd = null,
+		#[MapName('channel_id')]
+		public ?string $channelId = null,
+		#[MapName('create_at')]
+		public ?int $createAt = null,
+		#[MapName('delete_at')]
+		public ?int $deleteAt = null,
+		#[MapName('group_id')]
+		public ?string $groupId = null,
+		#[MapName('update_at')]
+		public ?int $updateAt = null,
+	) {
+	}
+}

--- a/src/Client/Dto/GroupSyncableChannels.php
+++ b/src/Client/Dto/GroupSyncableChannels.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class GroupSyncableChannels extends SpatieData
+{
+	public function __construct(
+		#[MapName('auto_add')]
+		public ?bool $autoAdd = null,
+		#[MapName('channel_display_name')]
+		public ?string $channelDisplayName = null,
+		#[MapName('channel_id')]
+		public ?string $channelId = null,
+		#[MapName('channel_type')]
+		public ?string $channelType = null,
+		#[MapName('create_at')]
+		public ?int $createAt = null,
+		#[MapName('delete_at')]
+		public ?int $deleteAt = null,
+		#[MapName('group_id')]
+		public ?string $groupId = null,
+		#[MapName('team_display_name')]
+		public ?string $teamDisplayName = null,
+		#[MapName('team_id')]
+		public ?string $teamId = null,
+		#[MapName('team_type')]
+		public ?string $teamType = null,
+		#[MapName('update_at')]
+		public ?int $updateAt = null,
+	) {
+	}
+}

--- a/src/Client/Dto/GroupSyncableTeam.php
+++ b/src/Client/Dto/GroupSyncableTeam.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class GroupSyncableTeam extends SpatieData
+{
+	public function __construct(
+		#[MapName('auto_add')]
+		public ?bool $autoAdd = null,
+		#[MapName('create_at')]
+		public ?int $createAt = null,
+		#[MapName('delete_at')]
+		public ?int $deleteAt = null,
+		#[MapName('group_id')]
+		public ?string $groupId = null,
+		#[MapName('team_id')]
+		public ?string $teamId = null,
+		#[MapName('update_at')]
+		public ?int $updateAt = null,
+	) {
+	}
+}

--- a/src/Client/Dto/GroupSyncableTeams.php
+++ b/src/Client/Dto/GroupSyncableTeams.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class GroupSyncableTeams extends SpatieData
+{
+	public function __construct(
+		#[MapName('auto_add')]
+		public ?bool $autoAdd = null,
+		#[MapName('create_at')]
+		public ?int $createAt = null,
+		#[MapName('delete_at')]
+		public ?int $deleteAt = null,
+		#[MapName('group_id')]
+		public ?string $groupId = null,
+		#[MapName('team_display_name')]
+		public ?string $teamDisplayName = null,
+		#[MapName('team_id')]
+		public ?string $teamId = null,
+		#[MapName('team_type')]
+		public ?string $teamType = null,
+		#[MapName('update_at')]
+		public ?int $updateAt = null,
+	) {
+	}
+}

--- a/src/Client/Dto/GroupWithSchemeAdmin.php
+++ b/src/Client/Dto/GroupWithSchemeAdmin.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+/**
+ * group augmented with scheme admin information
+ */
+class GroupWithSchemeAdmin extends SpatieData
+{
+	public function __construct(
+		public ?Group $group = null,
+		#[MapName('scheme_admin')]
+		public ?bool $schemeAdmin = null,
+	) {
+	}
+}

--- a/src/Client/Dto/GroupsAssociatedToChannels.php
+++ b/src/Client/Dto/GroupsAssociatedToChannels.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Data as SpatieData;
+
+/**
+ * a map of channel id(s) to the set of groups that constrain the corresponding channel in a team
+ */
+class GroupsAssociatedToChannels extends SpatieData
+{
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Dto/IncomingWebhook.php
+++ b/src/Client/Dto/IncomingWebhook.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class IncomingWebhook extends SpatieData
+{
+	public function __construct(
+		#[MapName('channel_id')]
+		public ?string $channelId = null,
+		#[MapName('create_at')]
+		public ?int $createAt = null,
+		#[MapName('delete_at')]
+		public ?int $deleteAt = null,
+		public ?string $description = null,
+		#[MapName('display_name')]
+		public ?string $displayName = null,
+		public ?string $id = null,
+		#[MapName('update_at')]
+		public ?int $updateAt = null,
+	) {
+	}
+}

--- a/src/Client/Dto/InsightUserInformation.php
+++ b/src/Client/Dto/InsightUserInformation.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class InsightUserInformation extends SpatieData
+{
+	public function __construct(
+		#[MapName('create_at')]
+		public ?int $createAt = null,
+		#[MapName('first_name')]
+		public ?string $firstName = null,
+		public ?string $id = null,
+		#[MapName('last_name')]
+		public ?string $lastName = null,
+		#[MapName('last_picture_update')]
+		public ?string $lastPictureUpdate = null,
+		public ?string $nickname = null,
+		public ?string $username = null,
+	) {
+	}
+}

--- a/src/Client/Dto/IntegrationsLimits.php
+++ b/src/Client/Dto/IntegrationsLimits.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Data as SpatieData;
+
+class IntegrationsLimits extends SpatieData
+{
+	public function __construct(
+		public ?int $enabled = null,
+	) {
+	}
+}

--- a/src/Client/Dto/IntegrityCheckResult.php
+++ b/src/Client/Dto/IntegrityCheckResult.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Data as SpatieData;
+
+/**
+ * an object with the result of the integrity check.
+ */
+class IntegrityCheckResult extends SpatieData
+{
+	public function __construct(
+		public ?RelationalIntegrityCheckData $data = null,
+		public ?string $err = null,
+	) {
+	}
+}

--- a/src/Client/Dto/Invoice.php
+++ b/src/Client/Dto/Invoice.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class Invoice extends SpatieData
+{
+	public function __construct(
+		#[MapName('create_at')]
+		public ?int $createAt = null,
+		public ?string $id = null,
+		public ?array $item = null,
+		public ?string $number = null,
+		#[MapName('period_end')]
+		public ?int $periodEnd = null,
+		#[MapName('period_start')]
+		public ?int $periodStart = null,
+		public ?string $status = null,
+		#[MapName('subscription_id')]
+		public ?string $subscriptionId = null,
+		public ?int $tax = null,
+		public ?int $total = null,
+	) {
+	}
+}

--- a/src/Client/Dto/InvoiceLineItem.php
+++ b/src/Client/Dto/InvoiceLineItem.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class InvoiceLineItem extends SpatieData
+{
+	public function __construct(
+		public ?string $description = null,
+		public ?array $metadata = null,
+		#[MapName('price_id')]
+		public ?string $priceId = null,
+		#[MapName('price_per_unit')]
+		public ?int $pricePerUnit = null,
+		public ?int $quantity = null,
+		public ?int $total = null,
+	) {
+	}
+}

--- a/src/Client/Dto/Job.php
+++ b/src/Client/Dto/Job.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class Job extends SpatieData
+{
+	public function __construct(
+		#[MapName('create_at')]
+		public ?int $createAt = null,
+		public ?object $data = null,
+		public ?string $id = null,
+		#[MapName('last_activity_at')]
+		public ?int $lastActivityAt = null,
+		public ?int $progress = null,
+		#[MapName('start_at')]
+		public ?int $startAt = null,
+		public ?string $status = null,
+		public ?string $type = null,
+	) {
+	}
+}

--- a/src/Client/Dto/KnownUsers.php
+++ b/src/Client/Dto/KnownUsers.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Data as SpatieData;
+
+class KnownUsers extends SpatieData
+{
+	public function __construct(
+		public ?string $items = null,
+	) {
+	}
+}

--- a/src/Client/Dto/Ldapgroup.php
+++ b/src/Client/Dto/Ldapgroup.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+/**
+ * A LDAP group
+ */
+class Ldapgroup extends SpatieData
+{
+	public function __construct(
+		#[MapName('has_syncables')]
+		public ?bool $hasSyncables = null,
+		#[MapName('mattermost_group_id')]
+		public ?string $mattermostGroupId = null,
+		public ?string $name = null,
+		#[MapName('primary_key')]
+		public ?string $primaryKey = null,
+	) {
+	}
+}

--- a/src/Client/Dto/LdapgroupsPaged.php
+++ b/src/Client/Dto/LdapgroupsPaged.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Data as SpatieData;
+
+/**
+ * A paged list of LDAP groups
+ */
+class LdapgroupsPaged extends SpatieData
+{
+	public function __construct(
+		public int|float|null $count = null,
+		public ?array $groups = null,
+	) {
+	}
+}

--- a/src/Client/Dto/LicenseRenewalLink.php
+++ b/src/Client/Dto/LicenseRenewalLink.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class LicenseRenewalLink extends SpatieData
+{
+	public function __construct(
+		#[MapName('renewal_link')]
+		public ?string $renewalLink = null,
+	) {
+	}
+}

--- a/src/Client/Dto/MarketplacePlugin.php
+++ b/src/Client/Dto/MarketplacePlugin.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class MarketplacePlugin extends SpatieData
+{
+	public function __construct(
+		#[MapName('download_url')]
+		public ?string $downloadUrl = null,
+		#[MapName('homepage_url')]
+		public ?string $homepageUrl = null,
+		#[MapName('icon_data')]
+		public ?string $iconData = null,
+		#[MapName('installed_version')]
+		public ?string $installedVersion = null,
+		public ?array $labels = null,
+		public ?PluginManifest $manifest = null,
+		#[MapName('release_notes_url')]
+		public ?string $releaseNotesUrl = null,
+		public ?string $signature = null,
+	) {
+	}
+}

--- a/src/Client/Dto/MessagesLimits.php
+++ b/src/Client/Dto/MessagesLimits.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Data as SpatieData;
+
+class MessagesLimits extends SpatieData
+{
+	public function __construct(
+		public ?int $history = null,
+	) {
+	}
+}

--- a/src/Client/Dto/NewTeamMember.php
+++ b/src/Client/Dto/NewTeamMember.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class NewTeamMember extends SpatieData
+{
+	public function __construct(
+		#[MapName('create_at')]
+		public ?int $createAt = null,
+		#[MapName('first_name')]
+		public ?string $firstName = null,
+		public ?string $id = null,
+		#[MapName('last_name')]
+		public ?string $lastName = null,
+		public ?string $nickname = null,
+		public ?string $position = null,
+		public ?string $username = null,
+	) {
+	}
+}

--- a/src/Client/Dto/NewTeamMembersList.php
+++ b/src/Client/Dto/NewTeamMembersList.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class NewTeamMembersList extends SpatieData
+{
+	public function __construct(
+		#[MapName('has_next')]
+		public ?bool $hasNext = null,
+		public ?array $items = null,
+		#[MapName('total_count')]
+		public ?int $totalCount = null,
+	) {
+	}
+}

--- a/src/Client/Dto/Notice.php
+++ b/src/Client/Dto/Notice.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Data as SpatieData;
+
+class Notice extends SpatieData
+{
+	public function __construct(
+		public ?string $action = null,
+		public ?string $actionParam = null,
+		public ?string $actionText = null,
+		public ?string $description = null,
+		public ?string $id = null,
+		public ?string $image = null,
+		public ?bool $sysAdminOnly = null,
+		public ?bool $teamAdminOnly = null,
+		public ?string $title = null,
+	) {
+	}
+}

--- a/src/Client/Dto/OauthApp.php
+++ b/src/Client/Dto/OauthApp.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class OauthApp extends SpatieData
+{
+	public function __construct(
+		#[MapName('callback_urls')]
+		public ?array $callbackUrls = null,
+		#[MapName('client_secret')]
+		public ?string $clientSecret = null,
+		#[MapName('create_at')]
+		public ?int $createAt = null,
+		public ?string $description = null,
+		public ?string $homepage = null,
+		#[MapName('icon_url')]
+		public ?string $iconUrl = null,
+		public ?string $id = null,
+		#[MapName('is_trusted')]
+		public ?bool $isTrusted = null,
+		public ?string $name = null,
+		#[MapName('update_at')]
+		public ?int $updateAt = null,
+	) {
+	}
+}

--- a/src/Client/Dto/OpenGraph.php
+++ b/src/Client/Dto/OpenGraph.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+/**
+ * OpenGraph metadata of a webpage
+ */
+class OpenGraph extends SpatieData
+{
+	public function __construct(
+		public ?object $article = null,
+		public ?array $audios = null,
+		public ?object $book = null,
+		public ?string $description = null,
+		public ?string $determiner = null,
+		public ?array $images = null,
+		public ?string $locale = null,
+		#[MapName('locales_alternate')]
+		public ?array $localesAlternate = null,
+		public ?object $profile = null,
+		#[MapName('site_name')]
+		public ?string $siteName = null,
+		public ?string $title = null,
+		public ?string $type = null,
+		public ?string $url = null,
+		public ?array $videos = null,
+	) {
+	}
+}

--- a/src/Client/Dto/OrderedSidebarCategories.php
+++ b/src/Client/Dto/OrderedSidebarCategories.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Data as SpatieData;
+
+/**
+ * List of user's categories with their channels
+ */
+class OrderedSidebarCategories extends SpatieData
+{
+	public function __construct(
+		public ?array $categories = null,
+		public ?array $order = null,
+	) {
+	}
+}

--- a/src/Client/Dto/OrphanedRecord.php
+++ b/src/Client/Dto/OrphanedRecord.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+/**
+ * an object containing information about an orphaned record.
+ */
+class OrphanedRecord extends SpatieData
+{
+	public function __construct(
+		#[MapName('child_id')]
+		public ?string $childId = null,
+		#[MapName('parent_id')]
+		public ?string $parentId = null,
+	) {
+	}
+}

--- a/src/Client/Dto/OutgoingWebhook.php
+++ b/src/Client/Dto/OutgoingWebhook.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class OutgoingWebhook extends SpatieData
+{
+	public function __construct(
+		#[MapName('callback_urls')]
+		public ?array $callbackUrls = null,
+		#[MapName('channel_id')]
+		public ?string $channelId = null,
+		#[MapName('content_type')]
+		public ?string $contentType = null,
+		#[MapName('create_at')]
+		public ?int $createAt = null,
+		#[MapName('creator_id')]
+		public ?string $creatorId = null,
+		#[MapName('delete_at')]
+		public ?int $deleteAt = null,
+		public ?string $description = null,
+		#[MapName('display_name')]
+		public ?string $displayName = null,
+		public ?string $id = null,
+		#[MapName('team_id')]
+		public ?string $teamId = null,
+		#[MapName('trigger_when')]
+		public ?int $triggerWhen = null,
+		#[MapName('trigger_words')]
+		public ?array $triggerWords = null,
+		#[MapName('update_at')]
+		public ?int $updateAt = null,
+	) {
+	}
+}

--- a/src/Client/Dto/OwnerInfo.php
+++ b/src/Client/Dto/OwnerInfo.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class OwnerInfo extends SpatieData
+{
+	public function __construct(
+		#[MapName('user_id')]
+		public ?string $userId = null,
+		public ?string $username = null,
+	) {
+	}
+}

--- a/src/Client/Dto/PaymentMethod.php
+++ b/src/Client/Dto/PaymentMethod.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class PaymentMethod extends SpatieData
+{
+	public function __construct(
+		#[MapName('card_brand')]
+		public ?string $cardBrand = null,
+		#[MapName('exp_month')]
+		public ?int $expMonth = null,
+		#[MapName('exp_year')]
+		public ?int $expYear = null,
+		#[MapName('last_four')]
+		public ?int $lastFour = null,
+		public ?string $name = null,
+		public ?string $type = null,
+	) {
+	}
+}

--- a/src/Client/Dto/PaymentSetupIntent.php
+++ b/src/Client/Dto/PaymentSetupIntent.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class PaymentSetupIntent extends SpatieData
+{
+	public function __construct(
+		#[MapName('client_secret')]
+		public ?string $clientSecret = null,
+		public ?string $id = null,
+	) {
+	}
+}

--- a/src/Client/Dto/Playbook.php
+++ b/src/Client/Dto/Playbook.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class Playbook extends SpatieData
+{
+	public function __construct(
+		public ?array $checklists = null,
+		#[MapName('create_at')]
+		public ?int $createAt = null,
+		#[MapName('create_public_playbook_run')]
+		public ?bool $createPublicPlaybookRun = null,
+		#[MapName('delete_at')]
+		public ?int $deleteAt = null,
+		public ?string $description = null,
+		public ?string $id = null,
+		#[MapName('member_ids')]
+		public ?array $memberIds = null,
+		#[MapName('num_stages')]
+		public ?int $numStages = null,
+		#[MapName('num_steps')]
+		public ?int $numSteps = null,
+		#[MapName('team_id')]
+		public ?string $teamId = null,
+		public ?string $title = null,
+	) {
+	}
+}

--- a/src/Client/Dto/PlaybookAutofollows.php
+++ b/src/Client/Dto/PlaybookAutofollows.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class PlaybookAutofollows extends SpatieData
+{
+	public function __construct(
+		public ?array $items = null,
+		#[MapName('total_count')]
+		public ?int $totalCount = null,
+	) {
+	}
+}

--- a/src/Client/Dto/PlaybookList.php
+++ b/src/Client/Dto/PlaybookList.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class PlaybookList extends SpatieData
+{
+	public function __construct(
+		#[MapName('has_more')]
+		public ?bool $hasMore = null,
+		public ?array $items = null,
+		#[MapName('page_count')]
+		public ?int $pageCount = null,
+		#[MapName('total_count')]
+		public ?int $totalCount = null,
+	) {
+	}
+}

--- a/src/Client/Dto/PlaybookRun.php
+++ b/src/Client/Dto/PlaybookRun.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class PlaybookRun extends SpatieData
+{
+	public function __construct(
+		#[MapName('active_stage')]
+		public ?int $activeStage = null,
+		#[MapName('active_stage_title')]
+		public ?string $activeStageTitle = null,
+		#[MapName('channel_id')]
+		public ?string $channelId = null,
+		public ?array $checklists = null,
+		#[MapName('create_at')]
+		public ?int $createAt = null,
+		#[MapName('delete_at')]
+		public ?int $deleteAt = null,
+		#[MapName('end_at')]
+		public ?int $endAt = null,
+		public ?string $id = null,
+		#[MapName('is_active')]
+		public ?bool $isActive = null,
+		public ?string $name = null,
+		#[MapName('owner_user_id')]
+		public ?string $ownerUserId = null,
+		#[MapName('playbook_id')]
+		public ?string $playbookId = null,
+		#[MapName('post_id')]
+		public ?string $postId = null,
+		public ?string $summary = null,
+		#[MapName('team_id')]
+		public ?string $teamId = null,
+	) {
+	}
+}

--- a/src/Client/Dto/PlaybookRunList.php
+++ b/src/Client/Dto/PlaybookRunList.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class PlaybookRunList extends SpatieData
+{
+	public function __construct(
+		#[MapName('has_more')]
+		public ?bool $hasMore = null,
+		public ?array $items = null,
+		#[MapName('page_count')]
+		public ?int $pageCount = null,
+		#[MapName('total_count')]
+		public ?int $totalCount = null,
+	) {
+	}
+}

--- a/src/Client/Dto/PlaybookRunMetadata.php
+++ b/src/Client/Dto/PlaybookRunMetadata.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class PlaybookRunMetadata extends SpatieData
+{
+	public function __construct(
+		#[MapName('channel_display_name')]
+		public ?string $channelDisplayName = null,
+		#[MapName('channel_name')]
+		public ?string $channelName = null,
+		#[MapName('num_members')]
+		public ?int $numMembers = null,
+		#[MapName('team_name')]
+		public ?string $teamName = null,
+		#[MapName('total_posts')]
+		public ?int $totalPosts = null,
+	) {
+	}
+}

--- a/src/Client/Dto/PluginManifest.php
+++ b/src/Client/Dto/PluginManifest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class PluginManifest extends SpatieData
+{
+	public function __construct(
+		public ?object $backend = null,
+		public ?string $description = null,
+		public ?string $id = null,
+		#[MapName('min_server_version')]
+		public ?string $minServerVersion = null,
+		public ?string $name = null,
+		public ?object $server = null,
+		#[MapName('settings_schema')]
+		public ?object $settingsSchema = null,
+		public ?string $version = null,
+		public ?object $webapp = null,
+	) {
+	}
+}

--- a/src/Client/Dto/PluginManifestWebapp.php
+++ b/src/Client/Dto/PluginManifestWebapp.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Data as SpatieData;
+
+class PluginManifestWebapp extends SpatieData
+{
+	public function __construct(
+		public ?string $id = null,
+		public ?string $version = null,
+		public ?object $webapp = null,
+	) {
+	}
+}

--- a/src/Client/Dto/PluginStatus.php
+++ b/src/Client/Dto/PluginStatus.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class PluginStatus extends SpatieData
+{
+	public function __construct(
+		#[MapName('cluster_id')]
+		public ?string $clusterId = null,
+		public ?string $description = null,
+		public ?string $name = null,
+		#[MapName('plugin_id')]
+		public ?string $pluginId = null,
+		#[MapName('plugin_path')]
+		public ?string $pluginPath = null,
+		public int|float|null $state = null,
+		public ?string $version = null,
+	) {
+	}
+}

--- a/src/Client/Dto/Post.php
+++ b/src/Client/Dto/Post.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class Post extends SpatieData
+{
+	public function __construct(
+		#[MapName('channel_id')]
+		public ?string $channelId = null,
+		#[MapName('create_at')]
+		public ?int $createAt = null,
+		#[MapName('delete_at')]
+		public ?int $deleteAt = null,
+		#[MapName('edit_at')]
+		public ?int $editAt = null,
+		#[MapName('file_ids')]
+		public ?array $fileIds = null,
+		public ?string $hashtag = null,
+		public ?string $id = null,
+		public ?string $message = null,
+		public ?PostMetadata $metadata = null,
+		#[MapName('original_id')]
+		public ?string $originalId = null,
+		#[MapName('pending_post_id')]
+		public ?string $pendingPostId = null,
+		public ?object $props = null,
+		#[MapName('root_id')]
+		public ?string $rootId = null,
+		public ?string $type = null,
+		#[MapName('update_at')]
+		public ?int $updateAt = null,
+		#[MapName('user_id')]
+		public ?string $userId = null,
+	) {
+	}
+}

--- a/src/Client/Dto/PostAcknowledgement.php
+++ b/src/Client/Dto/PostAcknowledgement.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class PostAcknowledgement extends SpatieData
+{
+	public function __construct(
+		#[MapName('acknowledged_at')]
+		public ?int $acknowledgedAt = null,
+		#[MapName('post_id')]
+		public ?string $postId = null,
+		#[MapName('user_id')]
+		public ?string $userId = null,
+	) {
+	}
+}

--- a/src/Client/Dto/PostIdToReactionsMap.php
+++ b/src/Client/Dto/PostIdToReactionsMap.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Data as SpatieData;
+
+class PostIdToReactionsMap extends SpatieData
+{
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Dto/PostList.php
+++ b/src/Client/Dto/PostList.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class PostList extends SpatieData
+{
+	public function __construct(
+		#[MapName('has_next')]
+		public ?bool $hasNext = null,
+		#[MapName('next_post_id')]
+		public ?string $nextPostId = null,
+		public ?array $order = null,
+		public ?object $posts = null,
+		#[MapName('prev_post_id')]
+		public ?string $prevPostId = null,
+	) {
+	}
+}

--- a/src/Client/Dto/PostListWithSearchMatches.php
+++ b/src/Client/Dto/PostListWithSearchMatches.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Data as SpatieData;
+
+class PostListWithSearchMatches extends SpatieData
+{
+	public function __construct(
+		public ?object $matches = null,
+		public ?array $order = null,
+		public ?object $posts = null,
+	) {
+	}
+}

--- a/src/Client/Dto/PostMetadata.php
+++ b/src/Client/Dto/PostMetadata.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Data as SpatieData;
+
+/**
+ * Additional information used to display a post.
+ */
+class PostMetadata extends SpatieData
+{
+	public function __construct(
+		public ?array $acknowledgements = null,
+		public ?array $embeds = null,
+		public ?array $emojis = null,
+		public ?array $files = null,
+		public ?object $images = null,
+		public ?object $priority = null,
+		public ?array $reactions = null,
+	) {
+	}
+}

--- a/src/Client/Dto/PostsUsage.php
+++ b/src/Client/Dto/PostsUsage.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Data as SpatieData;
+
+class PostsUsage extends SpatieData
+{
+	public function __construct(
+		public int|float|null $count = null,
+	) {
+	}
+}

--- a/src/Client/Dto/Preference.php
+++ b/src/Client/Dto/Preference.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class Preference extends SpatieData
+{
+	public function __construct(
+		public ?string $category = null,
+		public ?string $name = null,
+		#[MapName('user_id')]
+		public ?string $userId = null,
+		public ?string $value = null,
+	) {
+	}
+}

--- a/src/Client/Dto/Product.php
+++ b/src/Client/Dto/Product.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class Product extends SpatieData
+{
+	public function __construct(
+		#[MapName('add_ons')]
+		public ?array $addOns = null,
+		public ?string $description = null,
+		public ?string $id = null,
+		public ?string $name = null,
+		#[MapName('price_per_seat')]
+		public ?string $pricePerSeat = null,
+	) {
+	}
+}

--- a/src/Client/Dto/ProductLimits.php
+++ b/src/Client/Dto/ProductLimits.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Data as SpatieData;
+
+class ProductLimits extends SpatieData
+{
+	public function __construct(
+		public ?BoardsLimits $boards = null,
+		public ?FilesLimits $files = null,
+		public ?IntegrationsLimits $integrations = null,
+		public ?MessagesLimits $messages = null,
+		public ?TeamsLimits $teams = null,
+	) {
+	}
+}

--- a/src/Client/Dto/PropertyField.php
+++ b/src/Client/Dto/PropertyField.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class PropertyField extends SpatieData
+{
+	public function __construct(
+		public ?object $attrs = null,
+		#[MapName('create_at')]
+		public ?int $createAt = null,
+		#[MapName('delete_at')]
+		public ?int $deleteAt = null,
+		public ?string $description = null,
+		public ?string $id = null,
+		public ?string $name = null,
+		public ?string $type = null,
+		#[MapName('update_at')]
+		public ?int $updateAt = null,
+	) {
+	}
+}

--- a/src/Client/Dto/PropertyFieldRequest.php
+++ b/src/Client/Dto/PropertyFieldRequest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Data as SpatieData;
+
+class PropertyFieldRequest extends SpatieData
+{
+	public function __construct(
+		public ?object $attrs = null,
+		public ?string $name = null,
+		public ?string $type = null,
+	) {
+	}
+}

--- a/src/Client/Dto/PropertyValue.php
+++ b/src/Client/Dto/PropertyValue.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class PropertyValue extends SpatieData
+{
+	public function __construct(
+		#[MapName('create_at')]
+		public ?int $createAt = null,
+		#[MapName('delete_at')]
+		public ?int $deleteAt = null,
+		#[MapName('field_id')]
+		public ?string $fieldId = null,
+		public ?string $id = null,
+		#[MapName('update_at')]
+		public ?int $updateAt = null,
+		public ?string $value = null,
+	) {
+	}
+}

--- a/src/Client/Dto/PropertyValueRequest.php
+++ b/src/Client/Dto/PropertyValueRequest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Data as SpatieData;
+
+class PropertyValueRequest extends SpatieData
+{
+	public function __construct(
+		public ?string $value = null,
+	) {
+	}
+}

--- a/src/Client/Dto/PushNotification.php
+++ b/src/Client/Dto/PushNotification.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class PushNotification extends SpatieData
+{
+	public function __construct(
+		#[MapName('ack_id')]
+		public ?string $ackId = null,
+		public int|float|null $badge = null,
+		public ?string $category = null,
+		#[MapName('channel_id')]
+		public ?string $channelId = null,
+		#[MapName('channel_name')]
+		public ?string $channelName = null,
+		#[MapName('cont_ava')]
+		public int|float|null $contAva = null,
+		#[MapName('device_id')]
+		public ?string $deviceId = null,
+		#[MapName('from_webhook')]
+		public ?string $fromWebhook = null,
+		#[MapName('is_id_loaded')]
+		public ?bool $isIdLoaded = null,
+		public ?string $message = null,
+		#[MapName('override_icon_url')]
+		public ?string $overrideIconUrl = null,
+		#[MapName('override_username')]
+		public ?string $overrideUsername = null,
+		public ?string $platform = null,
+		#[MapName('post_id')]
+		public ?string $postId = null,
+		#[MapName('root_id')]
+		public ?string $rootId = null,
+		#[MapName('sender_id')]
+		public ?string $senderId = null,
+		#[MapName('sender_name')]
+		public ?string $senderName = null,
+		#[MapName('server_id')]
+		public ?string $serverId = null,
+		public ?string $sound = null,
+		#[MapName('team_id')]
+		public ?string $teamId = null,
+		public ?string $type = null,
+		public ?string $version = null,
+	) {
+	}
+}

--- a/src/Client/Dto/Reaction.php
+++ b/src/Client/Dto/Reaction.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class Reaction extends SpatieData
+{
+	public function __construct(
+		#[MapName('create_at')]
+		public ?int $createAt = null,
+		#[MapName('emoji_name')]
+		public ?string $emojiName = null,
+		#[MapName('post_id')]
+		public ?string $postId = null,
+		#[MapName('user_id')]
+		public ?string $userId = null,
+	) {
+	}
+}

--- a/src/Client/Dto/RelationalIntegrityCheckData.php
+++ b/src/Client/Dto/RelationalIntegrityCheckData.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+/**
+ * an object containing the results of a relational integrity check.
+ */
+class RelationalIntegrityCheckData extends SpatieData
+{
+	public function __construct(
+		#[MapName('child_id_attr')]
+		public ?string $childIdAttr = null,
+		#[MapName('child_name')]
+		public ?string $childName = null,
+		#[MapName('parent_id_attr')]
+		public ?string $parentIdAttr = null,
+		#[MapName('parent_name')]
+		public ?string $parentName = null,
+		public ?array $records = null,
+	) {
+	}
+}

--- a/src/Client/Dto/RemoteClusterInfo.php
+++ b/src/Client/Dto/RemoteClusterInfo.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class RemoteClusterInfo extends SpatieData
+{
+	public function __construct(
+		#[MapName('create_at')]
+		public ?int $createAt = null,
+		#[MapName('display_name')]
+		public ?string $displayName = null,
+		#[MapName('last_ping_at')]
+		public ?int $lastPingAt = null,
+	) {
+	}
+}

--- a/src/Client/Dto/RetentionPolicyForChannelList.php
+++ b/src/Client/Dto/RetentionPolicyForChannelList.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class RetentionPolicyForChannelList extends SpatieData
+{
+	public function __construct(
+		public ?array $policies = null,
+		#[MapName('total_count')]
+		public ?int $totalCount = null,
+	) {
+	}
+}

--- a/src/Client/Dto/RetentionPolicyForTeamList.php
+++ b/src/Client/Dto/RetentionPolicyForTeamList.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class RetentionPolicyForTeamList extends SpatieData
+{
+	public function __construct(
+		public ?array $policies = null,
+		#[MapName('total_count')]
+		public ?int $totalCount = null,
+	) {
+	}
+}

--- a/src/Client/Dto/Role.php
+++ b/src/Client/Dto/Role.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class Role extends SpatieData
+{
+	public function __construct(
+		public ?string $description = null,
+		#[MapName('display_name')]
+		public ?string $displayName = null,
+		public ?string $id = null,
+		public ?string $name = null,
+		public ?array $permissions = null,
+		#[MapName('scheme_managed')]
+		public ?bool $schemeManaged = null,
+	) {
+	}
+}

--- a/src/Client/Dto/SamlCertificateStatus.php
+++ b/src/Client/Dto/SamlCertificateStatus.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class SamlCertificateStatus extends SpatieData
+{
+	public function __construct(
+		#[MapName('idp_certificate_file')]
+		public ?bool $idpCertificateFile = null,
+		#[MapName('private_key_file')]
+		public ?bool $privateKeyFile = null,
+		#[MapName('public_certificate_file')]
+		public ?bool $publicCertificateFile = null,
+	) {
+	}
+}

--- a/src/Client/Dto/Scheme.php
+++ b/src/Client/Dto/Scheme.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class Scheme extends SpatieData
+{
+	public function __construct(
+		#[MapName('create_at')]
+		public ?int $createAt = null,
+		#[MapName('default_channel_admin_role')]
+		public ?string $defaultChannelAdminRole = null,
+		#[MapName('default_channel_user_role')]
+		public ?string $defaultChannelUserRole = null,
+		#[MapName('default_team_admin_role')]
+		public ?string $defaultTeamAdminRole = null,
+		#[MapName('default_team_user_role')]
+		public ?string $defaultTeamUserRole = null,
+		#[MapName('delete_at')]
+		public ?int $deleteAt = null,
+		public ?string $description = null,
+		public ?string $id = null,
+		public ?string $name = null,
+		public ?string $scope = null,
+		#[MapName('update_at')]
+		public ?int $updateAt = null,
+	) {
+	}
+}

--- a/src/Client/Dto/ServerBusy.php
+++ b/src/Client/Dto/ServerBusy.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Data as SpatieData;
+
+class ServerBusy extends SpatieData
+{
+	public function __construct(
+		public ?bool $busy = null,
+		public ?int $expires = null,
+	) {
+	}
+}

--- a/src/Client/Dto/Session.php
+++ b/src/Client/Dto/Session.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class Session extends SpatieData
+{
+	public function __construct(
+		#[MapName('create_at')]
+		public ?int $createAt = null,
+		#[MapName('device_id')]
+		public ?string $deviceId = null,
+		#[MapName('expires_at')]
+		public ?int $expiresAt = null,
+		public ?string $id = null,
+		#[MapName('is_oauth')]
+		public ?bool $isOauth = null,
+		#[MapName('last_activity_at')]
+		public ?int $lastActivityAt = null,
+		public ?object $props = null,
+		public ?string $roles = null,
+		#[MapName('team_members')]
+		public ?array $teamMembers = null,
+		public ?string $token = null,
+		#[MapName('user_id')]
+		public ?string $userId = null,
+	) {
+	}
+}

--- a/src/Client/Dto/SharedChannel.php
+++ b/src/Client/Dto/SharedChannel.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class SharedChannel extends SpatieData
+{
+	public function __construct(
+		#[MapName('create_at')]
+		public ?int $createAt = null,
+		#[MapName('creator_id')]
+		public ?string $creatorId = null,
+		#[MapName('display_name')]
+		public ?string $displayName = null,
+		public ?string $header = null,
+		public ?bool $home = null,
+		public ?string $id = null,
+		public ?string $name = null,
+		public ?string $purpose = null,
+		public ?bool $readonly = null,
+		#[MapName('remote_id')]
+		public ?string $remoteId = null,
+		#[MapName('team_id')]
+		public ?string $teamId = null,
+		#[MapName('update_at')]
+		public ?int $updateAt = null,
+	) {
+	}
+}

--- a/src/Client/Dto/SidebarCategory.php
+++ b/src/Client/Dto/SidebarCategory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+/**
+ * User's sidebar category
+ */
+class SidebarCategory extends SpatieData
+{
+	public function __construct(
+		#[MapName('display_name')]
+		public ?string $displayName = null,
+		public ?string $id = null,
+		#[MapName('team_id')]
+		public ?string $teamId = null,
+		public ?string $type = null,
+		#[MapName('user_id')]
+		public ?string $userId = null,
+	) {
+	}
+}

--- a/src/Client/Dto/SidebarCategoryWithChannels.php
+++ b/src/Client/Dto/SidebarCategoryWithChannels.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+/**
+ * User's sidebar category with it's channels
+ */
+class SidebarCategoryWithChannels extends SpatieData
+{
+	public function __construct(
+		#[MapName('channel_ids')]
+		public ?array $channelIds = null,
+		#[MapName('display_name')]
+		public ?string $displayName = null,
+		public ?string $id = null,
+		#[MapName('team_id')]
+		public ?string $teamId = null,
+		public ?string $type = null,
+		#[MapName('user_id')]
+		public ?string $userId = null,
+	) {
+	}
+}

--- a/src/Client/Dto/SlackAttachment.php
+++ b/src/Client/Dto/SlackAttachment.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class SlackAttachment extends SpatieData
+{
+	public function __construct(
+		#[MapName('AuthorIcon')]
+		public ?string $authorIcon = null,
+		#[MapName('AuthorLink')]
+		public ?string $authorLink = null,
+		#[MapName('AuthorName')]
+		public ?string $authorName = null,
+		#[MapName('Color')]
+		public ?string $color = null,
+		#[MapName('Fallback')]
+		public ?string $fallback = null,
+		#[MapName('Fields')]
+		public ?array $fields = null,
+		#[MapName('Footer')]
+		public ?string $footer = null,
+		#[MapName('FooterIcon')]
+		public ?string $footerIcon = null,
+		#[MapName('Id')]
+		public ?string $id = null,
+		#[MapName('ImageURL')]
+		public ?string $imageUrl = null,
+		#[MapName('Pretext')]
+		public ?string $pretext = null,
+		#[MapName('Text')]
+		public ?string $text = null,
+		#[MapName('ThumbURL')]
+		public ?string $thumbUrl = null,
+		#[MapName('Timestamp')]
+		public ?string $timestamp = null,
+		#[MapName('Title')]
+		public ?string $title = null,
+		#[MapName('TitleLink')]
+		public ?string $titleLink = null,
+	) {
+	}
+}

--- a/src/Client/Dto/SlackAttachmentField.php
+++ b/src/Client/Dto/SlackAttachmentField.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class SlackAttachmentField extends SpatieData
+{
+	public function __construct(
+		#[MapName('Short')]
+		public ?bool $short = null,
+		#[MapName('Title')]
+		public ?string $title = null,
+		#[MapName('Value')]
+		public ?string $value = null,
+	) {
+	}
+}

--- a/src/Client/Dto/Status.php
+++ b/src/Client/Dto/Status.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class Status extends SpatieData
+{
+	public function __construct(
+		#[MapName('last_activity_at')]
+		public ?int $lastActivityAt = null,
+		public ?bool $manual = null,
+		public ?string $status = null,
+		#[MapName('user_id')]
+		public ?string $userId = null,
+	) {
+	}
+}

--- a/src/Client/Dto/StatusOk.php
+++ b/src/Client/Dto/StatusOk.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Data as SpatieData;
+
+class StatusOk extends SpatieData
+{
+	public function __construct(
+		public ?string $status = null,
+	) {
+	}
+}

--- a/src/Client/Dto/StorageUsage.php
+++ b/src/Client/Dto/StorageUsage.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Data as SpatieData;
+
+class StorageUsage extends SpatieData
+{
+	public function __construct(
+		public int|float|null $bytes = null,
+	) {
+	}
+}

--- a/src/Client/Dto/Subscription.php
+++ b/src/Client/Dto/Subscription.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class Subscription extends SpatieData
+{
+	public function __construct(
+		#[MapName('add_ons')]
+		public ?array $addOns = null,
+		#[MapName('create_at')]
+		public ?int $createAt = null,
+		#[MapName('customer_id')]
+		public ?string $customerId = null,
+		public ?string $dns = null,
+		#[MapName('end_at')]
+		public ?int $endAt = null,
+		public ?string $id = null,
+		#[MapName('product_id')]
+		public ?string $productId = null,
+		public ?int $seats = null,
+		#[MapName('start_at')]
+		public ?int $startAt = null,
+	) {
+	}
+}

--- a/src/Client/Dto/SubscriptionStats.php
+++ b/src/Client/Dto/SubscriptionStats.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class SubscriptionStats extends SpatieData
+{
+	public function __construct(
+		#[MapName('is_paid_tier')]
+		public ?string $isPaidTier = null,
+		#[MapName('remaining_seats')]
+		public ?int $remainingSeats = null,
+	) {
+	}
+}

--- a/src/Client/Dto/System.php
+++ b/src/Client/Dto/System.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Data as SpatieData;
+
+class System extends SpatieData
+{
+	public function __construct(
+		public ?string $name = null,
+		public ?string $value = null,
+	) {
+	}
+}

--- a/src/Client/Dto/SystemStatusResponse.php
+++ b/src/Client/Dto/SystemStatusResponse.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class SystemStatusResponse extends SpatieData
+{
+	public function __construct(
+		#[MapName('AndroidLatestVersion')]
+		public ?string $androidLatestVersion = null,
+		#[MapName('AndroidMinVersion')]
+		public ?string $androidMinVersion = null,
+		#[MapName('CanReceiveNotifications')]
+		public ?string $canReceiveNotifications = null,
+		#[MapName('DesktopLatestVersion')]
+		public ?string $desktopLatestVersion = null,
+		#[MapName('DesktopMinVersion')]
+		public ?string $desktopMinVersion = null,
+		#[MapName('IosLatestVersion')]
+		public ?string $iosLatestVersion = null,
+		#[MapName('IosMinVersion')]
+		public ?string $iosMinVersion = null,
+		#[MapName('database_status')]
+		public ?string $databaseStatus = null,
+		#[MapName('filestore_status')]
+		public ?string $filestoreStatus = null,
+		public ?string $status = null,
+	) {
+	}
+}

--- a/src/Client/Dto/Team.php
+++ b/src/Client/Dto/Team.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class Team extends SpatieData
+{
+	public function __construct(
+		#[MapName('allow_open_invite')]
+		public ?bool $allowOpenInvite = null,
+		#[MapName('allowed_domains')]
+		public ?string $allowedDomains = null,
+		#[MapName('create_at')]
+		public ?int $createAt = null,
+		#[MapName('delete_at')]
+		public ?int $deleteAt = null,
+		public ?string $description = null,
+		#[MapName('display_name')]
+		public ?string $displayName = null,
+		public ?string $email = null,
+		public ?string $id = null,
+		#[MapName('invite_id')]
+		public ?string $inviteId = null,
+		public ?string $name = null,
+		#[MapName('policy_id')]
+		public ?string $policyId = null,
+		public ?string $type = null,
+		#[MapName('update_at')]
+		public ?int $updateAt = null,
+	) {
+	}
+}

--- a/src/Client/Dto/TeamExists.php
+++ b/src/Client/Dto/TeamExists.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Data as SpatieData;
+
+class TeamExists extends SpatieData
+{
+	public function __construct(
+		public ?bool $exists = null,
+	) {
+	}
+}

--- a/src/Client/Dto/TeamMap.php
+++ b/src/Client/Dto/TeamMap.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+/**
+ * A mapping of teamIds to teams.
+ */
+class TeamMap extends SpatieData
+{
+	public function __construct(
+		#[MapName('team_id')]
+		public ?Team $teamId = null,
+	) {
+	}
+}

--- a/src/Client/Dto/TeamMember.php
+++ b/src/Client/Dto/TeamMember.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class TeamMember extends SpatieData
+{
+	public function __construct(
+		#[MapName('delete_at')]
+		public ?int $deleteAt = null,
+		#[MapName('explicit_roles')]
+		public ?string $explicitRoles = null,
+		public ?string $roles = null,
+		#[MapName('scheme_admin')]
+		public ?bool $schemeAdmin = null,
+		#[MapName('scheme_user')]
+		public ?bool $schemeUser = null,
+		#[MapName('team_id')]
+		public ?string $teamId = null,
+		#[MapName('user_id')]
+		public ?string $userId = null,
+	) {
+	}
+}

--- a/src/Client/Dto/TeamStats.php
+++ b/src/Client/Dto/TeamStats.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class TeamStats extends SpatieData
+{
+	public function __construct(
+		#[MapName('active_member_count')]
+		public ?int $activeMemberCount = null,
+		#[MapName('team_id')]
+		public ?string $teamId = null,
+		#[MapName('total_member_count')]
+		public ?int $totalMemberCount = null,
+	) {
+	}
+}

--- a/src/Client/Dto/TeamUnread.php
+++ b/src/Client/Dto/TeamUnread.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class TeamUnread extends SpatieData
+{
+	public function __construct(
+		#[MapName('mention_count')]
+		public ?int $mentionCount = null,
+		#[MapName('msg_count')]
+		public ?int $msgCount = null,
+		#[MapName('team_id')]
+		public ?string $teamId = null,
+	) {
+	}
+}

--- a/src/Client/Dto/TeamsLimits.php
+++ b/src/Client/Dto/TeamsLimits.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Data as SpatieData;
+
+class TeamsLimits extends SpatieData
+{
+	public function __construct(
+		public ?int $active = null,
+	) {
+	}
+}

--- a/src/Client/Dto/TermsOfService.php
+++ b/src/Client/Dto/TermsOfService.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class TermsOfService extends SpatieData
+{
+	public function __construct(
+		#[MapName('create_at')]
+		public ?int $createAt = null,
+		public ?string $id = null,
+		public ?string $text = null,
+		#[MapName('user_id')]
+		public ?string $userId = null,
+	) {
+	}
+}

--- a/src/Client/Dto/Timezone.php
+++ b/src/Client/Dto/Timezone.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Data as SpatieData;
+
+class Timezone extends SpatieData
+{
+	public function __construct(
+		public ?string $automaticTimezone = null,
+		public ?string $manualTimezone = null,
+		public ?bool $useAutomaticTimezone = null,
+	) {
+	}
+}

--- a/src/Client/Dto/TopChannel.php
+++ b/src/Client/Dto/TopChannel.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class TopChannel extends SpatieData
+{
+	public function __construct(
+		#[MapName('display_name')]
+		public ?string $displayName = null,
+		public ?string $id = null,
+		#[MapName('message_count')]
+		public ?string $messageCount = null,
+		public ?string $name = null,
+		#[MapName('team_id')]
+		public ?string $teamId = null,
+		public ?string $type = null,
+	) {
+	}
+}

--- a/src/Client/Dto/TopChannelList.php
+++ b/src/Client/Dto/TopChannelList.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class TopChannelList extends SpatieData
+{
+	public function __construct(
+		#[MapName('has_next')]
+		public ?bool $hasNext = null,
+		public ?array $items = null,
+	) {
+	}
+}

--- a/src/Client/Dto/TopDm.php
+++ b/src/Client/Dto/TopDm.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class TopDm extends SpatieData
+{
+	public function __construct(
+		#[MapName('outgoing_message_count')]
+		public ?int $outgoingMessageCount = null,
+		#[MapName('post_count')]
+		public ?int $postCount = null,
+		#[MapName('second_participant')]
+		public ?TopDminsightUserInformation $secondParticipant = null,
+	) {
+	}
+}

--- a/src/Client/Dto/TopDminsightUserInformation.php
+++ b/src/Client/Dto/TopDminsightUserInformation.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Data as SpatieData;
+
+class TopDminsightUserInformation extends SpatieData
+{
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Dto/TopDmlist.php
+++ b/src/Client/Dto/TopDmlist.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class TopDmlist extends SpatieData
+{
+	public function __construct(
+		#[MapName('has_next')]
+		public ?bool $hasNext = null,
+		public ?array $items = null,
+	) {
+	}
+}

--- a/src/Client/Dto/TopReaction.php
+++ b/src/Client/Dto/TopReaction.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class TopReaction extends SpatieData
+{
+	public function __construct(
+		public ?int $count = null,
+		#[MapName('emoji_name')]
+		public ?string $emojiName = null,
+	) {
+	}
+}

--- a/src/Client/Dto/TopReactionList.php
+++ b/src/Client/Dto/TopReactionList.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class TopReactionList extends SpatieData
+{
+	public function __construct(
+		#[MapName('has_next')]
+		public ?bool $hasNext = null,
+		public ?array $items = null,
+	) {
+	}
+}

--- a/src/Client/Dto/TopThread.php
+++ b/src/Client/Dto/TopThread.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class TopThread extends SpatieData
+{
+	public function __construct(
+		#[MapName('Participants')]
+		public ?array $participants = null,
+		#[MapName('channel_display_name')]
+		public ?string $channelDisplayName = null,
+		#[MapName('channel_id')]
+		public ?string $channelId = null,
+		#[MapName('channel_name')]
+		public ?string $channelName = null,
+		public ?Post $post = null,
+		#[MapName('user_information')]
+		public ?InsightUserInformation $userInformation = null,
+	) {
+	}
+}

--- a/src/Client/Dto/TopThreadList.php
+++ b/src/Client/Dto/TopThreadList.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class TopThreadList extends SpatieData
+{
+	public function __construct(
+		#[MapName('has_next')]
+		public ?bool $hasNext = null,
+		public ?array $items = null,
+	) {
+	}
+}

--- a/src/Client/Dto/TriggerIdReturn.php
+++ b/src/Client/Dto/TriggerIdReturn.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class TriggerIdReturn extends SpatieData
+{
+	public function __construct(
+		#[MapName('trigger_id')]
+		public ?string $triggerId = null,
+	) {
+	}
+}

--- a/src/Client/Dto/UploadSession.php
+++ b/src/Client/Dto/UploadSession.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+/**
+ * an object containing information used to keep track of a file upload.
+ */
+class UploadSession extends SpatieData
+{
+	public function __construct(
+		#[MapName('channel_id')]
+		public ?string $channelId = null,
+		#[MapName('create_at')]
+		public ?int $createAt = null,
+		#[MapName('file_offset')]
+		public ?int $fileOffset = null,
+		#[MapName('file_size')]
+		public ?int $fileSize = null,
+		public ?string $filename = null,
+		public ?string $id = null,
+		public ?string $type = null,
+		#[MapName('user_id')]
+		public ?string $userId = null,
+	) {
+	}
+}

--- a/src/Client/Dto/User.php
+++ b/src/Client/Dto/User.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class User extends SpatieData
+{
+	public function __construct(
+		#[MapName('auth_service')]
+		public ?string $authService = null,
+		#[MapName('create_at')]
+		public ?int $createAt = null,
+		#[MapName('delete_at')]
+		public ?int $deleteAt = null,
+		public ?string $email = null,
+		#[MapName('email_verified')]
+		public ?bool $emailVerified = null,
+		#[MapName('failed_attempts')]
+		public ?int $failedAttempts = null,
+		#[MapName('first_name')]
+		public ?string $firstName = null,
+		public ?string $id = null,
+		#[MapName('last_name')]
+		public ?string $lastName = null,
+		#[MapName('last_password_update')]
+		public ?int $lastPasswordUpdate = null,
+		#[MapName('last_picture_update')]
+		public ?int $lastPictureUpdate = null,
+		public ?string $locale = null,
+		#[MapName('mfa_active')]
+		public ?bool $mfaActive = null,
+		public ?string $nickname = null,
+		#[MapName('notify_props')]
+		public ?UserNotifyProps $notifyProps = null,
+		public ?object $props = null,
+		public ?string $roles = null,
+		#[MapName('terms_of_service_create_at')]
+		public ?int $termsOfServiceCreateAt = null,
+		#[MapName('terms_of_service_id')]
+		public ?string $termsOfServiceId = null,
+		public ?Timezone $timezone = null,
+		#[MapName('update_at')]
+		public ?int $updateAt = null,
+		public ?string $username = null,
+	) {
+	}
+}

--- a/src/Client/Dto/UserAccessToken.php
+++ b/src/Client/Dto/UserAccessToken.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class UserAccessToken extends SpatieData
+{
+	public function __construct(
+		public ?string $description = null,
+		public ?string $id = null,
+		public ?string $token = null,
+		#[MapName('user_id')]
+		public ?string $userId = null,
+	) {
+	}
+}

--- a/src/Client/Dto/UserAccessTokenSanitized.php
+++ b/src/Client/Dto/UserAccessTokenSanitized.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class UserAccessTokenSanitized extends SpatieData
+{
+	public function __construct(
+		public ?string $description = null,
+		public ?string $id = null,
+		#[MapName('is_active')]
+		public ?bool $isActive = null,
+		#[MapName('user_id')]
+		public ?string $userId = null,
+	) {
+	}
+}

--- a/src/Client/Dto/UserAuthData.php
+++ b/src/Client/Dto/UserAuthData.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class UserAuthData extends SpatieData
+{
+	public function __construct(
+		#[MapName('auth_data')]
+		public ?string $authData = null,
+		#[MapName('auth_service')]
+		public ?string $authService = null,
+	) {
+	}
+}

--- a/src/Client/Dto/UserAutocomplete.php
+++ b/src/Client/Dto/UserAutocomplete.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class UserAutocomplete extends SpatieData
+{
+	public function __construct(
+		#[MapName('out_of_channel')]
+		public ?array $outOfChannel = null,
+		public ?array $users = null,
+	) {
+	}
+}

--- a/src/Client/Dto/UserAutocompleteInChannel.php
+++ b/src/Client/Dto/UserAutocompleteInChannel.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class UserAutocompleteInChannel extends SpatieData
+{
+	public function __construct(
+		#[MapName('in_channel')]
+		public ?array $inChannel = null,
+		#[MapName('out_of_channel')]
+		public ?array $outOfChannel = null,
+	) {
+	}
+}

--- a/src/Client/Dto/UserAutocompleteInTeam.php
+++ b/src/Client/Dto/UserAutocompleteInTeam.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class UserAutocompleteInTeam extends SpatieData
+{
+	public function __construct(
+		#[MapName('in_team')]
+		public ?array $inTeam = null,
+	) {
+	}
+}

--- a/src/Client/Dto/UserNotifyProps.php
+++ b/src/Client/Dto/UserNotifyProps.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class UserNotifyProps extends SpatieData
+{
+	public function __construct(
+		public ?string $channel = null,
+		public ?string $desktop = null,
+		#[MapName('desktop_sound')]
+		public ?string $desktopSound = null,
+		public ?string $email = null,
+		#[MapName('first_name')]
+		public ?string $firstName = null,
+		#[MapName('mention_keys')]
+		public ?string $mentionKeys = null,
+		public ?string $push = null,
+	) {
+	}
+}

--- a/src/Client/Dto/UserTermsOfService.php
+++ b/src/Client/Dto/UserTermsOfService.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class UserTermsOfService extends SpatieData
+{
+	public function __construct(
+		#[MapName('create_at')]
+		public ?int $createAt = null,
+		#[MapName('terms_of_service_id')]
+		public ?string $termsOfServiceId = null,
+		#[MapName('user_id')]
+		public ?string $userId = null,
+	) {
+	}
+}

--- a/src/Client/Dto/UserThread.php
+++ b/src/Client/Dto/UserThread.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+/**
+ * a thread that user is following
+ */
+class UserThread extends SpatieData
+{
+	public function __construct(
+		public ?string $id = null,
+		#[MapName('last_reply_at')]
+		public ?int $lastReplyAt = null,
+		#[MapName('last_viewed_at')]
+		public ?int $lastViewedAt = null,
+		public ?array $participants = null,
+		public ?Post $post = null,
+		#[MapName('reply_count')]
+		public ?int $replyCount = null,
+	) {
+	}
+}

--- a/src/Client/Dto/UserThreads.php
+++ b/src/Client/Dto/UserThreads.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Data as SpatieData;
+
+class UserThreads extends SpatieData
+{
+	public function __construct(
+		public ?array $threads = null,
+		public ?int $total = null,
+	) {
+	}
+}

--- a/src/Client/Dto/UsersStats.php
+++ b/src/Client/Dto/UsersStats.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Data as SpatieData;
+
+class UsersStats extends SpatieData
+{
+	public function __construct(
+		#[MapName('total_users_count')]
+		public ?int $totalUsersCount = null,
+	) {
+	}
+}

--- a/src/Client/Dto/WebhookOnCreationPayload.php
+++ b/src/Client/Dto/WebhookOnCreationPayload.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Data as SpatieData;
+
+class WebhookOnCreationPayload extends SpatieData
+{
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Dto/WebhookOnStatusUpdatePayload.php
+++ b/src/Client/Dto/WebhookOnStatusUpdatePayload.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Dto;
+
+use Spatie\LaravelData\Data as SpatieData;
+
+class WebhookOnStatusUpdatePayload extends SpatieData
+{
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Mattermost.php
+++ b/src/Client/Mattermost.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client;
+
+use ConduitUI\Mattermost\Client\Resource\Bots;
+use ConduitUI\Mattermost\Client\Resource\Channels;
+use ConduitUI\Mattermost\Client\Resource\Commands;
+use ConduitUI\Mattermost\Client\Resource\DataRetention;
+use ConduitUI\Mattermost\Client\Resource\Emoji;
+use ConduitUI\Mattermost\Client\Resource\Files;
+use ConduitUI\Mattermost\Client\Resource\Groups;
+use ConduitUI\Mattermost\Client\Resource\Insights;
+use ConduitUI\Mattermost\Client\Resource\Oauth;
+use ConduitUI\Mattermost\Client\Resource\Posts;
+use ConduitUI\Mattermost\Client\Resource\Preferences;
+use ConduitUI\Mattermost\Client\Resource\Reactions;
+use ConduitUI\Mattermost\Client\Resource\Status;
+use ConduitUI\Mattermost\Client\Resource\System;
+use ConduitUI\Mattermost\Client\Resource\Teams;
+use ConduitUI\Mattermost\Client\Resource\Threads;
+use ConduitUI\Mattermost\Client\Resource\Users;
+use ConduitUI\Mattermost\Client\Resource\Webhooks;
+use Saloon\Contracts\Authenticator;
+use Saloon\Http\Auth\MultiAuthenticator;
+use Saloon\Http\Auth\TokenAuthenticator;
+use Saloon\Http\Connector;
+
+/**
+ * Mattermost API Reference
+ *
+ * There is also a work-in-progress [Postman API reference](https://documenter.getpostman.com/view/4508214/RW8FERUn).
+ */
+class Mattermost extends Connector
+{
+	/**
+	 * @param string $bearerToken
+	 * @param string $bearerToken
+	 */
+	public function __construct(
+		protected string $bearerToken,
+	) {
+	}
+
+
+	public function resolveBaseUrl(): string
+	{
+		return "http://your-mattermost-url.com";
+	}
+
+
+	public function defaultAuth(): ?Authenticator
+	{
+		return new MultiAuthenticator(
+			new TokenAuthenticator($this->bearerToken, "Bearer"),
+			new TokenAuthenticator($this->bearerToken, "Bearer")
+		);
+	}
+
+
+	public function bots(): Bots
+	{
+		return new Bots($this);
+	}
+
+
+	public function channels(): Channels
+	{
+		return new Channels($this);
+	}
+
+
+	public function commands(): Commands
+	{
+		return new Commands($this);
+	}
+
+
+	public function dataRetention(): DataRetention
+	{
+		return new DataRetention($this);
+	}
+
+
+	public function emoji(): Emoji
+	{
+		return new Emoji($this);
+	}
+
+
+	public function files(): Files
+	{
+		return new Files($this);
+	}
+
+
+	public function groups(): Groups
+	{
+		return new Groups($this);
+	}
+
+
+	public function insights(): Insights
+	{
+		return new Insights($this);
+	}
+
+
+	public function oauth(): Oauth
+	{
+		return new Oauth($this);
+	}
+
+
+	public function posts(): Posts
+	{
+		return new Posts($this);
+	}
+
+
+	public function preferences(): Preferences
+	{
+		return new Preferences($this);
+	}
+
+
+	public function reactions(): Reactions
+	{
+		return new Reactions($this);
+	}
+
+
+	public function status(): Status
+	{
+		return new Status($this);
+	}
+
+
+	public function system(): System
+	{
+		return new System($this);
+	}
+
+
+	public function teams(): Teams
+	{
+		return new Teams($this);
+	}
+
+
+	public function threads(): Threads
+	{
+		return new Threads($this);
+	}
+
+
+	public function users(): Users
+	{
+		return new Users($this);
+	}
+
+
+	public function webhooks(): Webhooks
+	{
+		return new Webhooks($this);
+	}
+}

--- a/src/Client/Requests/Bots/AssignBot.php
+++ b/src/Client/Requests/Bots/AssignBot.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Bots;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * AssignBot
+ *
+ * Assign a bot to a specified user.
+ * ##### Permissions
+ * Must have `manage_bots` permission.
+ * __Minimum
+ * server version__: 5.10
+ */
+class AssignBot extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/bots/{$this->botUserId}/assign/{$this->userId}";
+	}
+
+
+	/**
+	 * @param string $botUserId Bot user ID
+	 * @param string $userId The user ID to assign the bot to.
+	 */
+	public function __construct(
+		protected string $botUserId,
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Bots/ConvertBotToUser.php
+++ b/src/Client/Requests/Bots/ConvertBotToUser.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Bots;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * ConvertBotToUser
+ *
+ * Convert a bot into a user.
+ *
+ * __Minimum server version__: 5.26
+ *
+ * ##### Permissions
+ * Must have
+ * `manage_system` permission.
+ */
+class ConvertBotToUser extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/bots/{$this->botUserId}/convert_to_user";
+	}
+
+
+	/**
+	 * @param string $botUserId Bot user ID
+	 * @param null|bool $setSystemAdmin Whether to give the user the system admin role.
+	 */
+	public function __construct(
+		protected string $botUserId,
+		protected ?bool $setSystemAdmin = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['set_system_admin' => $this->setSystemAdmin]);
+	}
+}

--- a/src/Client/Requests/Bots/ConvertUserToBot.php
+++ b/src/Client/Requests/Bots/ConvertUserToBot.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Bots;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * ConvertUserToBot
+ *
+ * Convert a user into a bot.
+ *
+ * __Minimum server version__: 5.26
+ *
+ * ##### Permissions
+ * Must have
+ * `manage_system` permission.
+ */
+class ConvertUserToBot extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/convert_to_bot";
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function __construct(
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Bots/CreateBot.php
+++ b/src/Client/Requests/Bots/CreateBot.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Bots;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * CreateBot
+ *
+ * Create a new bot account on the system. Username is required.
+ * ##### Permissions
+ * Must have
+ * `create_bot` permission.
+ * __Minimum server version__: 5.10
+ */
+class CreateBot extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/bots";
+	}
+
+
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Requests/Bots/DisableBot.php
+++ b/src/Client/Requests/Bots/DisableBot.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Bots;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * DisableBot
+ *
+ * Disable a bot.
+ * ##### Permissions
+ * Must have `manage_bots` permission.
+ * __Minimum server version__:
+ * 5.10
+ */
+class DisableBot extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/bots/{$this->botUserId}/disable";
+	}
+
+
+	/**
+	 * @param string $botUserId Bot user ID
+	 */
+	public function __construct(
+		protected string $botUserId,
+	) {
+	}
+}

--- a/src/Client/Requests/Bots/EnableBot.php
+++ b/src/Client/Requests/Bots/EnableBot.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Bots;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * EnableBot
+ *
+ * Enable a bot.
+ * ##### Permissions
+ * Must have `manage_bots` permission.
+ * __Minimum server version__:
+ * 5.10
+ */
+class EnableBot extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/bots/{$this->botUserId}/enable";
+	}
+
+
+	/**
+	 * @param string $botUserId Bot user ID
+	 */
+	public function __construct(
+		protected string $botUserId,
+	) {
+	}
+}

--- a/src/Client/Requests/Bots/GetBot.php
+++ b/src/Client/Requests/Bots/GetBot.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Bots;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetBot
+ *
+ * Get a bot specified by its bot id.
+ * ##### Permissions
+ * Must have `read_bots` permission for bots you
+ * are managing, and `read_others_bots` permission for bots others are managing.
+ * __Minimum server
+ * version__: 5.10
+ */
+class GetBot extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/bots/{$this->botUserId}";
+	}
+
+
+	/**
+	 * @param string $botUserId Bot user ID
+	 * @param null|bool $includeDeleted If deleted bots should be returned.
+	 */
+	public function __construct(
+		protected string $botUserId,
+		protected ?bool $includeDeleted = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['include_deleted' => $this->includeDeleted]);
+	}
+}

--- a/src/Client/Requests/Bots/GetBots.php
+++ b/src/Client/Requests/Bots/GetBots.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Bots;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetBots
+ *
+ * Get a page of a list of bots.
+ * ##### Permissions
+ * Must have `read_bots` permission for bots you are
+ * managing, and `read_others_bots` permission for bots others are managing.
+ * __Minimum server
+ * version__: 5.10
+ */
+class GetBots extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/bots";
+	}
+
+
+	/**
+	 * @param null|int $page The page to select.
+	 * @param null|bool $includeDeleted If deleted bots should be returned.
+	 * @param null|bool $onlyOrphaned When true, only orphaned bots will be returned. A bot is consitered orphaned if it's owner has been deactivated.
+	 */
+	public function __construct(
+		protected ?int $page = null,
+		protected ?bool $includeDeleted = null,
+		protected ?bool $onlyOrphaned = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['page' => $this->page, 'include_deleted' => $this->includeDeleted, 'only_orphaned' => $this->onlyOrphaned]);
+	}
+}

--- a/src/Client/Requests/Bots/PatchBot.php
+++ b/src/Client/Requests/Bots/PatchBot.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Bots;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * PatchBot
+ *
+ * Partially update a bot by providing only the fields you want to update. Omitted fields will not be
+ * updated. The fields that can be updated are defined in the request body, all other provided fields
+ * will be ignored.
+ * ##### Permissions
+ * Must have `manage_bots` permission.
+ * __Minimum server version__:
+ * 5.10
+ */
+class PatchBot extends Request
+{
+	protected Method $method = Method::PUT;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/bots/{$this->botUserId}";
+	}
+
+
+	/**
+	 * @param string $botUserId Bot user ID
+	 */
+	public function __construct(
+		protected string $botUserId,
+	) {
+	}
+}

--- a/src/Client/Requests/Channels/AddChannelMember.php
+++ b/src/Client/Requests/Channels/AddChannelMember.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * AddChannelMember
+ *
+ * Add a user to a channel by creating a channel member object.
+ */
+class AddChannelMember extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/channels/{$this->channelId}/members";
+	}
+
+
+	/**
+	 * @param string $channelId The channel ID
+	 */
+	public function __construct(
+		protected string $channelId,
+	) {
+	}
+}

--- a/src/Client/Requests/Channels/AutocompleteChannelsForTeam.php
+++ b/src/Client/Requests/Channels/AutocompleteChannelsForTeam.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * AutocompleteChannelsForTeam
+ *
+ * Autocomplete public channels on a team based on the search term provided in the request
+ * URL.
+ *
+ * __Minimum server version__: 4.7
+ *
+ * ##### Permissions
+ * Must have the `list_team_channels`
+ * permission.
+ */
+class AutocompleteChannelsForTeam extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/{$this->teamId}/channels/autocomplete";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param string $name Name or display name
+	 */
+	public function __construct(
+		protected string $teamId,
+		protected string $name,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['name' => $this->name]);
+	}
+}

--- a/src/Client/Requests/Channels/AutocompleteChannelsForTeamForSearch.php
+++ b/src/Client/Requests/Channels/AutocompleteChannelsForTeamForSearch.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * AutocompleteChannelsForTeamForSearch
+ *
+ * Autocomplete your channels on a team based on the search term provided in the request
+ * URL.
+ *
+ * __Minimum server version__: 5.4
+ *
+ * ##### Permissions
+ * Must have the `list_team_channels`
+ * permission.
+ */
+class AutocompleteChannelsForTeamForSearch extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/{$this->teamId}/channels/search_autocomplete";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param string $name Name or display name
+	 */
+	public function __construct(
+		protected string $teamId,
+		protected string $name,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['name' => $this->name]);
+	}
+}

--- a/src/Client/Requests/Channels/ChannelMembersMinusGroupMembers.php
+++ b/src/Client/Requests/Channels/ChannelMembersMinusGroupMembers.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * ChannelMembersMinusGroupMembers
+ *
+ * Get the set of users who are members of the channel minus the set of users who are members of the
+ * given groups.
+ * Each user object contains an array of group objects representing the group memberships
+ * for that user.
+ * Each user object contains the boolean fields `scheme_guest`, `scheme_user`, and
+ * `scheme_admin` representing the roles that user has for the given channel.
+ *
+ * ##### Permissions
+ * Must
+ * have `manage_system` permission.
+ *
+ * __Minimum server version__: 5.14
+ */
+class ChannelMembersMinusGroupMembers extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/channels/{$this->channelId}/members_minus_group_members";
+	}
+
+
+	/**
+	 * @param string $channelId Channel GUID
+	 * @param string $groupIds A comma-separated list of group ids.
+	 * @param null|int $page The page to select.
+	 */
+	public function __construct(
+		protected string $channelId,
+		protected string $groupIds,
+		protected ?int $page = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['group_ids' => $this->groupIds, 'page' => $this->page]);
+	}
+}

--- a/src/Client/Requests/Channels/CreateChannel.php
+++ b/src/Client/Requests/Channels/CreateChannel.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * CreateChannel
+ *
+ * Create a new channel.
+ * ##### Permissions
+ * If creating a public channel, `create_public_channel`
+ * permission is required. If creating a private channel, `create_private_channel` permission is
+ * required.
+ */
+class CreateChannel extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/channels";
+	}
+
+
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Requests/Channels/CreateDirectChannel.php
+++ b/src/Client/Requests/Channels/CreateDirectChannel.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * CreateDirectChannel
+ *
+ * Create a new direct message channel between two users.
+ * ##### Permissions
+ * Must be one of the two
+ * users and have `create_direct_channel` permission. Having the `manage_system` permission voids the
+ * previous requirements.
+ */
+class CreateDirectChannel extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/channels/direct";
+	}
+
+
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Requests/Channels/CreateGroupChannel.php
+++ b/src/Client/Requests/Channels/CreateGroupChannel.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * CreateGroupChannel
+ *
+ * Create a new group message channel to group of users. If the logged in user's id is not included in
+ * the list, it will be appended to the end.
+ * ##### Permissions
+ * Must have `create_group_channel`
+ * permission.
+ */
+class CreateGroupChannel extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/channels/group";
+	}
+
+
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Requests/Channels/CreateSidebarCategoryForTeamForUser.php
+++ b/src/Client/Requests/Channels/CreateSidebarCategoryForTeamForUser.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * CreateSidebarCategoryForTeamForUser
+ *
+ * Create a custom sidebar category for the user on the given team.
+ * __Minimum server version__:
+ * 5.26
+ * ##### Permissions
+ * Must be authenticated and have the `list_team_channels` permission.
+ */
+class CreateSidebarCategoryForTeamForUser extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/channels/categories";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param string $userId User GUID
+	 */
+	public function __construct(
+		protected string $teamId,
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Channels/DeleteChannel.php
+++ b/src/Client/Requests/Channels/DeleteChannel.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * DeleteChannel
+ *
+ * Archives a channel. This will set the `deleteAt` to the current timestamp in the database. Soft
+ * deleted channels may not be accessible in the user interface. They can be viewed and unarchived in
+ * the **System Console > User Management > Channels** based on your license. Direct and group message
+ * channels cannot be deleted.
+ *
+ * As of server version 5.28, optionally use the `permanent=true` query
+ * parameter to permanently delete the channel for compliance reasons. To use this feature
+ * `ServiceSettings.EnableAPIChannelDeletion` must be set to `true` in the server's configuration.  If
+ * you permanently delete a channel this action is not recoverable outside of a database backup.
+ *
+ * #####
+ * Permissions
+ * `delete_public_channel` permission if the channel is public,
+ * `delete_private_channel`
+ * permission if the channel is private,
+ * or have `manage_system` permission.
+ */
+class DeleteChannel extends Request
+{
+	protected Method $method = Method::DELETE;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/channels/{$this->channelId}";
+	}
+
+
+	/**
+	 * @param string $channelId Channel GUID
+	 */
+	public function __construct(
+		protected string $channelId,
+	) {
+	}
+}

--- a/src/Client/Requests/Channels/GetAllChannels.php
+++ b/src/Client/Requests/Channels/GetAllChannels.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetAllChannels
+ *
+ * ##### Permissions
+ * `manage_system`
+ */
+class GetAllChannels extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/channels";
+	}
+
+
+	/**
+	 * @param null|string $notAssociatedToGroup A group id to exclude channels that are associated with that group via GroupChannel records. This can also be left blank with `not_associated_to_group=`.
+	 * @param null|int $page The page to select.
+	 * @param null|bool $excludeDefaultChannels Whether to exclude default channels (ex Town Square, Off-Topic) from the results.
+	 * @param null|bool $includeDeleted Include channels that have been archived. This correlates to the `DeleteAt` flag being set in the database.
+	 * @param null|bool $includeTotalCount Appends a total count of returned channels inside the response object - ex: `{ "channels": [], "total_count" : 0 }`.
+	 * @param null|bool $excludePolicyConstrained If set to true, channels which are part of a data retention policy will be excluded. The `sysconsole_read_compliance` permission is required to use this parameter.
+	 * __Minimum server version__: 5.35
+	 */
+	public function __construct(
+		protected ?string $notAssociatedToGroup = null,
+		protected ?int $page = null,
+		protected ?bool $excludeDefaultChannels = null,
+		protected ?bool $includeDeleted = null,
+		protected ?bool $includeTotalCount = null,
+		protected ?bool $excludePolicyConstrained = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter([
+			'not_associated_to_group' => $this->notAssociatedToGroup,
+			'page' => $this->page,
+			'exclude_default_channels' => $this->excludeDefaultChannels,
+			'include_deleted' => $this->includeDeleted,
+			'include_total_count' => $this->includeTotalCount,
+			'exclude_policy_constrained' => $this->excludePolicyConstrained,
+		]);
+	}
+}

--- a/src/Client/Requests/Channels/GetChannel.php
+++ b/src/Client/Requests/Channels/GetChannel.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetChannel
+ *
+ * Get channel from the provided channel id string.
+ * ##### Permissions
+ * `read_channel` permission for the
+ * channel.
+ */
+class GetChannel extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/channels/{$this->channelId}";
+	}
+
+
+	/**
+	 * @param string $channelId Channel GUID
+	 */
+	public function __construct(
+		protected string $channelId,
+	) {
+	}
+}

--- a/src/Client/Requests/Channels/GetChannelByName.php
+++ b/src/Client/Requests/Channels/GetChannelByName.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetChannelByName
+ *
+ * Gets channel from the provided team id and channel name strings.
+ * ##### Permissions
+ * `read_channel`
+ * permission for the channel.
+ */
+class GetChannelByName extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/{$this->teamId}/channels/name/{$this->channelName}";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param string $channelName Channel Name
+	 * @param null|bool $includeDeleted Defines if deleted channels should be returned or not (Mattermost Server 5.26.0+)
+	 */
+	public function __construct(
+		protected string $teamId,
+		protected string $channelName,
+		protected ?bool $includeDeleted = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['include_deleted' => $this->includeDeleted]);
+	}
+}

--- a/src/Client/Requests/Channels/GetChannelByNameForTeamName.php
+++ b/src/Client/Requests/Channels/GetChannelByNameForTeamName.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetChannelByNameForTeamName
+ *
+ * Gets a channel from the provided team name and channel name strings.
+ * #####
+ * Permissions
+ * `read_channel` permission for the channel.
+ */
+class GetChannelByNameForTeamName extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/name/{$this->teamName}/channels/name/{$this->channelName}";
+	}
+
+
+	/**
+	 * @param string $teamName Team Name
+	 * @param string $channelName Channel Name
+	 * @param null|bool $includeDeleted Defines if deleted channels should be returned or not (Mattermost Server 5.26.0+)
+	 */
+	public function __construct(
+		protected string $teamName,
+		protected string $channelName,
+		protected ?bool $includeDeleted = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['include_deleted' => $this->includeDeleted]);
+	}
+}

--- a/src/Client/Requests/Channels/GetChannelMember.php
+++ b/src/Client/Requests/Channels/GetChannelMember.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetChannelMember
+ *
+ * Get a channel member.
+ * ##### Permissions
+ * `read_channel` permission for the channel.
+ */
+class GetChannelMember extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/channels/{$this->channelId}/members/{$this->userId}";
+	}
+
+
+	/**
+	 * @param string $channelId Channel GUID
+	 * @param string $userId User GUID
+	 */
+	public function __construct(
+		protected string $channelId,
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Channels/GetChannelMemberCountsByGroup.php
+++ b/src/Client/Requests/Channels/GetChannelMemberCountsByGroup.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetChannelMemberCountsByGroup
+ *
+ * Returns a set of ChannelMemberCountByGroup objects which contain a `group_id`,
+ * `channel_member_count` and a `channel_member_timezones_count`.
+ * ##### Permissions
+ * Must have
+ * `read_channel` permission for the given channel.
+ * __Minimum server version__: 5.24
+ */
+class GetChannelMemberCountsByGroup extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/channels/{$this->channelId}/member_counts_by_group";
+	}
+
+
+	/**
+	 * @param string $channelId Channel GUID
+	 * @param null|bool $includeTimezones Defines if member timezone counts should be returned or not
+	 */
+	public function __construct(
+		protected string $channelId,
+		protected ?bool $includeTimezones = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['include_timezones' => $this->includeTimezones]);
+	}
+}

--- a/src/Client/Requests/Channels/GetChannelMembers.php
+++ b/src/Client/Requests/Channels/GetChannelMembers.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetChannelMembers
+ *
+ * Get a page of members for a channel.
+ * ##### Permissions
+ * `read_channel` permission for the channel.
+ */
+class GetChannelMembers extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/channels/{$this->channelId}/members";
+	}
+
+
+	/**
+	 * @param string $channelId Channel GUID
+	 * @param null|int $page The page to select.
+	 */
+	public function __construct(
+		protected string $channelId,
+		protected ?int $page = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['page' => $this->page]);
+	}
+}

--- a/src/Client/Requests/Channels/GetChannelMembersByIds.php
+++ b/src/Client/Requests/Channels/GetChannelMembersByIds.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * GetChannelMembersByIds
+ *
+ * Get a list of channel members based on the provided user ids.
+ * ##### Permissions
+ * Must have the
+ * `read_channel` permission.
+ */
+class GetChannelMembersByIds extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/channels/{$this->channelId}/members/ids";
+	}
+
+
+	/**
+	 * @param string $channelId Channel GUID
+	 */
+	public function __construct(
+		protected string $channelId,
+	) {
+	}
+}

--- a/src/Client/Requests/Channels/GetChannelMembersForUser.php
+++ b/src/Client/Requests/Channels/GetChannelMembersForUser.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetChannelMembersForUser
+ *
+ * Get all channel memberships and associated membership roles (i.e. `channel_user`, `channel_admin`)
+ * for a user on a specific team.
+ * ##### Permissions
+ * Logged in as the user and `view_team` permission
+ * for the team. Having `manage_system` permission voids the previous requirements.
+ */
+class GetChannelMembersForUser extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/channels/members";
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 * @param string $teamId Team GUID
+	 */
+	public function __construct(
+		protected string $userId,
+		protected string $teamId,
+	) {
+	}
+}

--- a/src/Client/Requests/Channels/GetChannelMembersTimezones.php
+++ b/src/Client/Requests/Channels/GetChannelMembersTimezones.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetChannelMembersTimezones
+ *
+ * Get a list of timezones for the users who are in this channel.
+ *
+ * __Minimum server version__:
+ * 5.6
+ *
+ * ##### Permissions
+ * Must have the `read_channel` permission.
+ */
+class GetChannelMembersTimezones extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/channels/{$this->channelId}/timezones";
+	}
+
+
+	/**
+	 * @param string $channelId Channel GUID
+	 */
+	public function __construct(
+		protected string $channelId,
+	) {
+	}
+}

--- a/src/Client/Requests/Channels/GetChannelModerations.php
+++ b/src/Client/Requests/Channels/GetChannelModerations.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetChannelModerations
+ *
+ * ##### Permissions
+ * Must have `manage_system` permission.
+ *
+ * __Minimum server version__: 5.22
+ */
+class GetChannelModerations extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/channels/{$this->channelId}/moderations";
+	}
+
+
+	/**
+	 * @param string $channelId Channel GUID
+	 */
+	public function __construct(
+		protected string $channelId,
+	) {
+	}
+}

--- a/src/Client/Requests/Channels/GetChannelStats.php
+++ b/src/Client/Requests/Channels/GetChannelStats.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetChannelStats
+ *
+ * Get statistics for a channel.
+ * ##### Permissions
+ * Must have the `read_channel` permission.
+ */
+class GetChannelStats extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/channels/{$this->channelId}/stats";
+	}
+
+
+	/**
+	 * @param string $channelId Channel GUID
+	 */
+	public function __construct(
+		protected string $channelId,
+	) {
+	}
+}

--- a/src/Client/Requests/Channels/GetChannelUnread.php
+++ b/src/Client/Requests/Channels/GetChannelUnread.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetChannelUnread
+ *
+ * Get the total unread messages and mentions for a channel for a user.
+ * ##### Permissions
+ * Must be
+ * logged in as user and have the `read_channel` permission, or have `edit_other_usrs` permission.
+ */
+class GetChannelUnread extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/channels/{$this->channelId}/unread";
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 * @param string $channelId Channel GUID
+	 */
+	public function __construct(
+		protected string $userId,
+		protected string $channelId,
+	) {
+	}
+}

--- a/src/Client/Requests/Channels/GetChannelsForTeamForUser.php
+++ b/src/Client/Requests/Channels/GetChannelsForTeamForUser.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetChannelsForTeamForUser
+ *
+ * Get all the channels on a team for a user.
+ * ##### Permissions
+ * Logged in as the user, or have
+ * `edit_other_users` permission, and `view_team` permission for the team.
+ */
+class GetChannelsForTeamForUser extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/channels";
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 * @param string $teamId Team GUID
+	 * @param null|bool $includeDeleted Defines if deleted channels should be returned or not
+	 * @param null|int $lastDeleteAt Filters the deleted channels by this time in epoch format. Does not have any effect if include_deleted is set to false.
+	 */
+	public function __construct(
+		protected string $userId,
+		protected string $teamId,
+		protected ?bool $includeDeleted = null,
+		protected ?int $lastDeleteAt = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['include_deleted' => $this->includeDeleted, 'last_delete_at' => $this->lastDeleteAt]);
+	}
+}

--- a/src/Client/Requests/Channels/GetChannelsForUser.php
+++ b/src/Client/Requests/Channels/GetChannelsForUser.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetChannelsForUser
+ *
+ * Get all channels from all teams that a user is a member of.
+ *
+ * __Minimum server version__: 6.1
+ *
+ * #####
+ * Permissions
+ *
+ * Logged in as the user, or have `edit_other_users` permission.
+ */
+class GetChannelsForUser extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/channels";
+	}
+
+
+	/**
+	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
+	 * @param null|int $lastDeleteAt Filters the deleted channels by this time in epoch format. Does not have any effect if include_deleted is set to false.
+	 * @param null|bool $includeDeleted Defines if deleted channels should be returned or not
+	 */
+	public function __construct(
+		protected string $userId,
+		protected ?int $lastDeleteAt = null,
+		protected ?bool $includeDeleted = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['last_delete_at' => $this->lastDeleteAt, 'include_deleted' => $this->includeDeleted]);
+	}
+}

--- a/src/Client/Requests/Channels/GetDeletedChannelsForTeam.php
+++ b/src/Client/Requests/Channels/GetDeletedChannelsForTeam.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetDeletedChannelsForTeam
+ *
+ * Get a page of deleted channels on a team based on query string parameters - team_id, page and
+ * per_page.
+ *
+ * __Minimum server version__: 3.10
+ */
+class GetDeletedChannelsForTeam extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/{$this->teamId}/channels/deleted";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param null|int $page The page to select.
+	 */
+	public function __construct(
+		protected string $teamId,
+		protected ?int $page = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['page' => $this->page]);
+	}
+}

--- a/src/Client/Requests/Channels/GetPinnedPosts.php
+++ b/src/Client/Requests/Channels/GetPinnedPosts.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetPinnedPosts
+ *
+ * Get a list of pinned posts for channel.
+ */
+class GetPinnedPosts extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/channels/{$this->channelId}/pinned";
+	}
+
+
+	/**
+	 * @param string $channelId Channel GUID
+	 */
+	public function __construct(
+		protected string $channelId,
+	) {
+	}
+}

--- a/src/Client/Requests/Channels/GetPrivateChannelsForTeam.php
+++ b/src/Client/Requests/Channels/GetPrivateChannelsForTeam.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetPrivateChannelsForTeam
+ *
+ * Get a page of private channels on a team based on query string
+ * parameters - team_id, page and
+ * per_page.
+ *
+ * __Minimum server version__: 5.26
+ *
+ * ##### Permissions
+ * Must have `manage_system`
+ * permission.
+ */
+class GetPrivateChannelsForTeam extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/{$this->teamId}/channels/private";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param null|int $page The page to select.
+	 */
+	public function __construct(
+		protected string $teamId,
+		protected ?int $page = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['page' => $this->page]);
+	}
+}

--- a/src/Client/Requests/Channels/GetPublicChannelsByIdsForTeam.php
+++ b/src/Client/Requests/Channels/GetPublicChannelsByIdsForTeam.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * GetPublicChannelsByIdsForTeam
+ *
+ * Get a list of public channels on a team by id.
+ * ##### Permissions
+ * `view_team` for the team the
+ * channels are on.
+ */
+class GetPublicChannelsByIdsForTeam extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/{$this->teamId}/channels/ids";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 */
+	public function __construct(
+		protected string $teamId,
+	) {
+	}
+}

--- a/src/Client/Requests/Channels/GetPublicChannelsForTeam.php
+++ b/src/Client/Requests/Channels/GetPublicChannelsForTeam.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetPublicChannelsForTeam
+ *
+ * Get a page of public channels on a team based on query string parameters - page and per_page.
+ * #####
+ * Permissions
+ * Must be authenticated and have the `list_team_channels` permission.
+ */
+class GetPublicChannelsForTeam extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/{$this->teamId}/channels";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param null|int $page The page to select.
+	 */
+	public function __construct(
+		protected string $teamId,
+		protected ?int $page = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['page' => $this->page]);
+	}
+}

--- a/src/Client/Requests/Channels/GetSidebarCategoriesForTeamForUser.php
+++ b/src/Client/Requests/Channels/GetSidebarCategoriesForTeamForUser.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetSidebarCategoriesForTeamForUser
+ *
+ * Get a list of sidebar categories that will appear in the user's sidebar on the given team, including
+ * a list of channel IDs in each category.
+ * __Minimum server version__: 5.26
+ * ##### Permissions
+ * Must be
+ * authenticated and have the `list_team_channels` permission.
+ */
+class GetSidebarCategoriesForTeamForUser extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/channels/categories";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param string $userId User GUID
+	 */
+	public function __construct(
+		protected string $teamId,
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Channels/GetSidebarCategoryForTeamForUser.php
+++ b/src/Client/Requests/Channels/GetSidebarCategoryForTeamForUser.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetSidebarCategoryForTeamForUser
+ *
+ * Returns a single sidebar category for the user on the given team.
+ * __Minimum server version__:
+ * 5.26
+ * ##### Permissions
+ * Must be authenticated and have the `list_team_channels` permission.
+ */
+class GetSidebarCategoryForTeamForUser extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/channels/categories/{$this->categoryId}";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param string $userId User GUID
+	 * @param string $categoryId Category GUID
+	 */
+	public function __construct(
+		protected string $teamId,
+		protected string $userId,
+		protected string $categoryId,
+	) {
+	}
+}

--- a/src/Client/Requests/Channels/GetSidebarCategoryOrderForTeamForUser.php
+++ b/src/Client/Requests/Channels/GetSidebarCategoryOrderForTeamForUser.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetSidebarCategoryOrderForTeamForUser
+ *
+ * Returns the order of the sidebar categories for a user on the given team as an array of
+ * IDs.
+ * __Minimum server version__: 5.26
+ * ##### Permissions
+ * Must be authenticated and have the
+ * `list_team_channels` permission.
+ */
+class GetSidebarCategoryOrderForTeamForUser extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/channels/categories/order";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param string $userId User GUID
+	 */
+	public function __construct(
+		protected string $teamId,
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Channels/MoveChannel.php
+++ b/src/Client/Requests/Channels/MoveChannel.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * MoveChannel
+ *
+ * Move a channel to another team.
+ *
+ * __Minimum server version__: 5.26
+ *
+ * ##### Permissions
+ *
+ * Must have
+ * `manage_system` permission.
+ */
+class MoveChannel extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/channels/{$this->channelId}/move";
+	}
+
+
+	/**
+	 * @param string $channelId Channel GUID
+	 */
+	public function __construct(
+		protected string $channelId,
+	) {
+	}
+}

--- a/src/Client/Requests/Channels/PatchChannel.php
+++ b/src/Client/Requests/Channels/PatchChannel.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * PatchChannel
+ *
+ * Partially update a channel by providing only the fields you want to update. Omitted fields will not
+ * be updated. The fields that can be updated are defined in the request body, all other provided
+ * fields will be ignored.
+ * ##### Permissions
+ * If updating a public channel,
+ * `manage_public_channel_members` permission is required. If updating a private channel,
+ * `manage_private_channel_members` permission is required.
+ */
+class PatchChannel extends Request
+{
+	protected Method $method = Method::PUT;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/channels/{$this->channelId}/patch";
+	}
+
+
+	/**
+	 * @param string $channelId Channel GUID
+	 */
+	public function __construct(
+		protected string $channelId,
+	) {
+	}
+}

--- a/src/Client/Requests/Channels/PatchChannelModerations.php
+++ b/src/Client/Requests/Channels/PatchChannelModerations.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * PatchChannelModerations
+ *
+ * ##### Permissions
+ * Must have `manage_system` permission.
+ *
+ * __Minimum server version__: 5.22
+ */
+class PatchChannelModerations extends Request
+{
+	protected Method $method = Method::PUT;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/channels/{$this->channelId}/moderations/patch";
+	}
+
+
+	/**
+	 * @param string $channelId Channel GUID
+	 */
+	public function __construct(
+		protected string $channelId,
+	) {
+	}
+}

--- a/src/Client/Requests/Channels/RemoveSidebarCategoryForTeamForUser.php
+++ b/src/Client/Requests/Channels/RemoveSidebarCategoryForTeamForUser.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * RemoveSidebarCategoryForTeamForUser
+ *
+ * Deletes a single sidebar category for the user on the given team. Only custom categories can be
+ * deleted.
+ * __Minimum server version__: 5.26
+ * ##### Permissions
+ * Must be authenticated and have the
+ * `list_team_channels` permission.
+ */
+class RemoveSidebarCategoryForTeamForUser extends Request
+{
+	protected Method $method = Method::DELETE;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/channels/categories/{$this->categoryId}";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param string $userId User GUID
+	 * @param string $categoryId Category GUID
+	 */
+	public function __construct(
+		protected string $teamId,
+		protected string $userId,
+		protected string $categoryId,
+	) {
+	}
+}

--- a/src/Client/Requests/Channels/RemoveUserFromChannel.php
+++ b/src/Client/Requests/Channels/RemoveUserFromChannel.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * RemoveUserFromChannel
+ *
+ * Delete a channel member, effectively removing them from a channel.
+ *
+ * In server version 5.3 and later,
+ * channel members can only be deleted from public or private channels.
+ * #####
+ * Permissions
+ * `manage_public_channel_members` permission if the channel is
+ * public.
+ * `manage_private_channel_members` permission if the channel is private.
+ */
+class RemoveUserFromChannel extends Request
+{
+	protected Method $method = Method::DELETE;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/channels/{$this->channelId}/members/{$this->userId}";
+	}
+
+
+	/**
+	 * @param string $channelId Channel GUID
+	 * @param string $userId User GUID
+	 */
+	public function __construct(
+		protected string $channelId,
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Channels/RestoreChannel.php
+++ b/src/Client/Requests/Channels/RestoreChannel.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * RestoreChannel
+ *
+ * Restore channel from the provided channel id string.
+ *
+ * __Minimum server version__: 3.10
+ *
+ * #####
+ * Permissions
+ * `manage_team` permission for the team of the channel.
+ */
+class RestoreChannel extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/channels/{$this->channelId}/restore";
+	}
+
+
+	/**
+	 * @param string $channelId Channel GUID
+	 */
+	public function __construct(
+		protected string $channelId,
+	) {
+	}
+}

--- a/src/Client/Requests/Channels/SearchAllChannels.php
+++ b/src/Client/Requests/Channels/SearchAllChannels.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * SearchAllChannels
+ *
+ * Returns all private and open type channels where 'term' matches on the name, display name, or
+ * purpose of
+ * the channel.
+ *
+ * Configured 'default' channels (ex Town Square and Off-Topic) can be
+ * excluded from the results
+ * with the `exclude_default_channels` boolean parameter.
+ *
+ * Channels that are
+ * associated (via GroupChannel records) to a given group can be excluded from the results
+ * with the
+ * `not_associated_to_group` parameter and a group id string.
+ */
+class SearchAllChannels extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/channels/search";
+	}
+
+
+	/**
+	 * @param null|bool $systemConsole Is the request from system_console. If this is set to true, it filters channels by the logged in user.
+	 */
+	public function __construct(
+		protected ?bool $systemConsole = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['system_console' => $this->systemConsole]);
+	}
+}

--- a/src/Client/Requests/Channels/SearchArchivedChannels.php
+++ b/src/Client/Requests/Channels/SearchArchivedChannels.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * SearchArchivedChannels
+ *
+ * Search archived channels on a team based on the search term provided in the request body.
+ *
+ * __Minimum
+ * server version__: 5.18
+ *
+ * ##### Permissions
+ * Must have the `list_team_channels` permission.
+ *
+ * In server
+ * version 5.18 and later, a user without the `list_team_channels` permission will be able to use this
+ * endpoint, with the search results limited to the channels that the user is a member of.
+ */
+class SearchArchivedChannels extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/{$this->teamId}/channels/search_archived";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 */
+	public function __construct(
+		protected string $teamId,
+	) {
+	}
+}

--- a/src/Client/Requests/Channels/SearchChannels.php
+++ b/src/Client/Requests/Channels/SearchChannels.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * SearchChannels
+ *
+ * Search public channels on a team based on the search term provided in the request body.
+ * #####
+ * Permissions
+ * Must have the `list_team_channels` permission.
+ *
+ * In server version 5.16 and later, a user
+ * without the `list_team_channels` permission will be able to use this endpoint, with the search
+ * results limited to the channels that the user is a member of.
+ */
+class SearchChannels extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/{$this->teamId}/channels/search";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 */
+	public function __construct(
+		protected string $teamId,
+	) {
+	}
+}

--- a/src/Client/Requests/Channels/SearchGroupChannels.php
+++ b/src/Client/Requests/Channels/SearchGroupChannels.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * SearchGroupChannels
+ *
+ * Get a list of group channels for a user which members' usernames match the search term.
+ *
+ * __Minimum
+ * server version__: 5.14
+ */
+class SearchGroupChannels extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/channels/group/search";
+	}
+
+
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Requests/Channels/UpdateChannel.php
+++ b/src/Client/Requests/Channels/UpdateChannel.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * UpdateChannel
+ *
+ * Update a channel. The fields that can be updated are listed as parameters. Omitted fields will be
+ * treated as blanks.
+ * ##### Permissions
+ * If updating a public channel, `manage_public_channel_members`
+ * permission is required. If updating a private channel, `manage_private_channel_members` permission
+ * is required.
+ */
+class UpdateChannel extends Request
+{
+	protected Method $method = Method::PUT;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/channels/{$this->channelId}";
+	}
+
+
+	/**
+	 * @param string $channelId Channel GUID
+	 */
+	public function __construct(
+		protected string $channelId,
+	) {
+	}
+}

--- a/src/Client/Requests/Channels/UpdateChannelMemberSchemeRoles.php
+++ b/src/Client/Requests/Channels/UpdateChannelMemberSchemeRoles.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * UpdateChannelMemberSchemeRoles
+ *
+ * Update a channel member's scheme_admin/scheme_user properties. Typically this should either be
+ * `scheme_admin=false, scheme_user=true` for ordinary channel member, or `scheme_admin=true,
+ * scheme_user=true` for a channel admin.
+ * __Minimum server version__: 5.0
+ * ##### Permissions
+ * Must be
+ * authenticated and have the `manage_channel_roles` permission.
+ */
+class UpdateChannelMemberSchemeRoles extends Request
+{
+	protected Method $method = Method::PUT;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/channels/{$this->channelId}/members/{$this->userId}/schemeRoles";
+	}
+
+
+	/**
+	 * @param string $channelId Channel GUID
+	 * @param string $userId User GUID
+	 */
+	public function __construct(
+		protected string $channelId,
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Channels/UpdateChannelNotifyProps.php
+++ b/src/Client/Requests/Channels/UpdateChannelNotifyProps.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * UpdateChannelNotifyProps
+ *
+ * Update a user's notification properties for a channel. Only the provided fields are updated.
+ * #####
+ * Permissions
+ * Must be logged in as the user or have `edit_other_users` permission.
+ */
+class UpdateChannelNotifyProps extends Request
+{
+	protected Method $method = Method::PUT;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/channels/{$this->channelId}/members/{$this->userId}/notify_props";
+	}
+
+
+	/**
+	 * @param string $channelId Channel GUID
+	 * @param string $userId User GUID
+	 */
+	public function __construct(
+		protected string $channelId,
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Channels/UpdateChannelPrivacy.php
+++ b/src/Client/Requests/Channels/UpdateChannelPrivacy.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * UpdateChannelPrivacy
+ *
+ * Updates channel's privacy allowing changing a channel from Public to Private and back.
+ *
+ * __Minimum
+ * server version__: 5.16
+ *
+ * ##### Permissions
+ * `manage_team` permission for the channels team on version
+ * < 5.28. `convert_public_channel_to_private` permission for the channel if updating privacy to 'P' on
+ * version >= 5.28. `convert_private_channel_to_public` permission for the channel if updating privacy
+ * to 'O' on version >= 5.28.
+ */
+class UpdateChannelPrivacy extends Request
+{
+	protected Method $method = Method::PUT;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/channels/{$this->channelId}/privacy";
+	}
+
+
+	/**
+	 * @param string $channelId Channel GUID
+	 */
+	public function __construct(
+		protected string $channelId,
+	) {
+	}
+}

--- a/src/Client/Requests/Channels/UpdateChannelRoles.php
+++ b/src/Client/Requests/Channels/UpdateChannelRoles.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * UpdateChannelRoles
+ *
+ * Update a user's roles for a channel.
+ * ##### Permissions
+ * Must have `manage_channel_roles` permission
+ * for the channel.
+ */
+class UpdateChannelRoles extends Request
+{
+	protected Method $method = Method::PUT;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/channels/{$this->channelId}/members/{$this->userId}/roles";
+	}
+
+
+	/**
+	 * @param string $channelId Channel GUID
+	 * @param string $userId User GUID
+	 */
+	public function __construct(
+		protected string $channelId,
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Channels/UpdateChannelScheme.php
+++ b/src/Client/Requests/Channels/UpdateChannelScheme.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * UpdateChannelScheme
+ *
+ * Set a channel's scheme, more specifically sets the scheme_id value of a channel record.
+ *
+ * #####
+ * Permissions
+ * Must have `manage_system` permission.
+ *
+ * __Minimum server version__: 4.10
+ */
+class UpdateChannelScheme extends Request
+{
+	protected Method $method = Method::PUT;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/channels/{$this->channelId}/scheme";
+	}
+
+
+	/**
+	 * @param string $channelId Channel GUID
+	 */
+	public function __construct(
+		protected string $channelId,
+	) {
+	}
+}

--- a/src/Client/Requests/Channels/UpdateSidebarCategoriesForTeamForUser.php
+++ b/src/Client/Requests/Channels/UpdateSidebarCategoriesForTeamForUser.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * UpdateSidebarCategoriesForTeamForUser
+ *
+ * Update any number of sidebar categories for the user on the given team. This can be used to reorder
+ * the channels in these categories.
+ * __Minimum server version__: 5.26
+ * ##### Permissions
+ * Must be
+ * authenticated and have the `list_team_channels` permission.
+ */
+class UpdateSidebarCategoriesForTeamForUser extends Request
+{
+	protected Method $method = Method::PUT;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/channels/categories";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param string $userId User GUID
+	 */
+	public function __construct(
+		protected string $teamId,
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Channels/UpdateSidebarCategoryForTeamForUser.php
+++ b/src/Client/Requests/Channels/UpdateSidebarCategoryForTeamForUser.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * UpdateSidebarCategoryForTeamForUser
+ *
+ * Updates a single sidebar category for the user on the given team.
+ * __Minimum server version__:
+ * 5.26
+ * ##### Permissions
+ * Must be authenticated and have the `list_team_channels` permission.
+ */
+class UpdateSidebarCategoryForTeamForUser extends Request
+{
+	protected Method $method = Method::PUT;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/channels/categories/{$this->categoryId}";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param string $userId User GUID
+	 * @param string $categoryId Category GUID
+	 */
+	public function __construct(
+		protected string $teamId,
+		protected string $userId,
+		protected string $categoryId,
+	) {
+	}
+}

--- a/src/Client/Requests/Channels/UpdateSidebarCategoryOrderForTeamForUser.php
+++ b/src/Client/Requests/Channels/UpdateSidebarCategoryOrderForTeamForUser.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * UpdateSidebarCategoryOrderForTeamForUser
+ *
+ * Updates the order of the sidebar categories for a user on the given team. The provided array must
+ * include the IDs of all categories on the team.
+ * __Minimum server version__: 5.26
+ * #####
+ * Permissions
+ * Must be authenticated and have the `list_team_channels` permission.
+ */
+class UpdateSidebarCategoryOrderForTeamForUser extends Request
+{
+	protected Method $method = Method::PUT;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/channels/categories/order";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param string $userId User GUID
+	 */
+	public function __construct(
+		protected string $teamId,
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Channels/ViewChannel.php
+++ b/src/Client/Requests/Channels/ViewChannel.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Channels;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * ViewChannel
+ *
+ * Perform all the actions involved in viewing a channel. This includes marking channels as read,
+ * clearing push notifications, and updating the active channel.
+ * ##### Permissions
+ * Must be logged in as
+ * user or have `edit_other_users` permission.
+ *
+ * __Response only includes `last_viewed_at_times` in
+ * Mattermost server 4.3 and newer.__
+ */
+class ViewChannel extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/channels/members/{$this->userId}/view";
+	}
+
+
+	/**
+	 * @param string $userId User ID to perform the view action for
+	 */
+	public function __construct(
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Commands/CreateCommand.php
+++ b/src/Client/Requests/Commands/CreateCommand.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Commands;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * CreateCommand
+ *
+ * Create a command for a team.
+ * ##### Permissions
+ * `manage_slash_commands` for the team the command is
+ * in.
+ */
+class CreateCommand extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/commands";
+	}
+
+
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Requests/Commands/DeleteCommand.php
+++ b/src/Client/Requests/Commands/DeleteCommand.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Commands;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * DeleteCommand
+ *
+ * Delete a command based on command id string.
+ * ##### Permissions
+ * Must have `manage_slash_commands`
+ * permission for the team the command is in.
+ */
+class DeleteCommand extends Request
+{
+	protected Method $method = Method::DELETE;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/commands/{$this->commandId}";
+	}
+
+
+	/**
+	 * @param string $commandId ID of the command to delete
+	 */
+	public function __construct(
+		protected string $commandId,
+	) {
+	}
+}

--- a/src/Client/Requests/Commands/ExecuteCommand.php
+++ b/src/Client/Requests/Commands/ExecuteCommand.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Commands;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * ExecuteCommand
+ *
+ * Execute a command on a team.
+ * ##### Permissions
+ * Must have `use_slash_commands` permission for the
+ * team the command is in.
+ */
+class ExecuteCommand extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/commands/execute";
+	}
+
+
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Requests/Commands/GetCommandById.php
+++ b/src/Client/Requests/Commands/GetCommandById.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Commands;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetCommandById
+ *
+ * Get a command definition based on command id string.
+ * ##### Permissions
+ * Must have
+ * `manage_slash_commands` permission for the team the command is in.
+ *
+ * __Minimum server version__:
+ * 5.22
+ */
+class GetCommandById extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/commands/{$this->commandId}";
+	}
+
+
+	/**
+	 * @param string $commandId ID of the command to get
+	 */
+	public function __construct(
+		protected string $commandId,
+	) {
+	}
+}

--- a/src/Client/Requests/Commands/ListAutocompleteCommands.php
+++ b/src/Client/Requests/Commands/ListAutocompleteCommands.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Commands;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * ListAutocompleteCommands
+ *
+ * List autocomplete commands in the team.
+ * ##### Permissions
+ * `view_team` for the team.
+ */
+class ListAutocompleteCommands extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/{$this->teamId}/commands/autocomplete";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 */
+	public function __construct(
+		protected string $teamId,
+	) {
+	}
+}

--- a/src/Client/Requests/Commands/ListCommands.php
+++ b/src/Client/Requests/Commands/ListCommands.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Commands;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * ListCommands
+ *
+ * List commands for a team.
+ * ##### Permissions
+ * `manage_slash_commands` if need list custom commands.
+ */
+class ListCommands extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/commands";
+	}
+
+
+	/**
+	 * @param null|string $teamId The team id.
+	 * @param null|bool $customOnly To get only the custom commands. If set to false will get the custom
+	 * if the user have access plus the system commands, otherwise just the system commands.
+	 */
+	public function __construct(
+		protected ?string $teamId = null,
+		protected ?bool $customOnly = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['team_id' => $this->teamId, 'custom_only' => $this->customOnly]);
+	}
+}

--- a/src/Client/Requests/Commands/MoveCommand.php
+++ b/src/Client/Requests/Commands/MoveCommand.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Commands;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * MoveCommand
+ *
+ * Move a command to a different team based on command id string.
+ * ##### Permissions
+ * Must have
+ * `manage_slash_commands` permission for the team the command is currently in and the destination
+ * team.
+ *
+ * __Minimum server version__: 5.22
+ */
+class MoveCommand extends Request
+{
+	protected Method $method = Method::PUT;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/commands/{$this->commandId}/move";
+	}
+
+
+	/**
+	 * @param string $commandId ID of the command to move
+	 */
+	public function __construct(
+		protected string $commandId,
+	) {
+	}
+}

--- a/src/Client/Requests/Commands/RegenCommandToken.php
+++ b/src/Client/Requests/Commands/RegenCommandToken.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Commands;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * RegenCommandToken
+ *
+ * Generate a new token for the command based on command id string.
+ * ##### Permissions
+ * Must have
+ * `manage_slash_commands` permission for the team the command is in.
+ */
+class RegenCommandToken extends Request
+{
+	protected Method $method = Method::PUT;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/commands/{$this->commandId}/regen_token";
+	}
+
+
+	/**
+	 * @param string $commandId ID of the command to generate the new token
+	 */
+	public function __construct(
+		protected string $commandId,
+	) {
+	}
+}

--- a/src/Client/Requests/Commands/UpdateCommand.php
+++ b/src/Client/Requests/Commands/UpdateCommand.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Commands;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * UpdateCommand
+ *
+ * Update a single command based on command id string and Command struct.
+ * ##### Permissions
+ * Must have
+ * `manage_slash_commands` permission for the team the command is in.
+ */
+class UpdateCommand extends Request
+{
+	protected Method $method = Method::PUT;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/commands/{$this->commandId}";
+	}
+
+
+	/**
+	 * @param string $commandId ID of the command to update
+	 */
+	public function __construct(
+		protected string $commandId,
+	) {
+	}
+}

--- a/src/Client/Requests/DataRetention/GetChannelPoliciesForUser.php
+++ b/src/Client/Requests/DataRetention/GetChannelPoliciesForUser.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\DataRetention;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetChannelPoliciesForUser
+ *
+ * Gets the policies which are applied to the all of the channels to which a user belongs.
+ *
+ * __Minimum
+ * server version__: 5.35
+ *
+ * ##### Permissions
+ * Must be logged in as the user or have the `manage_system`
+ * permission.
+ *
+ * ##### License
+ * Requires an E20 license.
+ */
+class GetChannelPoliciesForUser extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/data_retention/channel_policies";
+	}
+
+
+	/**
+	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
+	 * @param null|int $page The page to select.
+	 */
+	public function __construct(
+		protected string $userId,
+		protected ?int $page = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['page' => $this->page]);
+	}
+}

--- a/src/Client/Requests/DataRetention/GetTeamPoliciesForUser.php
+++ b/src/Client/Requests/DataRetention/GetTeamPoliciesForUser.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\DataRetention;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetTeamPoliciesForUser
+ *
+ * Gets the policies which are applied to the all of the teams to which a user belongs.
+ *
+ * __Minimum
+ * server version__: 5.35
+ *
+ * ##### Permissions
+ * Must be logged in as the user or have the `manage_system`
+ * permission.
+ *
+ * ##### License
+ * Requires an E20 license.
+ */
+class GetTeamPoliciesForUser extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/data_retention/team_policies";
+	}
+
+
+	/**
+	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
+	 * @param null|int $page The page to select.
+	 */
+	public function __construct(
+		protected string $userId,
+		protected ?int $page = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['page' => $this->page]);
+	}
+}

--- a/src/Client/Requests/Emoji/AutocompleteEmoji.php
+++ b/src/Client/Requests/Emoji/AutocompleteEmoji.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Emoji;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * AutocompleteEmoji
+ *
+ * Get a list of custom emoji with names starting with or matching the provided name. Returns a maximum
+ * of 100 results.
+ * ##### Permissions
+ * Must be authenticated.
+ *
+ * __Minimum server version__: 4.7
+ */
+class AutocompleteEmoji extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/emoji/autocomplete";
+	}
+
+
+	/**
+	 * @param string $name The emoji name to search.
+	 */
+	public function __construct(
+		protected string $name,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['name' => $this->name]);
+	}
+}

--- a/src/Client/Requests/Emoji/CreateEmoji.php
+++ b/src/Client/Requests/Emoji/CreateEmoji.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Emoji;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * CreateEmoji
+ *
+ * Create a custom emoji for the team.
+ * ##### Permissions
+ * Must be authenticated.
+ */
+class CreateEmoji extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/emoji";
+	}
+
+
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Requests/Emoji/DeleteEmoji.php
+++ b/src/Client/Requests/Emoji/DeleteEmoji.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Emoji;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * DeleteEmoji
+ *
+ * Delete a custom emoji.
+ * ##### Permissions
+ * Must have the `manage_team` or `manage_system` permissions
+ * or be the user who created the emoji.
+ */
+class DeleteEmoji extends Request
+{
+	protected Method $method = Method::DELETE;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/emoji/{$this->emojiId}";
+	}
+
+
+	/**
+	 * @param string $emojiId Emoji GUID
+	 */
+	public function __construct(
+		protected string $emojiId,
+	) {
+	}
+}

--- a/src/Client/Requests/Emoji/GetEmoji.php
+++ b/src/Client/Requests/Emoji/GetEmoji.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Emoji;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetEmoji
+ *
+ * Get some metadata for a custom emoji.
+ * ##### Permissions
+ * Must be authenticated.
+ */
+class GetEmoji extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/emoji/{$this->emojiId}";
+	}
+
+
+	/**
+	 * @param string $emojiId Emoji GUID
+	 */
+	public function __construct(
+		protected string $emojiId,
+	) {
+	}
+}

--- a/src/Client/Requests/Emoji/GetEmojiByName.php
+++ b/src/Client/Requests/Emoji/GetEmojiByName.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Emoji;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetEmojiByName
+ *
+ * Get some metadata for a custom emoji using its name.
+ * ##### Permissions
+ * Must be
+ * authenticated.
+ *
+ * __Minimum server version__: 4.7
+ */
+class GetEmojiByName extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/emoji/name/{$this->emojiName}";
+	}
+
+
+	/**
+	 * @param string $emojiName Emoji name
+	 */
+	public function __construct(
+		protected string $emojiName,
+	) {
+	}
+}

--- a/src/Client/Requests/Emoji/GetEmojiImage.php
+++ b/src/Client/Requests/Emoji/GetEmojiImage.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Emoji;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetEmojiImage
+ *
+ * Get the image for a custom emoji.
+ * ##### Permissions
+ * Must be authenticated.
+ */
+class GetEmojiImage extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/emoji/{$this->emojiId}/image";
+	}
+
+
+	/**
+	 * @param string $emojiId Emoji GUID
+	 */
+	public function __construct(
+		protected string $emojiId,
+	) {
+	}
+}

--- a/src/Client/Requests/Emoji/GetEmojiList.php
+++ b/src/Client/Requests/Emoji/GetEmojiList.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Emoji;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetEmojiList
+ *
+ * Get a page of metadata for custom emoji on the system. Since server version 4.7, sort using the
+ * `sort` query parameter.
+ * ##### Permissions
+ * Must be authenticated.
+ */
+class GetEmojiList extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/emoji";
+	}
+
+
+	/**
+	 * @param null|int $page The page to select.
+	 * @param null|string $sort Either blank for no sorting or "name" to sort by emoji names. Minimum server version for sorting is 4.7.
+	 */
+	public function __construct(
+		protected ?int $page = null,
+		protected ?string $sort = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['page' => $this->page, 'sort' => $this->sort]);
+	}
+}

--- a/src/Client/Requests/Emoji/SearchEmoji.php
+++ b/src/Client/Requests/Emoji/SearchEmoji.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Emoji;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * SearchEmoji
+ *
+ * Search for custom emoji by name based on search criteria provided in the request body. A maximum of
+ * 200 results are returned.
+ * ##### Permissions
+ * Must be authenticated.
+ *
+ * __Minimum server version__: 4.7
+ */
+class SearchEmoji extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/emoji/search";
+	}
+
+
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Requests/Files/GetFile.php
+++ b/src/Client/Requests/Files/GetFile.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Files;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetFile
+ *
+ * Gets a file that has been uploaded previously.
+ * ##### Permissions
+ * Must have `read_channel` permission
+ * or be uploader of the file.
+ */
+class GetFile extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/files/{$this->fileId}";
+	}
+
+
+	/**
+	 * @param string $fileId The ID of the file to get
+	 */
+	public function __construct(
+		protected string $fileId,
+	) {
+	}
+}

--- a/src/Client/Requests/Files/GetFileInfo.php
+++ b/src/Client/Requests/Files/GetFileInfo.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Files;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetFileInfo
+ *
+ * Gets a file's info.
+ * ##### Permissions
+ * Must have `read_channel` permission or be uploader of the
+ * file.
+ */
+class GetFileInfo extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/files/{$this->fileId}/info";
+	}
+
+
+	/**
+	 * @param string $fileId The ID of the file info to get
+	 */
+	public function __construct(
+		protected string $fileId,
+	) {
+	}
+}

--- a/src/Client/Requests/Files/GetFileLink.php
+++ b/src/Client/Requests/Files/GetFileLink.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Files;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetFileLink
+ *
+ * Gets a public link for a file that can be accessed without logging into Mattermost.
+ * #####
+ * Permissions
+ * Must have `read_channel` permission or be uploader of the file.
+ */
+class GetFileLink extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/files/{$this->fileId}/link";
+	}
+
+
+	/**
+	 * @param string $fileId The ID of the file to get a link for
+	 */
+	public function __construct(
+		protected string $fileId,
+	) {
+	}
+}

--- a/src/Client/Requests/Files/GetFilePreview.php
+++ b/src/Client/Requests/Files/GetFilePreview.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Files;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetFilePreview
+ *
+ * Gets a file's preview.
+ * ##### Permissions
+ * Must have `read_channel` permission or be uploader of the
+ * file.
+ */
+class GetFilePreview extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/files/{$this->fileId}/preview";
+	}
+
+
+	/**
+	 * @param string $fileId The ID of the file to get
+	 */
+	public function __construct(
+		protected string $fileId,
+	) {
+	}
+}

--- a/src/Client/Requests/Files/GetFilePublic.php
+++ b/src/Client/Requests/Files/GetFilePublic.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Files;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetFilePublic
+ *
+ * ##### Permissions
+ * No permissions required.
+ */
+class GetFilePublic extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/files/{$this->fileId}/public";
+	}
+
+
+	/**
+	 * @param string $fileId The ID of the file to get
+	 * @param string $h File hash
+	 */
+	public function __construct(
+		protected string $fileId,
+		protected string $h,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['h' => $this->h]);
+	}
+}

--- a/src/Client/Requests/Files/GetFileThumbnail.php
+++ b/src/Client/Requests/Files/GetFileThumbnail.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Files;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetFileThumbnail
+ *
+ * Gets a file's thumbnail.
+ * ##### Permissions
+ * Must have `read_channel` permission or be uploader of the
+ * file.
+ */
+class GetFileThumbnail extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/files/{$this->fileId}/thumbnail";
+	}
+
+
+	/**
+	 * @param string $fileId The ID of the file to get
+	 */
+	public function __construct(
+		protected string $fileId,
+	) {
+	}
+}

--- a/src/Client/Requests/Files/UploadFile.php
+++ b/src/Client/Requests/Files/UploadFile.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Files;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * UploadFile
+ *
+ * Uploads a file that can later be attached to a post.
+ *
+ * This request can either be a
+ * multipart/form-data request with a channel_id, files and optional
+ * client_ids defined in the
+ * FormData, or it can be a request with the channel_id and filename
+ * defined as query parameters with
+ * the contents of a single file in the body of the request.
+ *
+ * Only multipart/form-data requests are
+ * supported by server versions up to and including 4.7.
+ * Server versions 4.8 and higher support both
+ * types of requests.
+ *
+ * ##### Permissions
+ * Must have `upload_file` permission.
+ */
+class UploadFile extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/files";
+	}
+
+
+	/**
+	 * @param null|string $channelId The ID of the channel that this file will be uploaded to
+	 * @param null|string $filename The name of the file to be uploaded
+	 */
+	public function __construct(
+		protected ?string $channelId = null,
+		protected ?string $filename = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['channel_id' => $this->channelId, 'filename' => $this->filename]);
+	}
+}

--- a/src/Client/Requests/Groups/GetGroupsAssociatedToChannelsByTeam.php
+++ b/src/Client/Requests/Groups/GetGroupsAssociatedToChannelsByTeam.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Groups;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetGroupsAssociatedToChannelsByTeam
+ *
+ * Retrieve the set of groups associated with the channels in the given team grouped by channel.
+ *
+ * #####
+ * Permissions
+ * Must have `manage_system` permission or can access only for current user
+ *
+ * __Minimum
+ * server version__: 5.11
+ */
+class GetGroupsAssociatedToChannelsByTeam extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/{$this->teamId}/groups_by_channels";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param null|int $page The page to select.
+	 * @param null|bool $filterAllowReference Boolean which filters in the group entries with the `allow_reference` attribute set.
+	 * @param null|bool $paginate Boolean to determine whether the pagination should be applied or not
+	 */
+	public function __construct(
+		protected string $teamId,
+		protected ?int $page = null,
+		protected ?bool $filterAllowReference = null,
+		protected ?bool $paginate = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['page' => $this->page, 'filter_allow_reference' => $this->filterAllowReference, 'paginate' => $this->paginate]);
+	}
+}

--- a/src/Client/Requests/Groups/GetGroupsByChannel.php
+++ b/src/Client/Requests/Groups/GetGroupsByChannel.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Groups;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetGroupsByChannel
+ *
+ * Retrieve the list of groups associated with a given channel.
+ *
+ * ##### Permissions
+ * Must have
+ * `manage_system` permission.
+ *
+ * __Minimum server version__: 5.11
+ */
+class GetGroupsByChannel extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/channels/{$this->channelId}/groups";
+	}
+
+
+	/**
+	 * @param string $channelId Channel GUID
+	 * @param null|int $page The page to select.
+	 * @param null|bool $filterAllowReference Boolean which filters the group entries with the `allow_reference` attribute set.
+	 */
+	public function __construct(
+		protected string $channelId,
+		protected ?int $page = null,
+		protected ?bool $filterAllowReference = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['page' => $this->page, 'filter_allow_reference' => $this->filterAllowReference]);
+	}
+}

--- a/src/Client/Requests/Groups/GetGroupsByTeam.php
+++ b/src/Client/Requests/Groups/GetGroupsByTeam.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Groups;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetGroupsByTeam
+ *
+ * Retrieve the list of groups associated with a given team.
+ *
+ * __Minimum server version__: 5.11
+ */
+class GetGroupsByTeam extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/{$this->teamId}/groups";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param null|int $page The page to select.
+	 * @param null|bool $filterAllowReference Boolean which filters in the group entries with the `allow_reference` attribute set.
+	 */
+	public function __construct(
+		protected string $teamId,
+		protected ?int $page = null,
+		protected ?bool $filterAllowReference = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['page' => $this->page, 'filter_allow_reference' => $this->filterAllowReference]);
+	}
+}

--- a/src/Client/Requests/Groups/GetGroupsByUserId.php
+++ b/src/Client/Requests/Groups/GetGroupsByUserId.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Groups;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetGroupsByUserId
+ *
+ * Retrieve the list of groups associated to the user
+ *
+ * __Minimum server version__: 5.24
+ */
+class GetGroupsByUserId extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/groups";
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function __construct(
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Insights/GetNewTeamMembers.php
+++ b/src/Client/Requests/Insights/GetNewTeamMembers.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Insights;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetNewTeamMembers
+ *
+ * Get a list of all of the new team members that have joined the given team during the given time
+ * period.
+ * ##### Permissions
+ * Must have `view_team` permission for the team.
+ */
+class GetNewTeamMembers extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/{$this->teamId}/top/team_members";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param string $timeRange Time range can be "today", "7_day", or "28_day".
+	 * - `today`: team members who joined during the current day.
+	 * - `7_day`: team members who joined in the last 7 days.
+	 * - `28_day`: team members who joined in the last 28 days.
+	 * @param null|int $page The page to select.
+	 */
+	public function __construct(
+		protected string $teamId,
+		protected string $timeRange,
+		protected ?int $page = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['time_range' => $this->timeRange, 'page' => $this->page]);
+	}
+}

--- a/src/Client/Requests/Insights/GetTopChannelsForTeam.php
+++ b/src/Client/Requests/Insights/GetTopChannelsForTeam.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Insights;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetTopChannelsForTeam
+ *
+ * Get a list of the top public and private channels (the user is a member of) for a given team.
+ * #####
+ * Permissions
+ * Must have `view_team` permission for the team.
+ */
+class GetTopChannelsForTeam extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/{$this->teamId}/top/channels";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param string $timeRange Time range can be "today", "7_day", or "28_day".
+	 * - `today`: channels with posts on the current day.
+	 * - `7_day`: channels with posts in the last 7 days.
+	 * - `28_day`: channels with posts in the last 28 days.
+	 * @param null|int $page The page to select.
+	 */
+	public function __construct(
+		protected string $teamId,
+		protected string $timeRange,
+		protected ?int $page = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['time_range' => $this->timeRange, 'page' => $this->page]);
+	}
+}

--- a/src/Client/Requests/Insights/GetTopChannelsForUser.php
+++ b/src/Client/Requests/Insights/GetTopChannelsForUser.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Insights;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetTopChannelsForUser
+ *
+ * Get a list of the top public and private channels (the user is a member of) for a given user.
+ * #####
+ * Permissions
+ * Must be logged in as the user.
+ */
+class GetTopChannelsForUser extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/me/top/channels";
+	}
+
+
+	/**
+	 * @param string $timeRange Time range can be "today", "7_day", or "28_day".
+	 * - `today`: channels with posts on the current day.
+	 * - `7_day`: channels with posts in the last 7 days.
+	 * - `28_day`: channels with posts in the last 28 days.
+	 * @param null|int $page The page to select.
+	 * @param null|string $teamId Team ID will scope the response to a given team.
+	 * ##### Permissions
+	 * Must have `view_team` permission for the team.
+	 */
+	public function __construct(
+		protected string $timeRange,
+		protected ?int $page = null,
+		protected ?string $teamId = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['time_range' => $this->timeRange, 'page' => $this->page, 'team_id' => $this->teamId]);
+	}
+}

--- a/src/Client/Requests/Insights/GetTopDmsForUser.php
+++ b/src/Client/Requests/Insights/GetTopDmsForUser.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Insights;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetTopDMsForUser
+ *
+ * Get a list of the top dms for a given user.
+ * ##### Permissions
+ * Must be logged in as the user.
+ */
+class GetTopDmsForUser extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/me/top/dms";
+	}
+
+
+	/**
+	 * @param string $timeRange Time range can be "today", "7_day", or "28_day".
+	 * - `today`: threads with activity on the current day.
+	 * - `7_day`: threads with activity in the last 7 days.
+	 * - `28_day`: threads with activity in the last 28 days.
+	 * @param null|int $page The page to select.
+	 */
+	public function __construct(
+		protected string $timeRange,
+		protected ?int $page = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['time_range' => $this->timeRange, 'page' => $this->page]);
+	}
+}

--- a/src/Client/Requests/Insights/GetTopReactionsForTeam.php
+++ b/src/Client/Requests/Insights/GetTopReactionsForTeam.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Insights;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetTopReactionsForTeam
+ *
+ * Get a list of the top reactions across all public and private channels (the user is a member of) for
+ * a given team.
+ * ##### Permissions
+ * Must have `view_team` permission for the team.
+ */
+class GetTopReactionsForTeam extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/{$this->teamId}/top/reactions";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param string $timeRange Time range can be "today", "7_day", or "28_day".
+	 * - `today`: reactions posted on the current day.
+	 * - `7_day`: reactions posted in the last 7 days.
+	 * - `28_day`: reactions posted in the last 28 days.
+	 * @param null|int $page The page to select.
+	 */
+	public function __construct(
+		protected string $teamId,
+		protected string $timeRange,
+		protected ?int $page = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['time_range' => $this->timeRange, 'page' => $this->page]);
+	}
+}

--- a/src/Client/Requests/Insights/GetTopReactionsForUser.php
+++ b/src/Client/Requests/Insights/GetTopReactionsForUser.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Insights;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetTopReactionsForUser
+ *
+ * Get a list of the top reactions across all public and private channels (the user is a member of) for
+ * a given user.
+ * If no `team_id` is provided, this will also include reactions posted by the given user
+ * in direct and group messages.
+ * ##### Permissions
+ * Must be logged in as the user.
+ */
+class GetTopReactionsForUser extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/me/top/reactions";
+	}
+
+
+	/**
+	 * @param string $timeRange Time range can be "today", "7_day", or "28_day".
+	 * - `today`: reactions posted on the current day.
+	 * - `7_day`: reactions posted in the last 7 days.
+	 * - `28_day`: reactions posted in the last 28 days.
+	 * @param null|int $page The page to select.
+	 * @param null|string $teamId Team ID will scope the response to a given team and exclude direct and group messages.
+	 * ##### Permissions
+	 * Must have `view_team` permission for the team.
+	 */
+	public function __construct(
+		protected string $timeRange,
+		protected ?int $page = null,
+		protected ?string $teamId = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['time_range' => $this->timeRange, 'page' => $this->page, 'team_id' => $this->teamId]);
+	}
+}

--- a/src/Client/Requests/Insights/GetTopThreadsForTeam.php
+++ b/src/Client/Requests/Insights/GetTopThreadsForTeam.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Insights;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetTopThreadsForTeam
+ *
+ * Get a list of the top threads from public and private channels (the user is a member of) for a given
+ * team.
+ * ##### Permissions
+ * Must have `view_team` permission for the team.
+ */
+class GetTopThreadsForTeam extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/{$this->teamId}/top/threads";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param string $timeRange Time range can be "today", "7_day", or "28_day".
+	 * - `today`: threads with activity on the current day.
+	 * - `7_day`: threads with activity in the last 7 days.
+	 * - `28_day`: threads with activity in the last 28 days.
+	 * @param null|int $page The page to select.
+	 */
+	public function __construct(
+		protected string $teamId,
+		protected string $timeRange,
+		protected ?int $page = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['time_range' => $this->timeRange, 'page' => $this->page]);
+	}
+}

--- a/src/Client/Requests/Insights/GetTopThreadsForUser.php
+++ b/src/Client/Requests/Insights/GetTopThreadsForUser.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Insights;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetTopThreadsForUser
+ *
+ * Get a list of the top threads from public and private channels (the user is a member of and
+ * participating in the thread) for a given user.
+ * ##### Permissions
+ * Must be logged in as the user.
+ */
+class GetTopThreadsForUser extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/me/top/threads";
+	}
+
+
+	/**
+	 * @param string $timeRange Time range can be "today", "7_day", or "28_day".
+	 * - `today`: threads with activity on the current day.
+	 * - `7_day`: threads with activity in the last 7 days.
+	 * - `28_day`: threads with activity in the last 28 days.
+	 * @param null|int $page The page to select.
+	 * @param null|string $teamId Team ID will scope the response to a given team.
+	 * ##### Permissions
+	 * Must have `view_team` permission for the team.
+	 */
+	public function __construct(
+		protected string $timeRange,
+		protected ?int $page = null,
+		protected ?string $teamId = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['time_range' => $this->timeRange, 'page' => $this->page, 'team_id' => $this->teamId]);
+	}
+}

--- a/src/Client/Requests/Oauth/GetAuthorizedOauthAppsForUser.php
+++ b/src/Client/Requests/Oauth/GetAuthorizedOauthAppsForUser.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Oauth;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetAuthorizedOAuthAppsForUser
+ *
+ * Get a page of OAuth 2.0 client applications authorized to access a user's account.
+ * #####
+ * Permissions
+ * Must be authenticated as the user or have `edit_other_users` permission.
+ */
+class GetAuthorizedOauthAppsForUser extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/oauth/apps/authorized";
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 * @param null|int $page The page to select.
+	 */
+	public function __construct(
+		protected string $userId,
+		protected ?int $page = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['page' => $this->page]);
+	}
+}

--- a/src/Client/Requests/Posts/CreatePost.php
+++ b/src/Client/Requests/Posts/CreatePost.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Posts;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * CreatePost
+ *
+ * Create a new post in a channel. To create the post as a comment on another post, provide
+ * `root_id`.
+ * ##### Permissions
+ * Must have `create_post` permission for the channel the post is being
+ * created in.
+ */
+class CreatePost extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/posts";
+	}
+
+
+	/**
+	 * @param null|bool $setOnline Whether to set the user status as online or not.
+	 */
+	public function __construct(
+		protected ?bool $setOnline = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['set_online' => $this->setOnline]);
+	}
+}

--- a/src/Client/Requests/Posts/CreatePostEphemeral.php
+++ b/src/Client/Requests/Posts/CreatePostEphemeral.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Posts;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * CreatePostEphemeral
+ *
+ * Create a new ephemeral post in a channel.
+ * ##### Permissions
+ * Must have `create_post_ephemeral`
+ * permission (currently only given to system admin)
+ */
+class CreatePostEphemeral extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/posts/ephemeral";
+	}
+
+
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Requests/Posts/DeletePost.php
+++ b/src/Client/Requests/Posts/DeletePost.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Posts;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * DeletePost
+ *
+ * Soft deletes a post, by marking the post as deleted in the database. Soft deleted posts will not be
+ * returned in post queries.
+ * ##### Permissions
+ * Must be logged in as the user or have
+ * `delete_others_posts` permission.
+ */
+class DeletePost extends Request
+{
+	protected Method $method = Method::DELETE;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/posts/{$this->postId}";
+	}
+
+
+	/**
+	 * @param string $postId ID of the post to delete
+	 */
+	public function __construct(
+		protected string $postId,
+	) {
+	}
+}

--- a/src/Client/Requests/Posts/DoPostAction.php
+++ b/src/Client/Requests/Posts/DoPostAction.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Posts;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * DoPostAction
+ *
+ * Perform a post action, which allows users to interact with integrations through posts.
+ * #####
+ * Permissions
+ * Must be authenticated and have the `read_channel` permission to the channel the post is
+ * in.
+ */
+class DoPostAction extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/posts/{$this->postId}/actions/{$this->actionId}";
+	}
+
+
+	/**
+	 * @param string $postId Post GUID
+	 * @param string $actionId Action GUID
+	 */
+	public function __construct(
+		protected string $postId,
+		protected string $actionId,
+	) {
+	}
+}

--- a/src/Client/Requests/Posts/GetFileInfosForPost.php
+++ b/src/Client/Requests/Posts/GetFileInfosForPost.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Posts;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetFileInfosForPost
+ *
+ * Gets a list of file information objects for the files attached to a post.
+ * ##### Permissions
+ * Must
+ * have `read_channel` permission for the channel the post is in.
+ */
+class GetFileInfosForPost extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/posts/{$this->postId}/files/info";
+	}
+
+
+	/**
+	 * @param string $postId ID of the post
+	 * @param null|bool $includeDeleted Defines if result should include deleted posts, must have 'manage_system' (admin) permission.
+	 */
+	public function __construct(
+		protected string $postId,
+		protected ?bool $includeDeleted = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['include_deleted' => $this->includeDeleted]);
+	}
+}

--- a/src/Client/Requests/Posts/GetFlaggedPostsForUser.php
+++ b/src/Client/Requests/Posts/GetFlaggedPostsForUser.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Posts;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetFlaggedPostsForUser
+ *
+ * Get a page of flagged posts of a user provided user id string. Selects from a channel, team, or all
+ * flagged posts by a user. Will only return posts from channels in which the user is member.
+ * #####
+ * Permissions
+ * Must be user or have `manage_system` permission.
+ */
+class GetFlaggedPostsForUser extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/posts/flagged";
+	}
+
+
+	/**
+	 * @param string $userId ID of the user
+	 * @param null|string $teamId Team ID
+	 * @param null|string $channelId Channel ID
+	 * @param null|int $page The page to select
+	 */
+	public function __construct(
+		protected string $userId,
+		protected ?string $teamId = null,
+		protected ?string $channelId = null,
+		protected ?int $page = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['team_id' => $this->teamId, 'channel_id' => $this->channelId, 'page' => $this->page]);
+	}
+}

--- a/src/Client/Requests/Posts/GetPost.php
+++ b/src/Client/Requests/Posts/GetPost.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Posts;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetPost
+ *
+ * Get a single post.
+ * ##### Permissions
+ * Must have `read_channel` permission for the channel the post is
+ * in or if the channel is public, have the `read_public_channels` permission for the team.
+ */
+class GetPost extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/posts/{$this->postId}";
+	}
+
+
+	/**
+	 * @param string $postId ID of the post to get
+	 * @param null|bool $includeDeleted Defines if result should include deleted posts, must have 'manage_system' (admin) permission.
+	 */
+	public function __construct(
+		protected string $postId,
+		protected ?bool $includeDeleted = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['include_deleted' => $this->includeDeleted]);
+	}
+}

--- a/src/Client/Requests/Posts/GetPostThread.php
+++ b/src/Client/Requests/Posts/GetPostThread.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Posts;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetPostThread
+ *
+ * Get a post and the rest of the posts in the same thread.
+ * ##### Permissions
+ * Must have `read_channel`
+ * permission for the channel the post is in or if the channel is public, have the
+ * `read_public_channels` permission for the team.
+ */
+class GetPostThread extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/posts/{$this->postId}/thread";
+	}
+
+
+	/**
+	 * @param string $postId ID of a post in the thread
+	 * @param null|int $perPage The number of posts per page
+	 * @param null|string $fromPost The post_id to return the next page of posts from
+	 * @param null|int $fromCreateAt The create_at timestamp to return the next page of posts from
+	 * @param null|string $direction The direction to return the posts. Either up or down.
+	 * @param null|bool $skipFetchThreads Whether to skip fetching threads or not
+	 * @param null|bool $collapsedThreads Whether the client uses CRT or not
+	 * @param null|bool $collapsedThreadsExtended Whether to return the associated users as part of the response or not
+	 */
+	public function __construct(
+		protected string $postId,
+		protected ?int $perPage = null,
+		protected ?string $fromPost = null,
+		protected ?int $fromCreateAt = null,
+		protected ?string $direction = null,
+		protected ?bool $skipFetchThreads = null,
+		protected ?bool $collapsedThreads = null,
+		protected ?bool $collapsedThreadsExtended = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter([
+			'perPage' => $this->perPage,
+			'fromPost' => $this->fromPost,
+			'fromCreateAt' => $this->fromCreateAt,
+			'direction' => $this->direction,
+			'skipFetchThreads' => $this->skipFetchThreads,
+			'collapsedThreads' => $this->collapsedThreads,
+			'collapsedThreadsExtended' => $this->collapsedThreadsExtended,
+		]);
+	}
+}

--- a/src/Client/Requests/Posts/GetPostsAroundLastUnread.php
+++ b/src/Client/Requests/Posts/GetPostsAroundLastUnread.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Posts;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetPostsAroundLastUnread
+ *
+ * Get the oldest unread post in the channel for the given user as well as the posts around it. The
+ * returned list is sorted in descending order (most recent post first).
+ * ##### Permissions
+ * Must be
+ * logged in as the user or have `edit_other_users` permission, and must have `read_channel` permission
+ * for the channel.
+ * __Minimum server version__: 5.14
+ */
+class GetPostsAroundLastUnread extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/channels/{$this->channelId}/posts/unread";
+	}
+
+
+	/**
+	 * @param string $userId ID of the user
+	 * @param string $channelId The channel ID to get the posts for
+	 * @param null|int $limitBefore Number of posts before the oldest unread posts. Maximum is 200 posts if limit is set greater than that.
+	 * @param null|int $limitAfter Number of posts after and including the oldest unread post. Maximum is 200 posts if limit is set greater than that.
+	 * @param null|bool $skipFetchThreads Whether to skip fetching threads or not
+	 * @param null|bool $collapsedThreads Whether the client uses CRT or not
+	 * @param null|bool $collapsedThreadsExtended Whether to return the associated users as part of the response or not
+	 */
+	public function __construct(
+		protected string $userId,
+		protected string $channelId,
+		protected ?int $limitBefore = null,
+		protected ?int $limitAfter = null,
+		protected ?bool $skipFetchThreads = null,
+		protected ?bool $collapsedThreads = null,
+		protected ?bool $collapsedThreadsExtended = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter([
+			'limit_before' => $this->limitBefore,
+			'limit_after' => $this->limitAfter,
+			'skipFetchThreads' => $this->skipFetchThreads,
+			'collapsedThreads' => $this->collapsedThreads,
+			'collapsedThreadsExtended' => $this->collapsedThreadsExtended,
+		]);
+	}
+}

--- a/src/Client/Requests/Posts/GetPostsByIds.php
+++ b/src/Client/Requests/Posts/GetPostsByIds.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Posts;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * getPostsByIds
+ *
+ * Fetch a list of posts based on the provided postIDs
+ * ##### Permissions
+ * Must have `read_channel`
+ * permission for the channel the post is in or if the channel is public, have the
+ * `read_public_channels` permission for the team.
+ */
+class GetPostsByIds extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/posts/ids";
+	}
+
+
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Requests/Posts/GetPostsForChannel.php
+++ b/src/Client/Requests/Posts/GetPostsForChannel.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Posts;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetPostsForChannel
+ *
+ * Get a page of posts in a channel. Use the query parameters to modify the behaviour of this endpoint.
+ * The parameter `since` must not be used with any of `before`, `after`, `page`, and `per_page`
+ * parameters.
+ * If `since` is used, it will always return all posts modified since that time, ordered by
+ * their create time limited till 1000. A caveat with this parameter is that there is no guarantee that
+ * the returned posts will be consecutive. It is left to the clients to maintain state and fill any
+ * missing holes in the post order.
+ * ##### Permissions
+ * Must have `read_channel` permission for the
+ * channel.
+ */
+class GetPostsForChannel extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/channels/{$this->channelId}/posts";
+	}
+
+
+	/**
+	 * @param string $channelId The channel ID to get the posts for
+	 * @param null|int $page The page to select
+	 * @param null|int $since Provide a non-zero value in Unix time milliseconds to select posts modified after that time
+	 * @param null|string $before A post id to select the posts that came before this one
+	 * @param null|bool $includeDeleted Whether to include deleted posts or not. Must have system admin permissions.
+	 */
+	public function __construct(
+		protected string $channelId,
+		protected ?int $page = null,
+		protected ?int $since = null,
+		protected ?string $before = null,
+		protected ?bool $includeDeleted = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['page' => $this->page, 'since' => $this->since, 'before' => $this->before, 'include_deleted' => $this->includeDeleted]);
+	}
+}

--- a/src/Client/Requests/Posts/PatchPost.php
+++ b/src/Client/Requests/Posts/PatchPost.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Posts;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * PatchPost
+ *
+ * Partially update a post by providing only the fields you want to update. Omitted fields will not be
+ * updated. The fields that can be updated are defined in the request body, all other provided fields
+ * will be ignored.
+ * ##### Permissions
+ * Must have the `edit_post` permission.
+ */
+class PatchPost extends Request
+{
+	protected Method $method = Method::PUT;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/posts/{$this->postId}/patch";
+	}
+
+
+	/**
+	 * @param string $postId Post GUID
+	 */
+	public function __construct(
+		protected string $postId,
+	) {
+	}
+}

--- a/src/Client/Requests/Posts/PinPost.php
+++ b/src/Client/Requests/Posts/PinPost.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Posts;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * PinPost
+ *
+ * Pin a post to a channel it is in based from the provided post id string.
+ * ##### Permissions
+ * Must be
+ * authenticated and have the `read_channel` permission to the channel the post is in.
+ */
+class PinPost extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/posts/{$this->postId}/pin";
+	}
+
+
+	/**
+	 * @param string $postId Post GUID
+	 */
+	public function __construct(
+		protected string $postId,
+	) {
+	}
+}

--- a/src/Client/Requests/Posts/SaveAcknowledgementForPost.php
+++ b/src/Client/Requests/Posts/SaveAcknowledgementForPost.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Posts;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * SaveAcknowledgementForPost
+ *
+ * Delete an acknowledgement form a post that you had previously acknowledged.
+ * ##### Permissions
+ * Must
+ * have `read_channel` permission for the channel the post is in.<br/> Must be logged in as the user or
+ * have `edit_other_users` permission.<br/> The post must have been acknowledged in the previous 5
+ * minutes.
+ *
+ * __Minimum server version__: 7.7
+ */
+class SaveAcknowledgementForPost extends Request
+{
+	protected Method $method = Method::DELETE;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/posts/{$this->postId}/ack";
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 * @param string $postId Post GUID
+	 */
+	public function __construct(
+		protected string $userId,
+		protected string $postId,
+	) {
+	}
+}

--- a/src/Client/Requests/Posts/SearchPosts.php
+++ b/src/Client/Requests/Posts/SearchPosts.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Posts;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * SearchPosts
+ *
+ * Search posts in the team and from the provided terms string.
+ * ##### Permissions
+ * Must be authenticated
+ * and have the `view_team` permission.
+ */
+class SearchPosts extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/{$this->teamId}/posts/search";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 */
+	public function __construct(
+		protected string $teamId,
+	) {
+	}
+}

--- a/src/Client/Requests/Posts/SetPostReminder.php
+++ b/src/Client/Requests/Posts/SetPostReminder.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Posts;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * SetPostReminder
+ *
+ * Set a reminder for the user for the post.
+ * ##### Permissions
+ * Must have `read_channel` permission for
+ * the channel the post is in.
+ *
+ * __Minimum server version__: 7.2
+ */
+class SetPostReminder extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/posts/{$this->postId}/reminder";
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 * @param string $postId Post GUID
+	 */
+	public function __construct(
+		protected string $userId,
+		protected string $postId,
+	) {
+	}
+}

--- a/src/Client/Requests/Posts/SetPostUnread.php
+++ b/src/Client/Requests/Posts/SetPostUnread.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Posts;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * SetPostUnread
+ *
+ * Mark a channel as being unread from a given post.
+ * ##### Permissions
+ * Must have `read_channel`
+ * permission for the channel the post is in or if the channel is public, have the
+ * `read_public_channels` permission for the team.
+ * Must have `edit_other_users` permission if the user
+ * is not the one marking the post for himself.
+ *
+ * __Minimum server version__: 5.18
+ */
+class SetPostUnread extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/posts/{$this->postId}/set_unread";
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 * @param string $postId Post GUID
+	 */
+	public function __construct(
+		protected string $userId,
+		protected string $postId,
+	) {
+	}
+}

--- a/src/Client/Requests/Posts/UnpinPost.php
+++ b/src/Client/Requests/Posts/UnpinPost.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Posts;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * UnpinPost
+ *
+ * Unpin a post to a channel it is in based from the provided post id string.
+ * ##### Permissions
+ * Must be
+ * authenticated and have the `read_channel` permission to the channel the post is in.
+ */
+class UnpinPost extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/posts/{$this->postId}/unpin";
+	}
+
+
+	/**
+	 * @param string $postId Post GUID
+	 */
+	public function __construct(
+		protected string $postId,
+	) {
+	}
+}

--- a/src/Client/Requests/Posts/UpdatePost.php
+++ b/src/Client/Requests/Posts/UpdatePost.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Posts;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * UpdatePost
+ *
+ * Update a post. Only the fields listed below are updatable, omitted fields will be treated as
+ * blank.
+ * ##### Permissions
+ * Must have `edit_post` permission for the channel the post is in.
+ */
+class UpdatePost extends Request
+{
+	protected Method $method = Method::PUT;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/posts/{$this->postId}";
+	}
+
+
+	/**
+	 * @param string $postId ID of the post to update
+	 */
+	public function __construct(
+		protected string $postId,
+	) {
+	}
+}

--- a/src/Client/Requests/Preferences/DeletePreferences.php
+++ b/src/Client/Requests/Preferences/DeletePreferences.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Preferences;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * DeletePreferences
+ *
+ * Delete a list of the user's preferences.
+ * ##### Permissions
+ * Must be logged in as the user being
+ * updated or have the `edit_other_users` permission.
+ */
+class DeletePreferences extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/preferences/delete";
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function __construct(
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Preferences/GetPreferences.php
+++ b/src/Client/Requests/Preferences/GetPreferences.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Preferences;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetPreferences
+ *
+ * Get a list of the user's preferences.
+ * ##### Permissions
+ * Must be logged in as the user being updated
+ * or have the `edit_other_users` permission.
+ */
+class GetPreferences extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/preferences";
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function __construct(
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Preferences/GetPreferencesByCategory.php
+++ b/src/Client/Requests/Preferences/GetPreferencesByCategory.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Preferences;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetPreferencesByCategory
+ *
+ * Lists the current user's stored preferences in the given category.
+ * ##### Permissions
+ * Must be logged
+ * in as the user being updated or have the `edit_other_users` permission.
+ */
+class GetPreferencesByCategory extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/preferences/{$this->category}";
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 * @param string $category The category of a group of preferences
+	 */
+	public function __construct(
+		protected string $userId,
+		protected string $category,
+	) {
+	}
+}

--- a/src/Client/Requests/Preferences/GetPreferencesByCategoryByName.php
+++ b/src/Client/Requests/Preferences/GetPreferencesByCategoryByName.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Preferences;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetPreferencesByCategoryByName
+ *
+ * Gets a single preference for the current user with the given category and name.
+ * #####
+ * Permissions
+ * Must be logged in as the user being updated or have the `edit_other_users` permission.
+ */
+class GetPreferencesByCategoryByName extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/preferences/{$this->category}/name/{$this->preferenceName}";
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 * @param string $category The category of a group of preferences
+	 * @param string $preferenceName The name of the preference
+	 */
+	public function __construct(
+		protected string $userId,
+		protected string $category,
+		protected string $preferenceName,
+	) {
+	}
+}

--- a/src/Client/Requests/Preferences/UpdatePreferences.php
+++ b/src/Client/Requests/Preferences/UpdatePreferences.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Preferences;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * UpdatePreferences
+ *
+ * Save a list of the user's preferences.
+ * ##### Permissions
+ * Must be logged in as the user being updated
+ * or have the `edit_other_users` permission.
+ */
+class UpdatePreferences extends Request
+{
+	protected Method $method = Method::PUT;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/preferences";
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function __construct(
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Reactions/DeleteReaction.php
+++ b/src/Client/Requests/Reactions/DeleteReaction.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Reactions;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * DeleteReaction
+ *
+ * Deletes a reaction made by a user from the given post.
+ * ##### Permissions
+ * Must be user or have
+ * `manage_system` permission.
+ */
+class DeleteReaction extends Request
+{
+	protected Method $method = Method::DELETE;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/posts/{$this->postId}/reactions/{$this->emojiName}";
+	}
+
+
+	/**
+	 * @param string $userId ID of the user
+	 * @param string $postId ID of the post
+	 * @param string $emojiName emoji name
+	 */
+	public function __construct(
+		protected string $userId,
+		protected string $postId,
+		protected string $emojiName,
+	) {
+	}
+}

--- a/src/Client/Requests/Reactions/GetBulkReactions.php
+++ b/src/Client/Requests/Reactions/GetBulkReactions.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Reactions;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * GetBulkReactions
+ *
+ * Get a list of reactions made by all users to a given post.
+ * ##### Permissions
+ * Must have
+ * `read_channel` permission for the channel the post is in.
+ *
+ * __Minimum server version__: 5.8
+ */
+class GetBulkReactions extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/posts/ids/reactions";
+	}
+
+
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Requests/Reactions/GetReactions.php
+++ b/src/Client/Requests/Reactions/GetReactions.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Reactions;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetReactions
+ *
+ * Get a list of reactions made by all users to a given post.
+ * ##### Permissions
+ * Must have
+ * `read_channel` permission for the channel the post is in.
+ */
+class GetReactions extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/posts/{$this->postId}/reactions";
+	}
+
+
+	/**
+	 * @param string $postId ID of a post
+	 */
+	public function __construct(
+		protected string $postId,
+	) {
+	}
+}

--- a/src/Client/Requests/Reactions/SaveReaction.php
+++ b/src/Client/Requests/Reactions/SaveReaction.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Reactions;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * SaveReaction
+ *
+ * Create a reaction.
+ * ##### Permissions
+ * Must have `read_channel` permission for the channel the post is
+ * in.
+ */
+class SaveReaction extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/reactions";
+	}
+
+
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Requests/Status/GetUserStatus.php
+++ b/src/Client/Requests/Status/GetUserStatus.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Status;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetUserStatus
+ *
+ * Get user status by id from the server.
+ * ##### Permissions
+ * Must be authenticated.
+ */
+class GetUserStatus extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/status";
+	}
+
+
+	/**
+	 * @param string $userId User ID
+	 */
+	public function __construct(
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Status/GetUsersStatusesByIds.php
+++ b/src/Client/Requests/Status/GetUsersStatusesByIds.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Status;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * GetUsersStatusesByIds
+ *
+ * Get a list of user statuses by id from the server.
+ * ##### Permissions
+ * Must be authenticated.
+ */
+class GetUsersStatusesByIds extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/status/ids";
+	}
+
+
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Requests/Status/PostUserRecentCustomStatusDelete.php
+++ b/src/Client/Requests/Status/PostUserRecentCustomStatusDelete.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Status;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * PostUserRecentCustomStatusDelete
+ *
+ * Deletes a user's recent custom status by removing the specific status from the recentCustomStatuses
+ * in the user's props and updates the user.
+ * ##### Permissions
+ * Must be logged in as the user whose
+ * recent custom status is being deleted.
+ */
+class PostUserRecentCustomStatusDelete extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/status/custom/recent/delete";
+	}
+
+
+	/**
+	 * @param string $userId User ID
+	 */
+	public function __construct(
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Status/RemoveRecentCustomStatus.php
+++ b/src/Client/Requests/Status/RemoveRecentCustomStatus.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Status;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * RemoveRecentCustomStatus
+ *
+ * Deletes a user's recent custom status by removing the specific status from the recentCustomStatuses
+ * in the user's props and updates the user.
+ * ##### Permissions
+ * Must be logged in as the user whose
+ * recent custom status is being deleted.
+ */
+class RemoveRecentCustomStatus extends Request
+{
+	protected Method $method = Method::DELETE;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/status/custom/recent";
+	}
+
+
+	/**
+	 * @param string $userId User ID
+	 */
+	public function __construct(
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Status/UnsetUserCustomStatus.php
+++ b/src/Client/Requests/Status/UnsetUserCustomStatus.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Status;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * UnsetUserCustomStatus
+ *
+ * Unsets a user's custom status by updating the user's props and updates the user
+ * #####
+ * Permissions
+ * Must be logged in as the user whose custom status is being removed.
+ */
+class UnsetUserCustomStatus extends Request
+{
+	protected Method $method = Method::DELETE;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/status/custom";
+	}
+
+
+	/**
+	 * @param string $userId User ID
+	 */
+	public function __construct(
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Status/UpdateUserCustomStatus.php
+++ b/src/Client/Requests/Status/UpdateUserCustomStatus.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Status;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * UpdateUserCustomStatus
+ *
+ * Updates a user's custom status by setting the value in the user's props and updates the user. Also
+ * save the given custom status to the recent custom statuses in the user's props
+ * #####
+ * Permissions
+ * Must be logged in as the user whose custom status is being updated.
+ */
+class UpdateUserCustomStatus extends Request
+{
+	protected Method $method = Method::PUT;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/status/custom";
+	}
+
+
+	/**
+	 * @param string $userId User ID
+	 */
+	public function __construct(
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Status/UpdateUserStatus.php
+++ b/src/Client/Requests/Status/UpdateUserStatus.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Status;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * UpdateUserStatus
+ *
+ * Manually set a user's status. When setting a user's status, the status will remain that value until
+ * set "online" again, which will return the status to being automatically updated based on user
+ * activity.
+ * ##### Permissions
+ * Must have `edit_other_users` permission for the team.
+ */
+class UpdateUserStatus extends Request
+{
+	protected Method $method = Method::PUT;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/status";
+	}
+
+
+	/**
+	 * @param string $userId User ID
+	 */
+	public function __construct(
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/System/GenerateSupportPacket.php
+++ b/src/Client/Requests/System/GenerateSupportPacket.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\System;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GenerateSupportPacket
+ *
+ * Download a zip file which contains helpful and useful information for troubleshooting your
+ * mattermost instance.
+ * __Minimum server version: 5.32__
+ * ##### Permissions
+ * Must have any of the system
+ * console read permissions.
+ * ##### License
+ * Requires either a E10 or E20 license.
+ */
+class GenerateSupportPacket extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/system/support_packet";
+	}
+
+
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Requests/System/GetNotices.php
+++ b/src/Client/Requests/System/GetNotices.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\System;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetNotices
+ *
+ * Will return appropriate product notices for current user in the team specified by teamId
+ * parameter.
+ * __Minimum server version__: 5.26
+ * ##### Permissions
+ * Must be logged in.
+ */
+class GetNotices extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/system/notices/{$this->teamId}";
+	}
+
+
+	/**
+	 * @param string $teamId ID of the team
+	 * @param string $clientVersion Version of the client (desktop/mobile/web) that issues the request
+	 * @param null|string $locale Client locale
+	 * @param string $client Client type (web/mobile-ios/mobile-android/desktop)
+	 */
+	public function __construct(
+		protected string $teamId,
+		protected string $clientVersion,
+		protected ?string $locale = null,
+		protected string $client,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['clientVersion' => $this->clientVersion, 'locale' => $this->locale, 'client' => $this->client]);
+	}
+}

--- a/src/Client/Requests/System/GetPing.php
+++ b/src/Client/Requests/System/GetPing.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\System;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetPing
+ *
+ * Check if the server is up and healthy based on the configuration setting `GoRoutineHealthThreshold`.
+ * If `GoRoutineHealthThreshold` and the number of goroutines on the server exceeds that threshold the
+ * server is considered unhealthy. If `GoRoutineHealthThreshold` is not set or the number of goroutines
+ * is below the threshold the server is considered healthy.
+ * __Minimum server version__: 3.10
+ * If a
+ * "device_id" is passed in the query, it will test the Push Notification Proxy in order to discover
+ * whether the device is able to receive notifications. The response will have a
+ * "CanReceiveNotifications" property with one of the following values: - true: It can receive
+ * notifications - false: It cannot receive notifications - unknown: There has been an unknown error,
+ * and it is not certain whether it can
+ *   receive notifications.
+ *
+ * __Minimum server version__: 6.5
+ * #####
+ * Permissions
+ * None.
+ */
+class GetPing extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/system/ping";
+	}
+
+
+	/**
+	 * @param null|bool $getServerStatus Check the status of the database and file storage as well
+	 * @param null|string $deviceId Check whether this device id can receive push notifications
+	 */
+	public function __construct(
+		protected ?bool $getServerStatus = null,
+		protected ?string $deviceId = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['get_server_status' => $this->getServerStatus, 'device_id' => $this->deviceId]);
+	}
+}

--- a/src/Client/Requests/System/GetSupportedTimezone.php
+++ b/src/Client/Requests/System/GetSupportedTimezone.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\System;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetSupportedTimezone
+ *
+ * __Minimum server version__: 3.10
+ * ##### Permissions
+ * Must be logged in.
+ */
+class GetSupportedTimezone extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/system/timezones";
+	}
+
+
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Requests/System/MarkNoticesViewed.php
+++ b/src/Client/Requests/System/MarkNoticesViewed.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\System;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * MarkNoticesViewed
+ *
+ * Will mark the specified notices as 'viewed' by the logged in user.
+ * __Minimum server version__:
+ * 5.26
+ * ##### Permissions
+ * Must be logged in.
+ */
+class MarkNoticesViewed extends Request
+{
+	protected Method $method = Method::PUT;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/system/notices/view";
+	}
+
+
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Requests/Teams/AddTeamMember.php
+++ b/src/Client/Requests/Teams/AddTeamMember.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Teams;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * AddTeamMember
+ *
+ * Add user to the team by user_id.
+ * ##### Permissions
+ * Must be authenticated and team be open to add
+ * self. For adding another user, authenticated user must have the `add_user_to_team` permission.
+ */
+class AddTeamMember extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/{$this->teamId}/members";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 */
+	public function __construct(
+		protected string $teamId,
+	) {
+	}
+}

--- a/src/Client/Requests/Teams/AddTeamMemberFromInvite.php
+++ b/src/Client/Requests/Teams/AddTeamMemberFromInvite.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Teams;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * AddTeamMemberFromInvite
+ *
+ * Using either an invite id or hash/data pair from an email invite link, add a user to a team.
+ * #####
+ * Permissions
+ * Must be authenticated.
+ */
+class AddTeamMemberFromInvite extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/members/invite";
+	}
+
+
+	/**
+	 * @param string $token Token id from the invitation
+	 */
+	public function __construct(
+		protected string $token,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['token' => $this->token]);
+	}
+}

--- a/src/Client/Requests/Teams/AddTeamMembers.php
+++ b/src/Client/Requests/Teams/AddTeamMembers.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Teams;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * AddTeamMembers
+ *
+ * Add a number of users to the team by user_id.
+ * ##### Permissions
+ * Must be authenticated. Authenticated
+ * user must have the `add_user_to_team` permission.
+ */
+class AddTeamMembers extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/{$this->teamId}/members/batch";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param null|bool $graceful Instead of aborting the operation if a user cannot be added, return an arrray that will contain both the success and added members and the ones with error, in form of `[{"member": {...}, "user_id", "...", "error": {...}}]`
+	 */
+	public function __construct(
+		protected string $teamId,
+		protected ?bool $graceful = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['graceful' => $this->graceful]);
+	}
+}

--- a/src/Client/Requests/Teams/CreateTeam.php
+++ b/src/Client/Requests/Teams/CreateTeam.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Teams;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * CreateTeam
+ *
+ * Create a new team on the system.
+ * ##### Permissions
+ * Must be authenticated and have the `create_team`
+ * permission.
+ */
+class CreateTeam extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams";
+	}
+
+
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Requests/Teams/GetAllTeams.php
+++ b/src/Client/Requests/Teams/GetAllTeams.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Teams;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetAllTeams
+ *
+ * For regular users only returns open teams. Users with the "manage_system" permission will return
+ * teams regardless of type. The result is based on query string parameters - page and per_page.
+ * #####
+ * Permissions
+ * Must be authenticated. "manage_system" permission is required to show all teams.
+ */
+class GetAllTeams extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams";
+	}
+
+
+	/**
+	 * @param null|int $page The page to select.
+	 * @param null|bool $includeTotalCount Appends a total count of returned teams inside the response object - ex: `{ "teams": [], "total_count" : 0 }`.
+	 * @param null|bool $excludePolicyConstrained If set to true, teams which are part of a data retention policy will be excluded. The `sysconsole_read_compliance` permission is required to use this parameter.
+	 * __Minimum server version__: 5.35
+	 */
+	public function __construct(
+		protected ?int $page = null,
+		protected ?bool $includeTotalCount = null,
+		protected ?bool $excludePolicyConstrained = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter([
+			'page' => $this->page,
+			'include_total_count' => $this->includeTotalCount,
+			'exclude_policy_constrained' => $this->excludePolicyConstrained,
+		]);
+	}
+}

--- a/src/Client/Requests/Teams/GetTeam.php
+++ b/src/Client/Requests/Teams/GetTeam.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Teams;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetTeam
+ *
+ * Get a team on the system.
+ * ##### Permissions
+ * Must be authenticated and have the `view_team`
+ * permission.
+ */
+class GetTeam extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/{$this->teamId}";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 */
+	public function __construct(
+		protected string $teamId,
+	) {
+	}
+}

--- a/src/Client/Requests/Teams/GetTeamByName.php
+++ b/src/Client/Requests/Teams/GetTeamByName.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Teams;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetTeamByName
+ *
+ * Get a team based on provided name string
+ * ##### Permissions
+ * Must be authenticated, team type is open
+ * and have the `view_team` permission.
+ */
+class GetTeamByName extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/name/{$this->name}";
+	}
+
+
+	/**
+	 * @param string $name Team Name
+	 */
+	public function __construct(
+		protected string $name,
+	) {
+	}
+}

--- a/src/Client/Requests/Teams/GetTeamIcon.php
+++ b/src/Client/Requests/Teams/GetTeamIcon.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Teams;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetTeamIcon
+ *
+ * Get the team icon of the team.
+ *
+ * __Minimum server version__: 4.9
+ *
+ * ##### Permissions
+ * User must be
+ * authenticated. In addition, team must be open or the user must have the `view_team` permission.
+ */
+class GetTeamIcon extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/{$this->teamId}/image";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 */
+	public function __construct(
+		protected string $teamId,
+	) {
+	}
+}

--- a/src/Client/Requests/Teams/GetTeamInviteInfo.php
+++ b/src/Client/Requests/Teams/GetTeamInviteInfo.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Teams;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetTeamInviteInfo
+ *
+ * Get the `name`, `display_name`, `description` and `id` for a team from the invite id.
+ *
+ * __Minimum
+ * server version__: 4.0
+ *
+ * ##### Permissions
+ * No authentication required.
+ */
+class GetTeamInviteInfo extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/invite/{$this->inviteId}";
+	}
+
+
+	/**
+	 * @param string $inviteId Invite id for a team
+	 */
+	public function __construct(
+		protected string $inviteId,
+	) {
+	}
+}

--- a/src/Client/Requests/Teams/GetTeamMember.php
+++ b/src/Client/Requests/Teams/GetTeamMember.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Teams;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetTeamMember
+ *
+ * Get a team member on the system.
+ * ##### Permissions
+ * Must be authenticated and have the `view_team`
+ * permission.
+ */
+class GetTeamMember extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/{$this->teamId}/members/{$this->userId}";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param string $userId User GUID
+	 */
+	public function __construct(
+		protected string $teamId,
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Teams/GetTeamMembers.php
+++ b/src/Client/Requests/Teams/GetTeamMembers.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Teams;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetTeamMembers
+ *
+ * Get a page team members list based on query string parameters - team id, page and per page.
+ * #####
+ * Permissions
+ * Must be authenticated and have the `view_team` permission.
+ */
+class GetTeamMembers extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/{$this->teamId}/members";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param null|int $page The page to select.
+	 */
+	public function __construct(
+		protected string $teamId,
+		protected ?int $page = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['page' => $this->page]);
+	}
+}

--- a/src/Client/Requests/Teams/GetTeamMembersByIds.php
+++ b/src/Client/Requests/Teams/GetTeamMembersByIds.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Teams;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * GetTeamMembersByIds
+ *
+ * Get a list of team members based on a provided array of user ids.
+ * ##### Permissions
+ * Must have
+ * `view_team` permission for the team.
+ */
+class GetTeamMembersByIds extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/{$this->teamId}/members/ids";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 */
+	public function __construct(
+		protected string $teamId,
+	) {
+	}
+}

--- a/src/Client/Requests/Teams/GetTeamMembersForUser.php
+++ b/src/Client/Requests/Teams/GetTeamMembersForUser.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Teams;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetTeamMembersForUser
+ *
+ * Get a list of team members for a user. Useful for getting the ids of teams the user is on and the
+ * roles they have in those teams.
+ * ##### Permissions
+ * Must be logged in as the user or have the
+ * `edit_other_users` permission.
+ */
+class GetTeamMembersForUser extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/teams/members";
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function __construct(
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Teams/GetTeamStats.php
+++ b/src/Client/Requests/Teams/GetTeamStats.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Teams;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetTeamStats
+ *
+ * Get a team stats on the system.
+ * ##### Permissions
+ * Must be authenticated and have the `view_team`
+ * permission.
+ */
+class GetTeamStats extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/{$this->teamId}/stats";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 */
+	public function __construct(
+		protected string $teamId,
+	) {
+	}
+}

--- a/src/Client/Requests/Teams/GetTeamUnread.php
+++ b/src/Client/Requests/Teams/GetTeamUnread.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Teams;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetTeamUnread
+ *
+ * Get the unread mention and message counts for a team for the specified user.
+ * ##### Permissions
+ * Must
+ * be the user or have `edit_other_users` permission and have `view_team` permission for the team.
+ */
+class GetTeamUnread extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/unread";
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 * @param string $teamId Team GUID
+	 */
+	public function __construct(
+		protected string $userId,
+		protected string $teamId,
+	) {
+	}
+}

--- a/src/Client/Requests/Teams/GetTeamsForUser.php
+++ b/src/Client/Requests/Teams/GetTeamsForUser.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Teams;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetTeamsForUser
+ *
+ * Get a list of teams that a user is on.
+ * ##### Permissions
+ * Must be authenticated as the user or have
+ * the `manage_system` permission.
+ */
+class GetTeamsForUser extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/teams";
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function __construct(
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Teams/GetTeamsUnreadForUser.php
+++ b/src/Client/Requests/Teams/GetTeamsUnreadForUser.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Teams;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetTeamsUnreadForUser
+ *
+ * Get the count for unread messages and mentions in the teams the user is a member of.
+ * #####
+ * Permissions
+ * Must be logged in.
+ */
+class GetTeamsUnreadForUser extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/teams/unread";
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 * @param string $excludeTeam Optional team id to be excluded from the results
+	 * @param null|bool $includeCollapsedThreads Boolean to determine whether the collapsed threads should be included or not
+	 */
+	public function __construct(
+		protected string $userId,
+		protected string $excludeTeam,
+		protected ?bool $includeCollapsedThreads = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['exclude_team' => $this->excludeTeam, 'include_collapsed_threads' => $this->includeCollapsedThreads]);
+	}
+}

--- a/src/Client/Requests/Teams/ImportTeam.php
+++ b/src/Client/Requests/Teams/ImportTeam.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Teams;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * ImportTeam
+ *
+ * Import a team into a existing team. Import users, channels, posts, hooks.
+ * ##### Permissions
+ * Must
+ * have `permission_import_team` permission.
+ */
+class ImportTeam extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/{$this->teamId}/import";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 */
+	public function __construct(
+		protected string $teamId,
+	) {
+	}
+}

--- a/src/Client/Requests/Teams/InvalidateEmailInvites.php
+++ b/src/Client/Requests/Teams/InvalidateEmailInvites.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Teams;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * InvalidateEmailInvites
+ *
+ * Invalidate active email invitations that have not been accepted by the user.
+ * ##### Permissions
+ * Must
+ * have `sysconsole_write_authentication` permission.
+ */
+class InvalidateEmailInvites extends Request
+{
+	protected Method $method = Method::DELETE;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/invites/email";
+	}
+
+
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Requests/Teams/InviteGuestsToTeam.php
+++ b/src/Client/Requests/Teams/InviteGuestsToTeam.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Teams;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * InviteGuestsToTeam
+ *
+ * Invite guests to existing team channels usign the user's email.
+ *
+ * The number of emails that can be
+ * sent is rate limited to 20 per hour with a burst of 20 emails. If the rate limit exceeds, the error
+ * message contains details on when to retry and when the timer will be reset.
+ *
+ * __Minimum server
+ * version__: 5.16
+ *
+ * ##### Permissions
+ * Must have `invite_guest` permission for the team.
+ */
+class InviteGuestsToTeam extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/{$this->teamId}/invite-guests/email";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 */
+	public function __construct(
+		protected string $teamId,
+	) {
+	}
+}

--- a/src/Client/Requests/Teams/InviteUsersToTeam.php
+++ b/src/Client/Requests/Teams/InviteUsersToTeam.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Teams;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * InviteUsersToTeam
+ *
+ * Invite users to the existing team using the user's email.
+ *
+ * The number of emails that can be sent is
+ * rate limited to 20 per hour with a burst of 20 emails. If the rate limit exceeds, the error message
+ * contains details on when to retry and when the timer will be reset.
+ * ##### Permissions
+ * Must have
+ * `invite_user` and `add_user_to_team` permissions for the team.
+ */
+class InviteUsersToTeam extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/{$this->teamId}/invite/email";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 */
+	public function __construct(
+		protected string $teamId,
+	) {
+	}
+}

--- a/src/Client/Requests/Teams/PatchTeam.php
+++ b/src/Client/Requests/Teams/PatchTeam.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Teams;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * PatchTeam
+ *
+ * Partially update a team by providing only the fields you want to update. Omitted fields will not be
+ * updated. The fields that can be updated are defined in the request body, all other provided fields
+ * will be ignored.
+ * ##### Permissions
+ * Must have the `manage_team` permission.
+ */
+class PatchTeam extends Request
+{
+	protected Method $method = Method::PUT;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/{$this->teamId}/patch";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 */
+	public function __construct(
+		protected string $teamId,
+	) {
+	}
+}

--- a/src/Client/Requests/Teams/RegenerateTeamInviteId.php
+++ b/src/Client/Requests/Teams/RegenerateTeamInviteId.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Teams;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * RegenerateTeamInviteId
+ *
+ * Regenerates the invite ID used in invite links of a team
+ * ##### Permissions
+ * Must be authenticated and
+ * have the `manage_team` permission.
+ */
+class RegenerateTeamInviteId extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/{$this->teamId}/regenerate_invite_id";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 */
+	public function __construct(
+		protected string $teamId,
+	) {
+	}
+}

--- a/src/Client/Requests/Teams/RemoveTeamIcon.php
+++ b/src/Client/Requests/Teams/RemoveTeamIcon.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Teams;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * RemoveTeamIcon
+ *
+ * Remove the team icon for the team.
+ *
+ * __Minimum server version__: 4.10
+ *
+ * ##### Permissions
+ * Must be
+ * authenticated and have the `manage_team` permission.
+ */
+class RemoveTeamIcon extends Request
+{
+	protected Method $method = Method::DELETE;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/{$this->teamId}/image";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 */
+	public function __construct(
+		protected string $teamId,
+	) {
+	}
+}

--- a/src/Client/Requests/Teams/RemoveTeamMember.php
+++ b/src/Client/Requests/Teams/RemoveTeamMember.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Teams;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * RemoveTeamMember
+ *
+ * Delete the team member object for a user, effectively removing them from a team.
+ * #####
+ * Permissions
+ * Must be logged in as the user or have the `remove_user_from_team` permission.
+ */
+class RemoveTeamMember extends Request
+{
+	protected Method $method = Method::DELETE;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/{$this->teamId}/members/{$this->userId}";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param string $userId User GUID
+	 */
+	public function __construct(
+		protected string $teamId,
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Teams/RestoreTeam.php
+++ b/src/Client/Requests/Teams/RestoreTeam.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Teams;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * RestoreTeam
+ *
+ * Restore a team that was previously soft deleted.
+ *
+ * __Minimum server version__: 5.24
+ *
+ * #####
+ * Permissions
+ * Must have the `manage_team` permission.
+ */
+class RestoreTeam extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/{$this->teamId}/restore";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 */
+	public function __construct(
+		protected string $teamId,
+	) {
+	}
+}

--- a/src/Client/Requests/Teams/SearchFiles.php
+++ b/src/Client/Requests/Teams/SearchFiles.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Teams;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * SearchFiles
+ *
+ * Search for files in a team based on file name, extention and file content (if file content
+ * extraction is enabled and supported for the files).
+ * __Minimum server version__: 5.34
+ * #####
+ * Permissions
+ * Must be authenticated and have the `view_team` permission.
+ */
+class SearchFiles extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/{$this->teamId}/files/search";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 */
+	public function __construct(
+		protected string $teamId,
+	) {
+	}
+}

--- a/src/Client/Requests/Teams/SearchTeams.php
+++ b/src/Client/Requests/Teams/SearchTeams.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Teams;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * SearchTeams
+ *
+ * Search teams based on search term and options provided in the request body.
+ *
+ * #####
+ * Permissions
+ * Logged in user only shows open teams
+ * Logged in user with "manage_system" permission
+ * shows all teams
+ */
+class SearchTeams extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/search";
+	}
+
+
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Requests/Teams/SetTeamIcon.php
+++ b/src/Client/Requests/Teams/SetTeamIcon.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Teams;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * SetTeamIcon
+ *
+ * Sets the team icon for the team.
+ *
+ * __Minimum server version__: 4.9
+ *
+ * ##### Permissions
+ * Must be
+ * authenticated and have the `manage_team` permission.
+ */
+class SetTeamIcon extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/{$this->teamId}/image";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 */
+	public function __construct(
+		protected string $teamId,
+	) {
+	}
+}

--- a/src/Client/Requests/Teams/SoftDeleteTeam.php
+++ b/src/Client/Requests/Teams/SoftDeleteTeam.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Teams;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * SoftDeleteTeam
+ *
+ * Soft deletes a team, by marking the team as deleted in the database. Soft deleted teams will not be
+ * accessible in the user interface.
+ *
+ * Optionally use the permanent query parameter to hard delete the
+ * team for compliance reasons. As of server version 5.0, to use this feature
+ * `ServiceSettings.EnableAPITeamDeletion` must be set to `true` in the server's configuration.
+ * #####
+ * Permissions
+ * Must have the `manage_team` permission.
+ */
+class SoftDeleteTeam extends Request
+{
+	protected Method $method = Method::DELETE;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/{$this->teamId}";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param null|bool $permanent Permanently delete the team, to be used for compliance reasons only. As of server version 5.0, `ServiceSettings.EnableAPITeamDeletion` must be set to `true` in the server's configuration.
+	 */
+	public function __construct(
+		protected string $teamId,
+		protected ?bool $permanent = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['permanent' => $this->permanent]);
+	}
+}

--- a/src/Client/Requests/Teams/TeamExists.php
+++ b/src/Client/Requests/Teams/TeamExists.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Teams;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * TeamExists
+ *
+ * Check if the team exists based on a team name.
+ * ##### Permissions
+ * Must be authenticated.
+ */
+class TeamExists extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/name/{$this->name}/exists";
+	}
+
+
+	/**
+	 * @param string $name Team Name
+	 */
+	public function __construct(
+		protected string $name,
+	) {
+	}
+}

--- a/src/Client/Requests/Teams/TeamMembersMinusGroupMembers.php
+++ b/src/Client/Requests/Teams/TeamMembersMinusGroupMembers.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Teams;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * TeamMembersMinusGroupMembers
+ *
+ * Get the set of users who are members of the team minus the set of users who are members of the given
+ * groups.
+ * Each user object contains an array of group objects representing the group memberships for
+ * that user.
+ * Each user object contains the boolean fields `scheme_guest`, `scheme_user`, and
+ * `scheme_admin` representing the roles that user has for the given team.
+ *
+ * ##### Permissions
+ * Must have
+ * `manage_system` permission.
+ *
+ * __Minimum server version__: 5.14
+ */
+class TeamMembersMinusGroupMembers extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/{$this->teamId}/members_minus_group_members";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param string $groupIds A comma-separated list of group ids.
+	 * @param null|int $page The page to select.
+	 */
+	public function __construct(
+		protected string $teamId,
+		protected string $groupIds,
+		protected ?int $page = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['group_ids' => $this->groupIds, 'page' => $this->page]);
+	}
+}

--- a/src/Client/Requests/Teams/UpdateTeam.php
+++ b/src/Client/Requests/Teams/UpdateTeam.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Teams;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * UpdateTeam
+ *
+ * Update a team by providing the team object. The fields that can be updated are defined in the
+ * request body, all other provided fields will be ignored.
+ * ##### Permissions
+ * Must have the
+ * `manage_team` permission.
+ */
+class UpdateTeam extends Request
+{
+	protected Method $method = Method::PUT;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/{$this->teamId}";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 */
+	public function __construct(
+		protected string $teamId,
+	) {
+	}
+}

--- a/src/Client/Requests/Teams/UpdateTeamMemberRoles.php
+++ b/src/Client/Requests/Teams/UpdateTeamMemberRoles.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Teams;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * UpdateTeamMemberRoles
+ *
+ * Update a team member roles. Valid team roles are "team_user", "team_admin" or both of them.
+ * Overwrites any previously assigned team roles.
+ * ##### Permissions
+ * Must be authenticated and have the
+ * `manage_team_roles` permission.
+ */
+class UpdateTeamMemberRoles extends Request
+{
+	protected Method $method = Method::PUT;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/{$this->teamId}/members/{$this->userId}/roles";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param string $userId User GUID
+	 */
+	public function __construct(
+		protected string $teamId,
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Teams/UpdateTeamMemberSchemeRoles.php
+++ b/src/Client/Requests/Teams/UpdateTeamMemberSchemeRoles.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Teams;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * UpdateTeamMemberSchemeRoles
+ *
+ * Update a team member's scheme_admin/scheme_user properties. Typically this should either be
+ * `scheme_admin=false, scheme_user=true` for ordinary team member, or `scheme_admin=true,
+ * scheme_user=true` for a team admin.
+ *
+ * __Minimum server version__: 5.0
+ *
+ * ##### Permissions
+ * Must be
+ * authenticated and have the `manage_team_roles` permission.
+ */
+class UpdateTeamMemberSchemeRoles extends Request
+{
+	protected Method $method = Method::PUT;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/{$this->teamId}/members/{$this->userId}/schemeRoles";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param string $userId User GUID
+	 */
+	public function __construct(
+		protected string $teamId,
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Teams/UpdateTeamPrivacy.php
+++ b/src/Client/Requests/Teams/UpdateTeamPrivacy.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Teams;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * UpdateTeamPrivacy
+ *
+ * Updates team's privacy allowing changing a team from Public (open) to Private (invitation only) and
+ * back.
+ *
+ * __Minimum server version__: 5.24
+ *
+ * ##### Permissions
+ * `manage_team` permission for the team of
+ * the team.
+ */
+class UpdateTeamPrivacy extends Request
+{
+	protected Method $method = Method::PUT;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/{$this->teamId}/privacy";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 */
+	public function __construct(
+		protected string $teamId,
+	) {
+	}
+}

--- a/src/Client/Requests/Teams/UpdateTeamScheme.php
+++ b/src/Client/Requests/Teams/UpdateTeamScheme.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Teams;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * UpdateTeamScheme
+ *
+ * Set a team's scheme, more specifically sets the scheme_id value of a team record.
+ *
+ * #####
+ * Permissions
+ * Must have `manage_system` permission.
+ *
+ * __Minimum server version__: 5.0
+ */
+class UpdateTeamScheme extends Request
+{
+	protected Method $method = Method::PUT;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/teams/{$this->teamId}/scheme";
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 */
+	public function __construct(
+		protected string $teamId,
+	) {
+	}
+}

--- a/src/Client/Requests/Threads/GetThreadMentionCountsByChannel.php
+++ b/src/Client/Requests/Threads/GetThreadMentionCountsByChannel.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Threads;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetThreadMentionCountsByChannel
+ *
+ * Get all unread mention counts from followed threads
+ *
+ * __Minimum server version__: 5.29
+ *
+ * #####
+ * Permissions
+ * Must be logged in as the user or have `edit_other_users` permission.
+ */
+class GetThreadMentionCountsByChannel extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/threads/mention_counts";
+	}
+
+
+	/**
+	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
+	 * @param string $teamId The ID of the team in which the thread is.
+	 */
+	public function __construct(
+		protected string $userId,
+		protected string $teamId,
+	) {
+	}
+}

--- a/src/Client/Requests/Threads/GetUserThread.php
+++ b/src/Client/Requests/Threads/GetUserThread.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Threads;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetUserThread
+ *
+ * Get a thread
+ *
+ * __Minimum server version__: 5.29
+ *
+ * ##### Permissions
+ * Must be logged in as the user or
+ * have `edit_other_users` permission.
+ */
+class GetUserThread extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/threads/{$this->threadId}";
+	}
+
+
+	/**
+	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
+	 * @param string $teamId The ID of the team in which the thread is.
+	 * @param string $threadId The ID of the thread to follow
+	 */
+	public function __construct(
+		protected string $userId,
+		protected string $teamId,
+		protected string $threadId,
+	) {
+	}
+}

--- a/src/Client/Requests/Threads/GetUserThreads.php
+++ b/src/Client/Requests/Threads/GetUserThreads.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Threads;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetUserThreads
+ *
+ * Get all threads that user is following
+ *
+ * __Minimum server version__: 5.29
+ *
+ * ##### Permissions
+ * Must be
+ * logged in as the user or have `edit_other_users` permission.
+ */
+class GetUserThreads extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/threads";
+	}
+
+
+	/**
+	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
+	 * @param string $teamId The ID of the team in which the thread is.
+	 * @param null|int $since Since filters the threads based on their LastUpdateAt timestamp.
+	 * @param null|bool $deleted Deleted will specify that even deleted threads should be returned (For mobile sync).
+	 * @param null|bool $extended Extended will enrich the response with participant details.
+	 * @param null|int $page Page specifies which part of the results to return, by PageSize.
+	 * @param null|int $pageSize PageSize specifies the size of the returned chunk of results.
+	 * @param null|bool $totalsOnly Setting this to true will only return the total counts.
+	 * @param null|bool $threadsOnly Setting this to true will only return threads.
+	 */
+	public function __construct(
+		protected string $userId,
+		protected string $teamId,
+		protected ?int $since = null,
+		protected ?bool $deleted = null,
+		protected ?bool $extended = null,
+		protected ?int $page = null,
+		protected ?int $pageSize = null,
+		protected ?bool $totalsOnly = null,
+		protected ?bool $threadsOnly = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter([
+			'since' => $this->since,
+			'deleted' => $this->deleted,
+			'extended' => $this->extended,
+			'page' => $this->page,
+			'pageSize' => $this->pageSize,
+			'totalsOnly' => $this->totalsOnly,
+			'threadsOnly' => $this->threadsOnly,
+		]);
+	}
+}

--- a/src/Client/Requests/Threads/SetThreadUnreadByPostId.php
+++ b/src/Client/Requests/Threads/SetThreadUnreadByPostId.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Threads;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * SetThreadUnreadByPostId
+ *
+ * Mark a thread that user is following as unread
+ *
+ * __Minimum server version__: 6.7
+ *
+ * #####
+ * Permissions
+ * Must have `read_channel` permission for the channel the thread is in or if the channel
+ * is public, have the `read_public_channels` permission for the team.
+ *
+ * Must have `edit_other_users`
+ * permission if the user is not the one marking the thread for himself.
+ */
+class SetThreadUnreadByPostId extends Request
+{
+	protected Method $method = Method::PUT;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/threads/{$this->threadId}/set_unread/{$this->postId}";
+	}
+
+
+	/**
+	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
+	 * @param string $teamId The ID of the team in which the thread is.
+	 * @param string $threadId The ID of the thread to update
+	 * @param string $postId The ID of a post belonging to the thread to mark as unread.
+	 */
+	public function __construct(
+		protected string $userId,
+		protected string $teamId,
+		protected string $threadId,
+		protected string $postId,
+	) {
+	}
+}

--- a/src/Client/Requests/Threads/StartFollowingThread.php
+++ b/src/Client/Requests/Threads/StartFollowingThread.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Threads;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * StartFollowingThread
+ *
+ * Start following a thread
+ *
+ * __Minimum server version__: 5.29
+ *
+ * ##### Permissions
+ * Must be logged in as
+ * the user or have `edit_other_users` permission.
+ */
+class StartFollowingThread extends Request
+{
+	protected Method $method = Method::PUT;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/threads/{$this->threadId}/following";
+	}
+
+
+	/**
+	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
+	 * @param string $teamId The ID of the team in which the thread is.
+	 * @param string $threadId The ID of the thread to follow
+	 */
+	public function __construct(
+		protected string $userId,
+		protected string $teamId,
+		protected string $threadId,
+	) {
+	}
+}

--- a/src/Client/Requests/Threads/StopFollowingThread.php
+++ b/src/Client/Requests/Threads/StopFollowingThread.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Threads;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * StopFollowingThread
+ *
+ * Stop following a thread
+ *
+ * __Minimum server version__: 5.29
+ *
+ * ##### Permissions
+ * Must be logged in as
+ * the user or have `edit_other_users` permission.
+ */
+class StopFollowingThread extends Request
+{
+	protected Method $method = Method::DELETE;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/threads/{$this->threadId}/following";
+	}
+
+
+	/**
+	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
+	 * @param string $teamId The ID of the team in which the thread is.
+	 * @param string $threadId The ID of the thread to update
+	 */
+	public function __construct(
+		protected string $userId,
+		protected string $teamId,
+		protected string $threadId,
+	) {
+	}
+}

--- a/src/Client/Requests/Threads/UpdateThreadReadForUser.php
+++ b/src/Client/Requests/Threads/UpdateThreadReadForUser.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Threads;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * UpdateThreadReadForUser
+ *
+ * Mark a thread that user is following as read
+ *
+ * __Minimum server version__: 5.29
+ *
+ * #####
+ * Permissions
+ * Must be logged in as the user or have `edit_other_users` permission.
+ */
+class UpdateThreadReadForUser extends Request
+{
+	protected Method $method = Method::PUT;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/threads/{$this->threadId}/read/{$this->timestamp}";
+	}
+
+
+	/**
+	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
+	 * @param string $teamId The ID of the team in which the thread is.
+	 * @param string $threadId The ID of the thread to update
+	 * @param string $timestamp The timestamp to which the thread's "last read" state will be reset.
+	 */
+	public function __construct(
+		protected string $userId,
+		protected string $teamId,
+		protected string $threadId,
+		protected string $timestamp,
+	) {
+	}
+}

--- a/src/Client/Requests/Threads/UpdateThreadsReadForUser.php
+++ b/src/Client/Requests/Threads/UpdateThreadsReadForUser.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Threads;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * UpdateThreadsReadForUser
+ *
+ * Mark all threads that user is following as read
+ *
+ * __Minimum server version__: 5.29
+ *
+ * #####
+ * Permissions
+ * Must be logged in as the user or have `edit_other_users` permission.
+ */
+class UpdateThreadsReadForUser extends Request
+{
+	protected Method $method = Method::PUT;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/threads/read";
+	}
+
+
+	/**
+	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
+	 * @param string $teamId The ID of the team in which the thread is.
+	 */
+	public function __construct(
+		protected string $userId,
+		protected string $teamId,
+	) {
+	}
+}

--- a/src/Client/Requests/Users/AttachDeviceId.php
+++ b/src/Client/Requests/Users/AttachDeviceId.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * AttachDeviceId
+ *
+ * Attach a mobile device id to the currently logged in session. This will enable push notifications
+ * for a user, if configured by the server.
+ * ##### Permissions
+ * Must be authenticated.
+ */
+class AttachDeviceId extends Request
+{
+	protected Method $method = Method::PUT;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/sessions/device";
+	}
+
+
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Requests/Users/AutocompleteUsers.php
+++ b/src/Client/Requests/Users/AutocompleteUsers.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * AutocompleteUsers
+ *
+ * Get a list of users for the purpose of autocompleting based on the provided search term. Specify a
+ * combination of `team_id` and `channel_id` to filter results further.
+ * ##### Permissions
+ * Requires an
+ * active session and `view_team` and `read_channel` on any teams or channels used to filter the
+ * results further.
+ */
+class AutocompleteUsers extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/autocomplete";
+	}
+
+
+	/**
+	 * @param null|string $teamId Team ID
+	 * @param null|string $channelId Channel ID
+	 * @param string $name Username, nickname first name or last name
+	 * @param null|int $limit The maximum number of users to return in each subresult
+	 *
+	 * __Available as of server version 5.6. Defaults to `100` if not provided or on an earlier server version.__
+	 */
+	public function __construct(
+		protected ?string $teamId = null,
+		protected ?string $channelId = null,
+		protected string $name,
+		protected ?int $limit = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['team_id' => $this->teamId, 'channel_id' => $this->channelId, 'name' => $this->name, 'limit' => $this->limit]);
+	}
+}

--- a/src/Client/Requests/Users/CheckUserMfa.php
+++ b/src/Client/Requests/Users/CheckUserMfa.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * CheckUserMfa
+ *
+ * Check if a user has multi-factor authentication active on their account by providing a login id.
+ * Used to check whether an MFA code needs to be provided when logging in.
+ * ##### Permissions
+ * No
+ * permission required.
+ */
+class CheckUserMfa extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/mfa";
+	}
+
+
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Requests/Users/CreateUser.php
+++ b/src/Client/Requests/Users/CreateUser.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * CreateUser
+ *
+ * Create a new user on the system. Password is required for email login. For other authentication
+ * types such as LDAP or SAML, auth_data and auth_service fields are required.
+ * ##### Permissions
+ * No
+ * permission required for creating email/username accounts on an open server. Auth Token is required
+ * for other authentication types such as LDAP or SAML.
+ */
+class CreateUser extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users";
+	}
+
+
+	/**
+	 * @param null|string $t Token id from an email invitation
+	 * @param null|string $iid Token id from an invitation link
+	 */
+	public function __construct(
+		protected ?string $t = null,
+		protected ?string $iid = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['t' => $this->t, 'iid' => $this->iid]);
+	}
+}

--- a/src/Client/Requests/Users/CreateUserAccessToken.php
+++ b/src/Client/Requests/Users/CreateUserAccessToken.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * CreateUserAccessToken
+ *
+ * Generate a user access token that can be used to authenticate with the Mattermost REST
+ * API.
+ *
+ * __Minimum server version__: 4.1
+ *
+ * ##### Permissions
+ * Must have `create_user_access_token`
+ * permission. For non-self requests, must also have the `edit_other_users` permission.
+ */
+class CreateUserAccessToken extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/tokens";
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function __construct(
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Users/DeleteUser.php
+++ b/src/Client/Requests/Users/DeleteUser.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * DeleteUser
+ *
+ * Deactivates the user and revokes all its sessions by archiving its user object.
+ *
+ * As of server
+ * version 5.28, optionally use the `permanent=true` query parameter to permanently delete the user for
+ * compliance reasons. To use this feature `ServiceSettings.EnableAPIUserDeletion` must be set to
+ * `true` in the server's configuration.
+ * ##### Permissions
+ * Must be logged in as the user being
+ * deactivated or have the `edit_other_users` permission.
+ */
+class DeleteUser extends Request
+{
+	protected Method $method = Method::DELETE;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}";
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function __construct(
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Users/DemoteUserToGuest.php
+++ b/src/Client/Requests/Users/DemoteUserToGuest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * DemoteUserToGuest
+ *
+ * Convert a regular user into a guest. This will convert the user into a
+ * guest for the whole system
+ * while retaining their existing team and
+ * channel memberships.
+ *
+ * __Minimum server version__:
+ * 5.16
+ *
+ * ##### Permissions
+ * Must be logged in as the user or have the `demote_to_guest` permission.
+ */
+class DemoteUserToGuest extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/demote";
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function __construct(
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Users/DisableUserAccessToken.php
+++ b/src/Client/Requests/Users/DisableUserAccessToken.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * DisableUserAccessToken
+ *
+ * Disable a personal access token and delete any sessions using the token. The token can be re-enabled
+ * using `/users/tokens/enable`.
+ *
+ * __Minimum server version__: 4.4
+ *
+ * ##### Permissions
+ * Must have
+ * `revoke_user_access_token` permission. For non-self requests, must also have the `edit_other_users`
+ * permission.
+ */
+class DisableUserAccessToken extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/tokens/disable";
+	}
+
+
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Requests/Users/EnableUserAccessToken.php
+++ b/src/Client/Requests/Users/EnableUserAccessToken.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * EnableUserAccessToken
+ *
+ * Re-enable a personal access token that has been disabled.
+ *
+ * __Minimum server version__: 4.4
+ *
+ * #####
+ * Permissions
+ * Must have `create_user_access_token` permission. For non-self requests, must also have
+ * the `edit_other_users` permission.
+ */
+class EnableUserAccessToken extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/tokens/enable";
+	}
+
+
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Requests/Users/GenerateMfaSecret.php
+++ b/src/Client/Requests/Users/GenerateMfaSecret.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * GenerateMfaSecret
+ *
+ * Generates an multi-factor authentication secret for a user and returns it as a string and as base64
+ * encoded QR code image.
+ * ##### Permissions
+ * Must be logged in as the user or have the
+ * `edit_other_users` permission.
+ */
+class GenerateMfaSecret extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/mfa/generate";
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function __construct(
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Users/GetChannelMembersWithTeamDataForUser.php
+++ b/src/Client/Requests/Users/GetChannelMembersWithTeamDataForUser.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetChannelMembersWithTeamDataForUser
+ *
+ * Get all channel members from all teams for a user.
+ *
+ * __Minimum server version__: 6.2.0
+ *
+ * #####
+ * Permissions
+ * Logged in as the user, or have `edit_other_users` permission.
+ */
+class GetChannelMembersWithTeamDataForUser extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/channel_members";
+	}
+
+
+	/**
+	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
+	 * @param null|int $page Page specifies which part of the results to return, by PageSize.
+	 * @param null|int $pageSize PageSize specifies the size of the returned chunk of results.
+	 */
+	public function __construct(
+		protected string $userId,
+		protected ?int $page = null,
+		protected ?int $pageSize = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['page' => $this->page, 'pageSize' => $this->pageSize]);
+	}
+}

--- a/src/Client/Requests/Users/GetKnownUsers.php
+++ b/src/Client/Requests/Users/GetKnownUsers.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetKnownUsers
+ *
+ * Get the list of user IDs of users with any direct relationship with a
+ * user. That means any user
+ * sharing any channel, including direct and
+ * group channels.
+ * ##### Permissions
+ * Must be
+ * authenticated.
+ *
+ * __Minimum server version__: 5.23
+ */
+class GetKnownUsers extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/known";
+	}
+
+
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Requests/Users/GetSessions.php
+++ b/src/Client/Requests/Users/GetSessions.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetSessions
+ *
+ * Get a list of sessions by providing the user GUID. Sensitive information will be sanitized
+ * out.
+ * ##### Permissions
+ * Must be logged in as the user being updated or have the `edit_other_users`
+ * permission.
+ */
+class GetSessions extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/sessions";
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function __construct(
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Users/GetTotalUsersStats.php
+++ b/src/Client/Requests/Users/GetTotalUsersStats.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetTotalUsersStats
+ *
+ * Get a total count of users in the system.
+ * ##### Permissions
+ * Must be authenticated.
+ */
+class GetTotalUsersStats extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/stats";
+	}
+
+
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Requests/Users/GetTotalUsersStatsFiltered.php
+++ b/src/Client/Requests/Users/GetTotalUsersStatsFiltered.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetTotalUsersStatsFiltered
+ *
+ * Get a count of users in the system matching the specified filters.
+ *
+ * __Minimum server version__:
+ * 5.26
+ *
+ * ##### Permissions
+ * Must have `manage_system` permission.
+ */
+class GetTotalUsersStatsFiltered extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/stats/filtered";
+	}
+
+
+	/**
+	 * @param null|string $inTeam The ID of the team to get user stats for.
+	 * @param null|string $inChannel The ID of the channel to get user stats for.
+	 * @param null|bool $includeDeleted If deleted accounts should be included in the count.
+	 * @param null|bool $includeBots If bot accounts should be included in the count.
+	 * @param null|string $roles Comma separated string used to filter users based on any of the specified system roles
+	 *
+	 * Example: `?roles=system_admin,system_user` will include users that are either system admins or system users
+	 * @param null|string $channelRoles Comma separated string used to filter users based on any of the specified channel roles, can only be used in conjunction with `in_channel`
+	 *
+	 * Example: `?in_channel=4eb6axxw7fg3je5iyasnfudc5y&channel_roles=channel_user` will include users that are only channel users and not admins or guests
+	 * @param null|string $teamRoles Comma separated string used to filter users based on any of the specified team roles, can only be used in conjunction with `in_team`
+	 *
+	 * Example: `?in_team=4eb6axxw7fg3je5iyasnfudc5y&team_roles=team_user` will include users that are only team users and not admins or guests
+	 */
+	public function __construct(
+		protected ?string $inTeam = null,
+		protected ?string $inChannel = null,
+		protected ?bool $includeDeleted = null,
+		protected ?bool $includeBots = null,
+		protected ?string $roles = null,
+		protected ?string $channelRoles = null,
+		protected ?string $teamRoles = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter([
+			'in_team' => $this->inTeam,
+			'in_channel' => $this->inChannel,
+			'include_deleted' => $this->includeDeleted,
+			'include_bots' => $this->includeBots,
+			'roles' => $this->roles,
+			'channel_roles' => $this->channelRoles,
+			'team_roles' => $this->teamRoles,
+		]);
+	}
+}

--- a/src/Client/Requests/Users/GetUploadsForUser.php
+++ b/src/Client/Requests/Users/GetUploadsForUser.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetUploadsForUser
+ *
+ * Gets all the upload sessions belonging to a user.
+ *
+ * __Minimum server version__: 5.28
+ *
+ * #####
+ * Permissions
+ * Must be logged in as the user who created the upload sessions.
+ */
+class GetUploadsForUser extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/uploads";
+	}
+
+
+	/**
+	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
+	 */
+	public function __construct(
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Users/GetUser.php
+++ b/src/Client/Requests/Users/GetUser.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetUser
+ *
+ * Get a user a object. Sensitive information will be sanitized out.
+ * ##### Permissions
+ * Requires an
+ * active session but no other permissions.
+ */
+class GetUser extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}";
+	}
+
+
+	/**
+	 * @param string $userId User GUID. This can also be "me" which will point to the current user.
+	 */
+	public function __construct(
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Users/GetUserAccessToken.php
+++ b/src/Client/Requests/Users/GetUserAccessToken.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetUserAccessToken
+ *
+ * Get a user access token. Does not include the actual authentication token.
+ *
+ * __Minimum server
+ * version__: 4.1
+ *
+ * ##### Permissions
+ * Must have `read_user_access_token` permission. For non-self
+ * requests, must also have the `edit_other_users` permission.
+ */
+class GetUserAccessToken extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/tokens/{$this->tokenId}";
+	}
+
+
+	/**
+	 * @param string $tokenId User access token GUID
+	 */
+	public function __construct(
+		protected string $tokenId,
+	) {
+	}
+}

--- a/src/Client/Requests/Users/GetUserAccessTokens.php
+++ b/src/Client/Requests/Users/GetUserAccessTokens.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetUserAccessTokens
+ *
+ * Get a page of user access tokens for users on the system. Does not include the actual authentication
+ * tokens. Use query parameters for paging.
+ *
+ * __Minimum server version__: 4.7
+ *
+ * ##### Permissions
+ * Must
+ * have `manage_system` permission.
+ */
+class GetUserAccessTokens extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/tokens";
+	}
+
+
+	/**
+	 * @param null|int $page The page to select.
+	 */
+	public function __construct(
+		protected ?int $page = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['page' => $this->page]);
+	}
+}

--- a/src/Client/Requests/Users/GetUserAccessTokensForUser.php
+++ b/src/Client/Requests/Users/GetUserAccessTokensForUser.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetUserAccessTokensForUser
+ *
+ * Get a list of user access tokens for a user. Does not include the actual authentication tokens. Use
+ * query parameters for paging.
+ *
+ * __Minimum server version__: 4.1
+ *
+ * ##### Permissions
+ * Must have
+ * `read_user_access_token` permission. For non-self requests, must also have the `edit_other_users`
+ * permission.
+ */
+class GetUserAccessTokensForUser extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/tokens";
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 * @param null|int $page The page to select.
+	 */
+	public function __construct(
+		protected string $userId,
+		protected ?int $page = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['page' => $this->page]);
+	}
+}

--- a/src/Client/Requests/Users/GetUserAudits.php
+++ b/src/Client/Requests/Users/GetUserAudits.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetUserAudits
+ *
+ * Get a list of audit by providing the user GUID.
+ * ##### Permissions
+ * Must be logged in as the user or
+ * have the `edit_other_users` permission.
+ */
+class GetUserAudits extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/audits";
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function __construct(
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Users/GetUserByEmail.php
+++ b/src/Client/Requests/Users/GetUserByEmail.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetUserByEmail
+ *
+ * Get a user object by providing a user email. Sensitive information will be sanitized out.
+ * #####
+ * Permissions
+ * Requires an active session and for the current session to be able to view another user's
+ * email based on the server's privacy settings.
+ */
+class GetUserByEmail extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/email/{$this->email}";
+	}
+
+
+	/**
+	 * @param string $email User Email
+	 */
+	public function __construct(
+		protected string $email,
+	) {
+	}
+}

--- a/src/Client/Requests/Users/GetUserByUsername.php
+++ b/src/Client/Requests/Users/GetUserByUsername.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetUserByUsername
+ *
+ * Get a user object by providing a username. Sensitive information will be sanitized out.
+ * #####
+ * Permissions
+ * Requires an active session but no other permissions.
+ */
+class GetUserByUsername extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/username/{$this->username}";
+	}
+
+
+	/**
+	 * @param string $username Username
+	 */
+	public function __construct(
+		protected string $username,
+	) {
+	}
+}

--- a/src/Client/Requests/Users/GetUserTermsOfService.php
+++ b/src/Client/Requests/Users/GetUserTermsOfService.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetUserTermsOfService
+ *
+ * Will be deprecated in v6.0
+ * Fetches user's latest terms of service action if the latest action was
+ * for acceptance.
+ *
+ * __Minimum server version__: 5.6
+ * ##### Permissions
+ * Must be logged in as the user
+ * being acted on.
+ */
+class GetUserTermsOfService extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/terms_of_service";
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function __construct(
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Users/GetUsers.php
+++ b/src/Client/Requests/Users/GetUsers.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetUsers
+ *
+ * Get a page of a list of users. Based on query string parameters, select users from a team, channel,
+ * or select users not in a specific channel.
+ *
+ * Since server version 4.0, some basic sorting is
+ * available using the `sort` query parameter. Sorting is currently only supported when selecting users
+ * on a team.
+ * ##### Permissions
+ * Requires an active session and (if specified) membership to the channel
+ * or team being selected from.
+ */
+class GetUsers extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users";
+	}
+
+
+	/**
+	 * @param null|int $page The page to select.
+	 * @param null|string $inTeam The ID of the team to get users for.
+	 * @param null|string $notInTeam The ID of the team to exclude users for. Must not be used with "in_team" query parameter.
+	 * @param null|string $inChannel The ID of the channel to get users for.
+	 * @param null|string $notInChannel The ID of the channel to exclude users for. Must be used with "in_channel" query parameter.
+	 * @param null|string $inGroup The ID of the group to get users for. Must have `manage_system` permission.
+	 * @param null|bool $groupConstrained When used with `not_in_channel` or `not_in_team`, returns only the users that are allowed to join the channel or team based on its group constrains.
+	 * @param null|bool $withoutTeam Whether or not to list users that are not on any team. This option takes precendence over `in_team`, `in_channel`, and `not_in_channel`.
+	 * @param null|bool $active Whether or not to list only users that are active. This option cannot be used along with the `inactive` option.
+	 * @param null|bool $inactive Whether or not to list only users that are deactivated. This option cannot be used along with the `active` option.
+	 * @param null|string $role Returns users that have this role.
+	 * @param null|string $sort Sort is only available in conjunction with certain options below. The paging parameter is also always available.
+	 *
+	 * ##### `in_team`
+	 * Can be "", "last_activity_at" or "create_at".
+	 * When left blank, sorting is done by username.
+	 * __Minimum server version__: 4.0
+	 * ##### `in_channel`
+	 * Can be "", "status".
+	 * When left blank, sorting is done by username. `status` will sort by User's current status (Online, Away, DND, Offline), then by Username.
+	 * __Minimum server version__: 4.7
+	 * ##### `in_group`
+	 * Can be "", "display_name".
+	 * When left blank, sorting is done by username. `display_name` will sort alphabetically by user's display name.
+	 * __Minimum server version__: 7.7
+	 * @param null|string $roles Comma separated string used to filter users based on any of the specified system roles
+	 *
+	 * Example: `?roles=system_admin,system_user` will return users that are either system admins or system users
+	 *
+	 * __Minimum server version__: 5.26
+	 * @param null|string $channelRoles Comma separated string used to filter users based on any of the specified channel roles, can only be used in conjunction with `in_channel`
+	 *
+	 * Example: `?in_channel=4eb6axxw7fg3je5iyasnfudc5y&channel_roles=channel_user` will return users that are only channel users and not admins or guests
+	 *
+	 * __Minimum server version__: 5.26
+	 * @param null|string $teamRoles Comma separated string used to filter users based on any of the specified team roles, can only be used in conjunction with `in_team`
+	 *
+	 * Example: `?in_team=4eb6axxw7fg3je5iyasnfudc5y&team_roles=team_user` will return users that are only team users and not admins or guests
+	 *
+	 * __Minimum server version__: 5.26
+	 */
+	public function __construct(
+		protected ?int $page = null,
+		protected ?string $inTeam = null,
+		protected ?string $notInTeam = null,
+		protected ?string $inChannel = null,
+		protected ?string $notInChannel = null,
+		protected ?string $inGroup = null,
+		protected ?bool $groupConstrained = null,
+		protected ?bool $withoutTeam = null,
+		protected ?bool $active = null,
+		protected ?bool $inactive = null,
+		protected ?string $role = null,
+		protected ?string $sort = null,
+		protected ?string $roles = null,
+		protected ?string $channelRoles = null,
+		protected ?string $teamRoles = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter([
+			'page' => $this->page,
+			'in_team' => $this->inTeam,
+			'not_in_team' => $this->notInTeam,
+			'in_channel' => $this->inChannel,
+			'not_in_channel' => $this->notInChannel,
+			'in_group' => $this->inGroup,
+			'group_constrained' => $this->groupConstrained,
+			'without_team' => $this->withoutTeam,
+			'active' => $this->active,
+			'inactive' => $this->inactive,
+			'role' => $this->role,
+			'sort' => $this->sort,
+			'roles' => $this->roles,
+			'channel_roles' => $this->channelRoles,
+			'team_roles' => $this->teamRoles,
+		]);
+	}
+}

--- a/src/Client/Requests/Users/GetUsersByGroupChannelIds.php
+++ b/src/Client/Requests/Users/GetUsersByGroupChannelIds.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * GetUsersByGroupChannelIds
+ *
+ * Get an object containing a key per group channel id in the
+ * query and its value as a list of users
+ * members of that group
+ * channel.
+ *
+ * The user must be a member of the group ids in the query, or
+ * they
+ * will be omitted from the response.
+ * ##### Permissions
+ * Requires an active session but no other
+ * permissions.
+ *
+ * __Minimum server version__: 5.14
+ */
+class GetUsersByGroupChannelIds extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/group_channels";
+	}
+
+
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Requests/Users/GetUsersByIds.php
+++ b/src/Client/Requests/Users/GetUsersByIds.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * GetUsersByIds
+ *
+ * Get a list of users based on a provided list of user ids.
+ * ##### Permissions
+ * Requires an active
+ * session but no other permissions.
+ */
+class GetUsersByIds extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/ids";
+	}
+
+
+	/**
+	 * @param null|int $since Only return users that have been modified since the given Unix timestamp (in milliseconds).
+	 *
+	 * __Minimum server version__: 5.14
+	 */
+	public function __construct(
+		protected ?int $since = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['since' => $this->since]);
+	}
+}

--- a/src/Client/Requests/Users/GetUsersByUsernames.php
+++ b/src/Client/Requests/Users/GetUsersByUsernames.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * GetUsersByUsernames
+ *
+ * Get a list of users based on a provided list of usernames.
+ * ##### Permissions
+ * Requires an active
+ * session but no other permissions.
+ */
+class GetUsersByUsernames extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/usernames";
+	}
+
+
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Requests/Users/Login.php
+++ b/src/Client/Requests/Users/Login.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * Login
+ *
+ * ##### Permissions
+ * No permission required
+ */
+class Login extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/login";
+	}
+
+
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Requests/Users/LoginByCwsToken.php
+++ b/src/Client/Requests/Users/LoginByCwsToken.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * LoginByCwsToken
+ *
+ * CWS stands for Customer Web Server which is the cloud service used to manage cloud instances.
+ * #####
+ * Permissions
+ * A Cloud license is required
+ */
+class LoginByCwsToken extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/login/cws";
+	}
+
+
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Requests/Users/Logout.php
+++ b/src/Client/Requests/Users/Logout.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * Logout
+ *
+ * ##### Permissions
+ * An active session is required
+ */
+class Logout extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/logout";
+	}
+
+
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Requests/Users/MigrateAuthToLdap.php
+++ b/src/Client/Requests/Users/MigrateAuthToLdap.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * MigrateAuthToLdap
+ *
+ * Migrates accounts from one authentication provider to another. For example, you can upgrade your
+ * authentication provider from email to LDAP.
+ * __Minimum server version__: 5.28
+ * ##### Permissions
+ * Must
+ * have `manage_system` permission.
+ */
+class MigrateAuthToLdap extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/migrate_auth/ldap";
+	}
+
+
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Requests/Users/MigrateAuthToSaml.php
+++ b/src/Client/Requests/Users/MigrateAuthToSaml.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * MigrateAuthToSaml
+ *
+ * Migrates accounts from one authentication provider to another. For example, you can upgrade your
+ * authentication provider from email to SAML.
+ * __Minimum server version__: 5.28
+ * ##### Permissions
+ * Must
+ * have `manage_system` permission.
+ */
+class MigrateAuthToSaml extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/migrate_auth/saml";
+	}
+
+
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Requests/Users/PatchUser.php
+++ b/src/Client/Requests/Users/PatchUser.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * PatchUser
+ *
+ * Partially update a user by providing only the fields you want to update. Omitted fields will not be
+ * updated. The fields that can be updated are defined in the request body, all other provided fields
+ * will be ignored.
+ * ##### Permissions
+ * Must be logged in as the user being updated or have the
+ * `edit_other_users` permission.
+ */
+class PatchUser extends Request
+{
+	protected Method $method = Method::PUT;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/patch";
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function __construct(
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Users/PermanentDeleteAllUsers.php
+++ b/src/Client/Requests/Users/PermanentDeleteAllUsers.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * PermanentDeleteAllUsers
+ *
+ * Permanently deletes all users and all their related information, including posts.
+ *
+ * __Minimum server
+ * version__: 5.26.0
+ *
+ * __Local mode only__: This endpoint is only available through [local
+ * mode](https://docs.mattermost.com/administration/mmctl-cli-tool.html#local-mode).
+ */
+class PermanentDeleteAllUsers extends Request
+{
+	protected Method $method = Method::DELETE;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users";
+	}
+
+
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Requests/Users/PromoteGuestToUser.php
+++ b/src/Client/Requests/Users/PromoteGuestToUser.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * PromoteGuestToUser
+ *
+ * Convert a guest into a regular user. This will convert the guest into a
+ * user for the whole system
+ * while retaining any team and channel
+ * memberships and automatically joining them to the default
+ * channels.
+ *
+ * __Minimum server version__: 5.16
+ *
+ * ##### Permissions
+ * Must be logged in as the user or have
+ * the `promote_guest` permission.
+ */
+class PromoteGuestToUser extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/promote";
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function __construct(
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Users/PublishUserTyping.php
+++ b/src/Client/Requests/Users/PublishUserTyping.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * PublishUserTyping
+ *
+ * Notify users in the given channel via websocket that the given user is typing.
+ * __Minimum server
+ * version__: 5.26
+ * ##### Permissions
+ * Must have `manage_system` permission to publish for any user other
+ * than oneself.
+ */
+class PublishUserTyping extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/typing";
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function __construct(
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Users/RegisterTermsOfServiceAction.php
+++ b/src/Client/Requests/Users/RegisterTermsOfServiceAction.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * RegisterTermsOfServiceAction
+ *
+ * Records user action when they accept or decline custom terms of service. Records the action in audit
+ * table.
+ * Updates user's last accepted terms of service ID if they accepted it.
+ *
+ * __Minimum server
+ * version__: 5.4
+ * ##### Permissions
+ * Must be logged in as the user being acted on.
+ */
+class RegisterTermsOfServiceAction extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/terms_of_service";
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function __construct(
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Users/ResetPassword.php
+++ b/src/Client/Requests/Users/ResetPassword.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * ResetPassword
+ *
+ * Update the password for a user using a one-use, timed recovery code tied to the user's account. Only
+ * works for non-SSO users.
+ * ##### Permissions
+ * No permissions required.
+ */
+class ResetPassword extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/password/reset";
+	}
+
+
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Requests/Users/RevokeAllSessions.php
+++ b/src/Client/Requests/Users/RevokeAllSessions.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * RevokeAllSessions
+ *
+ * Revokes all user sessions from the provided user id and session id strings.
+ * ##### Permissions
+ * Must
+ * be logged in as the user being updated or have the `edit_other_users` permission.
+ * __Minimum server
+ * version__: 4.4
+ */
+class RevokeAllSessions extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/sessions/revoke/all";
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function __construct(
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Users/RevokeSession.php
+++ b/src/Client/Requests/Users/RevokeSession.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * RevokeSession
+ *
+ * Revokes a user session from the provided user id and session id strings.
+ * ##### Permissions
+ * Must be
+ * logged in as the user being updated or have the `edit_other_users` permission.
+ */
+class RevokeSession extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/sessions/revoke";
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function __construct(
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Users/RevokeSessionsFromAllUsers.php
+++ b/src/Client/Requests/Users/RevokeSessionsFromAllUsers.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * RevokeSessionsFromAllUsers
+ *
+ * For any session currently on the server (including admin) it will be revoked.
+ * Clients will be
+ * notified to log out users.
+ *
+ * __Minimum server version__: 5.14
+ *
+ * ##### Permissions
+ * Must have
+ * `manage_system` permission.
+ */
+class RevokeSessionsFromAllUsers extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/sessions/revoke/all";
+	}
+
+
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Requests/Users/RevokeUserAccessToken.php
+++ b/src/Client/Requests/Users/RevokeUserAccessToken.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * RevokeUserAccessToken
+ *
+ * Revoke a user access token and delete any sessions using the token.
+ *
+ * __Minimum server version__:
+ * 4.1
+ *
+ * ##### Permissions
+ * Must have `revoke_user_access_token` permission. For non-self requests, must
+ * also have the `edit_other_users` permission.
+ */
+class RevokeUserAccessToken extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/tokens/revoke";
+	}
+
+
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Requests/Users/SearchUserAccessTokens.php
+++ b/src/Client/Requests/Users/SearchUserAccessTokens.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * SearchUserAccessTokens
+ *
+ * Get a list of tokens based on search criteria provided in the request body. Searches are done
+ * against the token id, user id and username.
+ *
+ * __Minimum server version__: 4.7
+ *
+ * ##### Permissions
+ * Must
+ * have `manage_system` permission.
+ */
+class SearchUserAccessTokens extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/tokens/search";
+	}
+
+
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Requests/Users/SearchUsers.php
+++ b/src/Client/Requests/Users/SearchUsers.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * SearchUsers
+ *
+ * Get a list of users based on search criteria provided in the request body. Searches are typically
+ * done against username, full name, nickname and email unless otherwise configured by the
+ * server.
+ * ##### Permissions
+ * Requires an active session and `read_channel` and/or `view_team`
+ * permissions for any channels or teams specified in the request body.
+ */
+class SearchUsers extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/search";
+	}
+
+
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Requests/Users/SendPasswordResetEmail.php
+++ b/src/Client/Requests/Users/SendPasswordResetEmail.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * SendPasswordResetEmail
+ *
+ * Send an email containing a link for resetting the user's password. The link will contain a one-use,
+ * timed recovery code tied to the user's account. Only works for non-SSO users.
+ * ##### Permissions
+ * No
+ * permissions required.
+ */
+class SendPasswordResetEmail extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/password/reset/send";
+	}
+
+
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Requests/Users/SendVerificationEmail.php
+++ b/src/Client/Requests/Users/SendVerificationEmail.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * SendVerificationEmail
+ *
+ * Send an email with a verification link to a user that has an email matching the one in the request
+ * body. This endpoint will return success even if the email does not match any users on the
+ * system.
+ * ##### Permissions
+ * No permissions required.
+ */
+class SendVerificationEmail extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/email/verify/send";
+	}
+
+
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Requests/Users/SwitchAccountType.php
+++ b/src/Client/Requests/Users/SwitchAccountType.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * SwitchAccountType
+ *
+ * Switch a user's login method from using email to OAuth2/SAML/LDAP or back to email. When switching
+ * to OAuth2/SAML, account switching is not complete until the user follows the returned link and
+ * completes any steps on the OAuth2/SAML service provider.
+ *
+ * To switch from email to OAuth2/SAML,
+ * specify `current_service`, `new_service`, `email` and `password`.
+ *
+ * To switch from OAuth2/SAML to
+ * email, specify `current_service`, `new_service`, `email` and `new_password`.
+ *
+ * To switch from email
+ * to LDAP/AD, specify `current_service`, `new_service`, `email`, `password`, `ldap_ip` and
+ * `new_password` (this is the user's LDAP password).
+ *
+ * To switch from LDAP/AD to email, specify
+ * `current_service`, `new_service`, `ldap_ip`, `password` (this is the user's LDAP password), `email`
+ * and `new_password`.
+ *
+ * Additionally, specify `mfa_code` when trying to switch an account on LDAP/AD or
+ * email that has MFA activated.
+ *
+ * ##### Permissions
+ * No current authentication required except when
+ * switching from OAuth2/SAML to email.
+ */
+class SwitchAccountType extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/login/switch";
+	}
+
+
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Requests/Users/UpdateUser.php
+++ b/src/Client/Requests/Users/UpdateUser.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * UpdateUser
+ *
+ * Update a user by providing the user object. The fields that can be updated are defined in the
+ * request body, all other provided fields will be ignored. Any fields not included in the request body
+ * will be set to null or reverted to default values.
+ * ##### Permissions
+ * Must be logged in as the user
+ * being updated or have the `edit_other_users` permission.
+ */
+class UpdateUser extends Request
+{
+	protected Method $method = Method::PUT;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}";
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function __construct(
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Users/UpdateUserActive.php
+++ b/src/Client/Requests/Users/UpdateUserActive.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * UpdateUserActive
+ *
+ * Update user active or inactive status.
+ *
+ * __Since server version 4.6, users using a SSO provider to
+ * login can be activated or deactivated with this endpoint. However, if their activation status in
+ * Mattermost does not reflect their status in the SSO provider, the next synchronization or login by
+ * that user will reset the activation status to that of their account in the SSO provider. Server
+ * versions 4.5 and before do not allow activation or deactivation of SSO users from this
+ * endpoint.__
+ * ##### Permissions
+ * User can deactivate themselves.
+ * User with `manage_system` permission
+ * can activate or deactivate a user.
+ */
+class UpdateUserActive extends Request
+{
+	protected Method $method = Method::PUT;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/active";
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function __construct(
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Users/UpdateUserAuth.php
+++ b/src/Client/Requests/Users/UpdateUserAuth.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * UpdateUserAuth
+ *
+ * Updates a user's authentication method. This can be used to change them to/from LDAP authentication
+ * for example.
+ *
+ * __Minimum server version__: 4.6
+ * ##### Permissions
+ * Must have the `edit_other_users`
+ * permission.
+ */
+class UpdateUserAuth extends Request
+{
+	protected Method $method = Method::PUT;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/auth";
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function __construct(
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Users/UpdateUserMfa.php
+++ b/src/Client/Requests/Users/UpdateUserMfa.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * UpdateUserMfa
+ *
+ * Activates multi-factor authentication for the user if `activate` is true and a valid `code` is
+ * provided. If activate is false, then `code` is not required and multi-factor authentication is
+ * disabled for the user.
+ * ##### Permissions
+ * Must be logged in as the user being updated or have the
+ * `edit_other_users` permission.
+ */
+class UpdateUserMfa extends Request
+{
+	protected Method $method = Method::PUT;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/mfa";
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function __construct(
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Users/UpdateUserPassword.php
+++ b/src/Client/Requests/Users/UpdateUserPassword.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * UpdateUserPassword
+ *
+ * Update a user's password. New password must meet password policy set by server configuration.
+ * Current password is required if you're updating your own password.
+ * ##### Permissions
+ * Must be logged
+ * in as the user the password is being changed for or have `manage_system` permission.
+ */
+class UpdateUserPassword extends Request
+{
+	protected Method $method = Method::PUT;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/password";
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function __construct(
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Users/UpdateUserRoles.php
+++ b/src/Client/Requests/Users/UpdateUserRoles.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * UpdateUserRoles
+ *
+ * Update a user's system-level roles. Valid user roles are "system_user", "system_admin" or both of
+ * them. Overwrites any previously assigned system-level roles.
+ * ##### Permissions
+ * Must have the
+ * `manage_roles` permission.
+ */
+class UpdateUserRoles extends Request
+{
+	protected Method $method = Method::PUT;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/roles";
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function __construct(
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Users/VerifyUserEmail.php
+++ b/src/Client/Requests/Users/VerifyUserEmail.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * VerifyUserEmail
+ *
+ * Verify the email used by a user to sign-up their account with.
+ * ##### Permissions
+ * No permissions
+ * required.
+ */
+class VerifyUserEmail extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/email/verify";
+	}
+
+
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Requests/Users/VerifyUserEmailWithoutToken.php
+++ b/src/Client/Requests/Users/VerifyUserEmailWithoutToken.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * VerifyUserEmailWithoutToken
+ *
+ * Verify the email used by a user without a token.
+ *
+ * __Minimum server version__: 5.24
+ *
+ * #####
+ * Permissions
+ *
+ * Must have `manage_system` permission.
+ */
+class VerifyUserEmailWithoutToken extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/users/{$this->userId}/email/verify/member";
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function __construct(
+		protected string $userId,
+	) {
+	}
+}

--- a/src/Client/Requests/Webhooks/CreateIncomingWebhook.php
+++ b/src/Client/Requests/Webhooks/CreateIncomingWebhook.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Webhooks;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * CreateIncomingWebhook
+ *
+ * Create an incoming webhook for a channel.
+ * ##### Permissions
+ * `manage_webhooks` for the team the
+ * webhook is in.
+ *
+ * `manage_others_incoming_webhooks` for the team the webhook is in if the user is
+ * different than the requester.
+ */
+class CreateIncomingWebhook extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/hooks/incoming";
+	}
+
+
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Requests/Webhooks/CreateOutgoingWebhook.php
+++ b/src/Client/Requests/Webhooks/CreateOutgoingWebhook.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Webhooks;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * CreateOutgoingWebhook
+ *
+ * Create an outgoing webhook for a team.
+ * ##### Permissions
+ * `manage_webhooks` for the team the webhook
+ * is in.
+ *
+ * `manage_others_outgoing_webhooks` for the team the webhook is in if the user is different
+ * than the requester.
+ */
+class CreateOutgoingWebhook extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/hooks/outgoing";
+	}
+
+
+	public function __construct()
+	{
+	}
+}

--- a/src/Client/Requests/Webhooks/DeleteIncomingWebhook.php
+++ b/src/Client/Requests/Webhooks/DeleteIncomingWebhook.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Webhooks;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * DeleteIncomingWebhook
+ *
+ * Delete an incoming webhook given the hook id.
+ * ##### Permissions
+ * `manage_webhooks` for system or
+ * `manage_webhooks` for the specific team or `manage_webhooks` for the channel.
+ */
+class DeleteIncomingWebhook extends Request
+{
+	protected Method $method = Method::DELETE;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/hooks/incoming/{$this->hookId}";
+	}
+
+
+	/**
+	 * @param string $hookId Incoming webhook GUID
+	 */
+	public function __construct(
+		protected string $hookId,
+	) {
+	}
+}

--- a/src/Client/Requests/Webhooks/DeleteOutgoingWebhook.php
+++ b/src/Client/Requests/Webhooks/DeleteOutgoingWebhook.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Webhooks;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * DeleteOutgoingWebhook
+ *
+ * Delete an outgoing webhook given the hook id.
+ * ##### Permissions
+ * `manage_webhooks` for system or
+ * `manage_webhooks` for the specific team or `manage_webhooks` for the channel.
+ */
+class DeleteOutgoingWebhook extends Request
+{
+	protected Method $method = Method::DELETE;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/hooks/outgoing/{$this->hookId}";
+	}
+
+
+	/**
+	 * @param string $hookId Outgoing webhook GUID
+	 */
+	public function __construct(
+		protected string $hookId,
+	) {
+	}
+}

--- a/src/Client/Requests/Webhooks/GetIncomingWebhook.php
+++ b/src/Client/Requests/Webhooks/GetIncomingWebhook.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Webhooks;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetIncomingWebhook
+ *
+ * Get an incoming webhook given the hook id.
+ * ##### Permissions
+ * `manage_webhooks` for system or
+ * `manage_webhooks` for the specific team or `manage_webhooks` for the channel.
+ */
+class GetIncomingWebhook extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/hooks/incoming/{$this->hookId}";
+	}
+
+
+	/**
+	 * @param string $hookId Incoming Webhook GUID
+	 */
+	public function __construct(
+		protected string $hookId,
+	) {
+	}
+}

--- a/src/Client/Requests/Webhooks/GetIncomingWebhooks.php
+++ b/src/Client/Requests/Webhooks/GetIncomingWebhooks.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Webhooks;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetIncomingWebhooks
+ *
+ * Get a page of a list of incoming webhooks. Optionally filter for a specific team using query
+ * parameters.
+ * ##### Permissions
+ * `manage_webhooks` for the system or `manage_webhooks` for the specific
+ * team.
+ */
+class GetIncomingWebhooks extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/hooks/incoming";
+	}
+
+
+	/**
+	 * @param null|int $page The page to select.
+	 * @param null|string $teamId The ID of the team to get hooks for.
+	 */
+	public function __construct(
+		protected ?int $page = null,
+		protected ?string $teamId = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['page' => $this->page, 'team_id' => $this->teamId]);
+	}
+}

--- a/src/Client/Requests/Webhooks/GetOutgoingWebhook.php
+++ b/src/Client/Requests/Webhooks/GetOutgoingWebhook.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Webhooks;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetOutgoingWebhook
+ *
+ * Get an outgoing webhook given the hook id.
+ * ##### Permissions
+ * `manage_webhooks` for system or
+ * `manage_webhooks` for the specific team or `manage_webhooks` for the channel.
+ */
+class GetOutgoingWebhook extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/hooks/outgoing/{$this->hookId}";
+	}
+
+
+	/**
+	 * @param string $hookId Outgoing webhook GUID
+	 */
+	public function __construct(
+		protected string $hookId,
+	) {
+	}
+}

--- a/src/Client/Requests/Webhooks/GetOutgoingWebhooks.php
+++ b/src/Client/Requests/Webhooks/GetOutgoingWebhooks.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Webhooks;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * GetOutgoingWebhooks
+ *
+ * Get a page of a list of outgoing webhooks. Optionally filter for a specific team or channel using
+ * query parameters.
+ * ##### Permissions
+ * `manage_webhooks` for the system or `manage_webhooks` for the
+ * specific team/channel.
+ */
+class GetOutgoingWebhooks extends Request
+{
+	protected Method $method = Method::GET;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/hooks/outgoing";
+	}
+
+
+	/**
+	 * @param null|int $page The page to select.
+	 * @param null|string $teamId The ID of the team to get hooks for.
+	 * @param null|string $channelId The ID of the channel to get hooks for.
+	 */
+	public function __construct(
+		protected ?int $page = null,
+		protected ?string $teamId = null,
+		protected ?string $channelId = null,
+	) {
+	}
+
+
+	public function defaultQuery(): array
+	{
+		return array_filter(['page' => $this->page, 'team_id' => $this->teamId, 'channel_id' => $this->channelId]);
+	}
+}

--- a/src/Client/Requests/Webhooks/RegenOutgoingHookToken.php
+++ b/src/Client/Requests/Webhooks/RegenOutgoingHookToken.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Webhooks;
+
+use DateTime;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+/**
+ * RegenOutgoingHookToken
+ *
+ * Regenerate the token for the outgoing webhook.
+ * ##### Permissions
+ * `manage_webhooks` for system or
+ * `manage_webhooks` for the specific team or `manage_webhooks` for the channel.
+ */
+class RegenOutgoingHookToken extends Request implements HasBody
+{
+	use HasJsonBody;
+
+	protected Method $method = Method::POST;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/hooks/outgoing/{$this->hookId}/regen_token";
+	}
+
+
+	/**
+	 * @param string $hookId Outgoing webhook GUID
+	 */
+	public function __construct(
+		protected string $hookId,
+	) {
+	}
+}

--- a/src/Client/Requests/Webhooks/UpdateIncomingWebhook.php
+++ b/src/Client/Requests/Webhooks/UpdateIncomingWebhook.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Webhooks;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * UpdateIncomingWebhook
+ *
+ * Update an incoming webhook given the hook id.
+ * ##### Permissions
+ * `manage_webhooks` for system or
+ * `manage_webhooks` for the specific team or `manage_webhooks` for the channel.
+ */
+class UpdateIncomingWebhook extends Request
+{
+	protected Method $method = Method::PUT;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/hooks/incoming/{$this->hookId}";
+	}
+
+
+	/**
+	 * @param string $hookId Incoming Webhook GUID
+	 */
+	public function __construct(
+		protected string $hookId,
+	) {
+	}
+}

--- a/src/Client/Requests/Webhooks/UpdateOutgoingWebhook.php
+++ b/src/Client/Requests/Webhooks/UpdateOutgoingWebhook.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Requests\Webhooks;
+
+use DateTime;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * UpdateOutgoingWebhook
+ *
+ * Update an outgoing webhook given the hook id.
+ * ##### Permissions
+ * `manage_webhooks` for system or
+ * `manage_webhooks` for the specific team or `manage_webhooks` for the channel.
+ */
+class UpdateOutgoingWebhook extends Request
+{
+	protected Method $method = Method::PUT;
+
+
+	public function resolveEndpoint(): string
+	{
+		return "/api/v4/hooks/outgoing/{$this->hookId}";
+	}
+
+
+	/**
+	 * @param string $hookId outgoing Webhook GUID
+	 */
+	public function __construct(
+		protected string $hookId,
+	) {
+	}
+}

--- a/src/Client/Resource/Bots.php
+++ b/src/Client/Resource/Bots.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Resource;
+
+use ConduitUI\Mattermost\Client\Requests\Bots\AssignBot;
+use ConduitUI\Mattermost\Client\Requests\Bots\ConvertBotToUser;
+use ConduitUI\Mattermost\Client\Requests\Bots\ConvertUserToBot;
+use ConduitUI\Mattermost\Client\Requests\Bots\CreateBot;
+use ConduitUI\Mattermost\Client\Requests\Bots\DisableBot;
+use ConduitUI\Mattermost\Client\Requests\Bots\EnableBot;
+use ConduitUI\Mattermost\Client\Requests\Bots\GetBot;
+use ConduitUI\Mattermost\Client\Requests\Bots\GetBots;
+use ConduitUI\Mattermost\Client\Requests\Bots\PatchBot;
+use Saloon\Http\BaseResource;
+use Saloon\Http\Response;
+
+class Bots extends BaseResource
+{
+	/**
+	 * @param int $page The page to select.
+	 * @param bool $includeDeleted If deleted bots should be returned.
+	 * @param bool $onlyOrphaned When true, only orphaned bots will be returned. A bot is consitered orphaned if it's owner has been deactivated.
+	 */
+	public function getBots(?int $page = null, ?bool $includeDeleted = null, ?bool $onlyOrphaned = null): Response
+	{
+		return $this->connector->send(new GetBots($page, $includeDeleted, $onlyOrphaned));
+	}
+
+
+	public function createBot(): Response
+	{
+		return $this->connector->send(new CreateBot());
+	}
+
+
+	/**
+	 * @param string $botUserId Bot user ID
+	 * @param bool $includeDeleted If deleted bots should be returned.
+	 */
+	public function getBot(string $botUserId, ?bool $includeDeleted = null): Response
+	{
+		return $this->connector->send(new GetBot($botUserId, $includeDeleted));
+	}
+
+
+	/**
+	 * @param string $botUserId Bot user ID
+	 */
+	public function patchBot(string $botUserId): Response
+	{
+		return $this->connector->send(new PatchBot($botUserId));
+	}
+
+
+	/**
+	 * @param string $botUserId Bot user ID
+	 * @param string $userId The user ID to assign the bot to.
+	 */
+	public function assignBot(string $botUserId, string $userId): Response
+	{
+		return $this->connector->send(new AssignBot($botUserId, $userId));
+	}
+
+
+	/**
+	 * @param string $botUserId Bot user ID
+	 * @param bool $setSystemAdmin Whether to give the user the system admin role.
+	 */
+	public function convertBotToUser(string $botUserId, ?bool $setSystemAdmin = null): Response
+	{
+		return $this->connector->send(new ConvertBotToUser($botUserId, $setSystemAdmin));
+	}
+
+
+	/**
+	 * @param string $botUserId Bot user ID
+	 */
+	public function disableBot(string $botUserId): Response
+	{
+		return $this->connector->send(new DisableBot($botUserId));
+	}
+
+
+	/**
+	 * @param string $botUserId Bot user ID
+	 */
+	public function enableBot(string $botUserId): Response
+	{
+		return $this->connector->send(new EnableBot($botUserId));
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function convertUserToBot(string $userId): Response
+	{
+		return $this->connector->send(new ConvertUserToBot($userId));
+	}
+}

--- a/src/Client/Resource/Channels.php
+++ b/src/Client/Resource/Channels.php
@@ -1,0 +1,574 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Resource;
+
+use ConduitUI\Mattermost\Client\Requests\Channels\AddChannelMember;
+use ConduitUI\Mattermost\Client\Requests\Channels\AutocompleteChannelsForTeam;
+use ConduitUI\Mattermost\Client\Requests\Channels\AutocompleteChannelsForTeamForSearch;
+use ConduitUI\Mattermost\Client\Requests\Channels\ChannelMembersMinusGroupMembers;
+use ConduitUI\Mattermost\Client\Requests\Channels\CreateChannel;
+use ConduitUI\Mattermost\Client\Requests\Channels\CreateDirectChannel;
+use ConduitUI\Mattermost\Client\Requests\Channels\CreateGroupChannel;
+use ConduitUI\Mattermost\Client\Requests\Channels\CreateSidebarCategoryForTeamForUser;
+use ConduitUI\Mattermost\Client\Requests\Channels\DeleteChannel;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetAllChannels;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetChannel;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelByName;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelByNameForTeamName;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelMember;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelMemberCountsByGroup;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelMembers;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelMembersByIds;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelMembersForUser;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelMembersTimezones;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelModerations;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelStats;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelUnread;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelsForTeamForUser;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelsForUser;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetDeletedChannelsForTeam;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetPinnedPosts;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetPrivateChannelsForTeam;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetPublicChannelsByIdsForTeam;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetPublicChannelsForTeam;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetSidebarCategoriesForTeamForUser;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetSidebarCategoryForTeamForUser;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetSidebarCategoryOrderForTeamForUser;
+use ConduitUI\Mattermost\Client\Requests\Channels\MoveChannel;
+use ConduitUI\Mattermost\Client\Requests\Channels\PatchChannel;
+use ConduitUI\Mattermost\Client\Requests\Channels\PatchChannelModerations;
+use ConduitUI\Mattermost\Client\Requests\Channels\RemoveSidebarCategoryForTeamForUser;
+use ConduitUI\Mattermost\Client\Requests\Channels\RemoveUserFromChannel;
+use ConduitUI\Mattermost\Client\Requests\Channels\RestoreChannel;
+use ConduitUI\Mattermost\Client\Requests\Channels\SearchAllChannels;
+use ConduitUI\Mattermost\Client\Requests\Channels\SearchArchivedChannels;
+use ConduitUI\Mattermost\Client\Requests\Channels\SearchChannels;
+use ConduitUI\Mattermost\Client\Requests\Channels\SearchGroupChannels;
+use ConduitUI\Mattermost\Client\Requests\Channels\UpdateChannel;
+use ConduitUI\Mattermost\Client\Requests\Channels\UpdateChannelMemberSchemeRoles;
+use ConduitUI\Mattermost\Client\Requests\Channels\UpdateChannelNotifyProps;
+use ConduitUI\Mattermost\Client\Requests\Channels\UpdateChannelPrivacy;
+use ConduitUI\Mattermost\Client\Requests\Channels\UpdateChannelRoles;
+use ConduitUI\Mattermost\Client\Requests\Channels\UpdateChannelScheme;
+use ConduitUI\Mattermost\Client\Requests\Channels\UpdateSidebarCategoriesForTeamForUser;
+use ConduitUI\Mattermost\Client\Requests\Channels\UpdateSidebarCategoryForTeamForUser;
+use ConduitUI\Mattermost\Client\Requests\Channels\UpdateSidebarCategoryOrderForTeamForUser;
+use ConduitUI\Mattermost\Client\Requests\Channels\ViewChannel;
+use Saloon\Http\BaseResource;
+use Saloon\Http\Response;
+
+class Channels extends BaseResource
+{
+	/**
+	 * @param string $notAssociatedToGroup A group id to exclude channels that are associated with that group via GroupChannel records. This can also be left blank with `not_associated_to_group=`.
+	 * @param int $page The page to select.
+	 * @param bool $excludeDefaultChannels Whether to exclude default channels (ex Town Square, Off-Topic) from the results.
+	 * @param bool $includeDeleted Include channels that have been archived. This correlates to the `DeleteAt` flag being set in the database.
+	 * @param bool $includeTotalCount Appends a total count of returned channels inside the response object - ex: `{ "channels": [], "total_count" : 0 }`.
+	 * @param bool $excludePolicyConstrained If set to true, channels which are part of a data retention policy will be excluded. The `sysconsole_read_compliance` permission is required to use this parameter.
+	 * __Minimum server version__: 5.35
+	 */
+	public function getAllChannels(
+		?string $notAssociatedToGroup = null,
+		?int $page = null,
+		?bool $excludeDefaultChannels = null,
+		?bool $includeDeleted = null,
+		?bool $includeTotalCount = null,
+		?bool $excludePolicyConstrained = null,
+	): Response
+	{
+		return $this->connector->send(new GetAllChannels($notAssociatedToGroup, $page, $excludeDefaultChannels, $includeDeleted, $includeTotalCount, $excludePolicyConstrained));
+	}
+
+
+	public function createChannel(): Response
+	{
+		return $this->connector->send(new CreateChannel());
+	}
+
+
+	public function createDirectChannel(): Response
+	{
+		return $this->connector->send(new CreateDirectChannel());
+	}
+
+
+	public function createGroupChannel(): Response
+	{
+		return $this->connector->send(new CreateGroupChannel());
+	}
+
+
+	public function searchGroupChannels(): Response
+	{
+		return $this->connector->send(new SearchGroupChannels());
+	}
+
+
+	/**
+	 * @param string $userId User ID to perform the view action for
+	 */
+	public function viewChannel(string $userId): Response
+	{
+		return $this->connector->send(new ViewChannel($userId));
+	}
+
+
+	/**
+	 * @param bool $systemConsole Is the request from system_console. If this is set to true, it filters channels by the logged in user.
+	 */
+	public function searchAllChannels(?bool $systemConsole = null): Response
+	{
+		return $this->connector->send(new SearchAllChannels($systemConsole));
+	}
+
+
+	/**
+	 * @param string $channelId Channel GUID
+	 */
+	public function getChannel(string $channelId): Response
+	{
+		return $this->connector->send(new GetChannel($channelId));
+	}
+
+
+	/**
+	 * @param string $channelId Channel GUID
+	 */
+	public function updateChannel(string $channelId): Response
+	{
+		return $this->connector->send(new UpdateChannel($channelId));
+	}
+
+
+	/**
+	 * @param string $channelId Channel GUID
+	 */
+	public function deleteChannel(string $channelId): Response
+	{
+		return $this->connector->send(new DeleteChannel($channelId));
+	}
+
+
+	/**
+	 * @param string $channelId Channel GUID
+	 * @param bool $includeTimezones Defines if member timezone counts should be returned or not
+	 */
+	public function getChannelMemberCountsByGroup(string $channelId, ?bool $includeTimezones = null): Response
+	{
+		return $this->connector->send(new GetChannelMemberCountsByGroup($channelId, $includeTimezones));
+	}
+
+
+	/**
+	 * @param string $channelId Channel GUID
+	 * @param int $page The page to select.
+	 */
+	public function getChannelMembers(string $channelId, ?int $page = null): Response
+	{
+		return $this->connector->send(new GetChannelMembers($channelId, $page));
+	}
+
+
+	/**
+	 * @param string $channelId The channel ID
+	 */
+	public function addChannelMember(string $channelId): Response
+	{
+		return $this->connector->send(new AddChannelMember($channelId));
+	}
+
+
+	/**
+	 * @param string $channelId Channel GUID
+	 */
+	public function getChannelMembersByIds(string $channelId): Response
+	{
+		return $this->connector->send(new GetChannelMembersByIds($channelId));
+	}
+
+
+	/**
+	 * @param string $channelId Channel GUID
+	 * @param string $userId User GUID
+	 */
+	public function getChannelMember(string $channelId, string $userId): Response
+	{
+		return $this->connector->send(new GetChannelMember($channelId, $userId));
+	}
+
+
+	/**
+	 * @param string $channelId Channel GUID
+	 * @param string $userId User GUID
+	 */
+	public function removeUserFromChannel(string $channelId, string $userId): Response
+	{
+		return $this->connector->send(new RemoveUserFromChannel($channelId, $userId));
+	}
+
+
+	/**
+	 * @param string $channelId Channel GUID
+	 * @param string $userId User GUID
+	 */
+	public function updateChannelNotifyProps(string $channelId, string $userId): Response
+	{
+		return $this->connector->send(new UpdateChannelNotifyProps($channelId, $userId));
+	}
+
+
+	/**
+	 * @param string $channelId Channel GUID
+	 * @param string $userId User GUID
+	 */
+	public function updateChannelRoles(string $channelId, string $userId): Response
+	{
+		return $this->connector->send(new UpdateChannelRoles($channelId, $userId));
+	}
+
+
+	/**
+	 * @param string $channelId Channel GUID
+	 * @param string $userId User GUID
+	 */
+	public function updateChannelMemberSchemeRoles(string $channelId, string $userId): Response
+	{
+		return $this->connector->send(new UpdateChannelMemberSchemeRoles($channelId, $userId));
+	}
+
+
+	/**
+	 * @param string $channelId Channel GUID
+	 * @param string $groupIds A comma-separated list of group ids.
+	 * @param int $page The page to select.
+	 */
+	public function channelMembersMinusGroupMembers(string $channelId, string $groupIds, ?int $page = null): Response
+	{
+		return $this->connector->send(new ChannelMembersMinusGroupMembers($channelId, $groupIds, $page));
+	}
+
+
+	/**
+	 * @param string $channelId Channel GUID
+	 */
+	public function getChannelModerations(string $channelId): Response
+	{
+		return $this->connector->send(new GetChannelModerations($channelId));
+	}
+
+
+	/**
+	 * @param string $channelId Channel GUID
+	 */
+	public function patchChannelModerations(string $channelId): Response
+	{
+		return $this->connector->send(new PatchChannelModerations($channelId));
+	}
+
+
+	/**
+	 * @param string $channelId Channel GUID
+	 */
+	public function moveChannel(string $channelId): Response
+	{
+		return $this->connector->send(new MoveChannel($channelId));
+	}
+
+
+	/**
+	 * @param string $channelId Channel GUID
+	 */
+	public function patchChannel(string $channelId): Response
+	{
+		return $this->connector->send(new PatchChannel($channelId));
+	}
+
+
+	/**
+	 * @param string $channelId Channel GUID
+	 */
+	public function getPinnedPosts(string $channelId): Response
+	{
+		return $this->connector->send(new GetPinnedPosts($channelId));
+	}
+
+
+	/**
+	 * @param string $channelId Channel GUID
+	 */
+	public function updateChannelPrivacy(string $channelId): Response
+	{
+		return $this->connector->send(new UpdateChannelPrivacy($channelId));
+	}
+
+
+	/**
+	 * @param string $channelId Channel GUID
+	 */
+	public function restoreChannel(string $channelId): Response
+	{
+		return $this->connector->send(new RestoreChannel($channelId));
+	}
+
+
+	/**
+	 * @param string $channelId Channel GUID
+	 */
+	public function updateChannelScheme(string $channelId): Response
+	{
+		return $this->connector->send(new UpdateChannelScheme($channelId));
+	}
+
+
+	/**
+	 * @param string $channelId Channel GUID
+	 */
+	public function getChannelStats(string $channelId): Response
+	{
+		return $this->connector->send(new GetChannelStats($channelId));
+	}
+
+
+	/**
+	 * @param string $channelId Channel GUID
+	 */
+	public function getChannelMembersTimezones(string $channelId): Response
+	{
+		return $this->connector->send(new GetChannelMembersTimezones($channelId));
+	}
+
+
+	/**
+	 * @param string $teamName Team Name
+	 * @param string $channelName Channel Name
+	 * @param bool $includeDeleted Defines if deleted channels should be returned or not (Mattermost Server 5.26.0+)
+	 */
+	public function getChannelByNameForTeamName(
+		string $teamName,
+		string $channelName,
+		?bool $includeDeleted = null,
+	): Response
+	{
+		return $this->connector->send(new GetChannelByNameForTeamName($teamName, $channelName, $includeDeleted));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param int $page The page to select.
+	 */
+	public function getPublicChannelsForTeam(string $teamId, ?int $page = null): Response
+	{
+		return $this->connector->send(new GetPublicChannelsForTeam($teamId, $page));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param string $name Name or display name
+	 */
+	public function autocompleteChannelsForTeam(string $teamId, string $name): Response
+	{
+		return $this->connector->send(new AutocompleteChannelsForTeam($teamId, $name));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param int $page The page to select.
+	 */
+	public function getDeletedChannelsForTeam(string $teamId, ?int $page = null): Response
+	{
+		return $this->connector->send(new GetDeletedChannelsForTeam($teamId, $page));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 */
+	public function getPublicChannelsByIdsForTeam(string $teamId): Response
+	{
+		return $this->connector->send(new GetPublicChannelsByIdsForTeam($teamId));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param string $channelName Channel Name
+	 * @param bool $includeDeleted Defines if deleted channels should be returned or not (Mattermost Server 5.26.0+)
+	 */
+	public function getChannelByName(string $teamId, string $channelName, ?bool $includeDeleted = null): Response
+	{
+		return $this->connector->send(new GetChannelByName($teamId, $channelName, $includeDeleted));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param int $page The page to select.
+	 */
+	public function getPrivateChannelsForTeam(string $teamId, ?int $page = null): Response
+	{
+		return $this->connector->send(new GetPrivateChannelsForTeam($teamId, $page));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 */
+	public function searchChannels(string $teamId): Response
+	{
+		return $this->connector->send(new SearchChannels($teamId));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 */
+	public function searchArchivedChannels(string $teamId): Response
+	{
+		return $this->connector->send(new SearchArchivedChannels($teamId));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param string $name Name or display name
+	 */
+	public function autocompleteChannelsForTeamForSearch(string $teamId, string $name): Response
+	{
+		return $this->connector->send(new AutocompleteChannelsForTeamForSearch($teamId, $name));
+	}
+
+
+	/**
+	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
+	 * @param int $lastDeleteAt Filters the deleted channels by this time in epoch format. Does not have any effect if include_deleted is set to false.
+	 * @param bool $includeDeleted Defines if deleted channels should be returned or not
+	 */
+	public function getChannelsForUser(string $userId, ?int $lastDeleteAt = null, ?bool $includeDeleted = null): Response
+	{
+		return $this->connector->send(new GetChannelsForUser($userId, $lastDeleteAt, $includeDeleted));
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 * @param string $channelId Channel GUID
+	 */
+	public function getChannelUnread(string $userId, string $channelId): Response
+	{
+		return $this->connector->send(new GetChannelUnread($userId, $channelId));
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 * @param string $teamId Team GUID
+	 * @param bool $includeDeleted Defines if deleted channels should be returned or not
+	 * @param int $lastDeleteAt Filters the deleted channels by this time in epoch format. Does not have any effect if include_deleted is set to false.
+	 */
+	public function getChannelsForTeamForUser(
+		string $userId,
+		string $teamId,
+		?bool $includeDeleted = null,
+		?int $lastDeleteAt = null,
+	): Response
+	{
+		return $this->connector->send(new GetChannelsForTeamForUser($userId, $teamId, $includeDeleted, $lastDeleteAt));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param string $userId User GUID
+	 */
+	public function getSidebarCategoriesForTeamForUser(string $teamId, string $userId): Response
+	{
+		return $this->connector->send(new GetSidebarCategoriesForTeamForUser($teamId, $userId));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param string $userId User GUID
+	 */
+	public function updateSidebarCategoriesForTeamForUser(string $teamId, string $userId): Response
+	{
+		return $this->connector->send(new UpdateSidebarCategoriesForTeamForUser($teamId, $userId));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param string $userId User GUID
+	 */
+	public function createSidebarCategoryForTeamForUser(string $teamId, string $userId): Response
+	{
+		return $this->connector->send(new CreateSidebarCategoryForTeamForUser($teamId, $userId));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param string $userId User GUID
+	 */
+	public function getSidebarCategoryOrderForTeamForUser(string $teamId, string $userId): Response
+	{
+		return $this->connector->send(new GetSidebarCategoryOrderForTeamForUser($teamId, $userId));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param string $userId User GUID
+	 */
+	public function updateSidebarCategoryOrderForTeamForUser(string $teamId, string $userId): Response
+	{
+		return $this->connector->send(new UpdateSidebarCategoryOrderForTeamForUser($teamId, $userId));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param string $userId User GUID
+	 * @param string $categoryId Category GUID
+	 */
+	public function getSidebarCategoryForTeamForUser(string $teamId, string $userId, string $categoryId): Response
+	{
+		return $this->connector->send(new GetSidebarCategoryForTeamForUser($teamId, $userId, $categoryId));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param string $userId User GUID
+	 * @param string $categoryId Category GUID
+	 */
+	public function updateSidebarCategoryForTeamForUser(string $teamId, string $userId, string $categoryId): Response
+	{
+		return $this->connector->send(new UpdateSidebarCategoryForTeamForUser($teamId, $userId, $categoryId));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param string $userId User GUID
+	 * @param string $categoryId Category GUID
+	 */
+	public function removeSidebarCategoryForTeamForUser(string $teamId, string $userId, string $categoryId): Response
+	{
+		return $this->connector->send(new RemoveSidebarCategoryForTeamForUser($teamId, $userId, $categoryId));
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 * @param string $teamId Team GUID
+	 */
+	public function getChannelMembersForUser(string $userId, string $teamId): Response
+	{
+		return $this->connector->send(new GetChannelMembersForUser($userId, $teamId));
+	}
+}

--- a/src/Client/Resource/Commands.php
+++ b/src/Client/Resource/Commands.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Resource;
+
+use ConduitUI\Mattermost\Client\Requests\Commands\CreateCommand;
+use ConduitUI\Mattermost\Client\Requests\Commands\DeleteCommand;
+use ConduitUI\Mattermost\Client\Requests\Commands\ExecuteCommand;
+use ConduitUI\Mattermost\Client\Requests\Commands\GetCommandById;
+use ConduitUI\Mattermost\Client\Requests\Commands\ListAutocompleteCommands;
+use ConduitUI\Mattermost\Client\Requests\Commands\ListCommands;
+use ConduitUI\Mattermost\Client\Requests\Commands\MoveCommand;
+use ConduitUI\Mattermost\Client\Requests\Commands\RegenCommandToken;
+use ConduitUI\Mattermost\Client\Requests\Commands\UpdateCommand;
+use Saloon\Http\BaseResource;
+use Saloon\Http\Response;
+
+class Commands extends BaseResource
+{
+	/**
+	 * @param string $teamId The team id.
+	 * @param bool $customOnly To get only the custom commands. If set to false will get the custom
+	 * if the user have access plus the system commands, otherwise just the system commands.
+	 */
+	public function listCommands(?string $teamId = null, ?bool $customOnly = null): Response
+	{
+		return $this->connector->send(new ListCommands($teamId, $customOnly));
+	}
+
+
+	public function createCommand(): Response
+	{
+		return $this->connector->send(new CreateCommand());
+	}
+
+
+	public function executeCommand(): Response
+	{
+		return $this->connector->send(new ExecuteCommand());
+	}
+
+
+	/**
+	 * @param string $commandId ID of the command to get
+	 */
+	public function getCommandById(string $commandId): Response
+	{
+		return $this->connector->send(new GetCommandById($commandId));
+	}
+
+
+	/**
+	 * @param string $commandId ID of the command to update
+	 */
+	public function updateCommand(string $commandId): Response
+	{
+		return $this->connector->send(new UpdateCommand($commandId));
+	}
+
+
+	/**
+	 * @param string $commandId ID of the command to delete
+	 */
+	public function deleteCommand(string $commandId): Response
+	{
+		return $this->connector->send(new DeleteCommand($commandId));
+	}
+
+
+	/**
+	 * @param string $commandId ID of the command to move
+	 */
+	public function moveCommand(string $commandId): Response
+	{
+		return $this->connector->send(new MoveCommand($commandId));
+	}
+
+
+	/**
+	 * @param string $commandId ID of the command to generate the new token
+	 */
+	public function regenCommandToken(string $commandId): Response
+	{
+		return $this->connector->send(new RegenCommandToken($commandId));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 */
+	public function listAutocompleteCommands(string $teamId): Response
+	{
+		return $this->connector->send(new ListAutocompleteCommands($teamId));
+	}
+}

--- a/src/Client/Resource/DataRetention.php
+++ b/src/Client/Resource/DataRetention.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Resource;
+
+use ConduitUI\Mattermost\Client\Requests\DataRetention\GetChannelPoliciesForUser;
+use ConduitUI\Mattermost\Client\Requests\DataRetention\GetTeamPoliciesForUser;
+use Saloon\Http\BaseResource;
+use Saloon\Http\Response;
+
+class DataRetention extends BaseResource
+{
+	/**
+	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
+	 * @param int $page The page to select.
+	 */
+	public function getChannelPoliciesForUser(string $userId, ?int $page = null): Response
+	{
+		return $this->connector->send(new GetChannelPoliciesForUser($userId, $page));
+	}
+
+
+	/**
+	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
+	 * @param int $page The page to select.
+	 */
+	public function getTeamPoliciesForUser(string $userId, ?int $page = null): Response
+	{
+		return $this->connector->send(new GetTeamPoliciesForUser($userId, $page));
+	}
+}

--- a/src/Client/Resource/Emoji.php
+++ b/src/Client/Resource/Emoji.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Resource;
+
+use ConduitUI\Mattermost\Client\Requests\Emoji\AutocompleteEmoji;
+use ConduitUI\Mattermost\Client\Requests\Emoji\CreateEmoji;
+use ConduitUI\Mattermost\Client\Requests\Emoji\DeleteEmoji;
+use ConduitUI\Mattermost\Client\Requests\Emoji\GetEmoji;
+use ConduitUI\Mattermost\Client\Requests\Emoji\GetEmojiByName;
+use ConduitUI\Mattermost\Client\Requests\Emoji\GetEmojiImage;
+use ConduitUI\Mattermost\Client\Requests\Emoji\GetEmojiList;
+use ConduitUI\Mattermost\Client\Requests\Emoji\SearchEmoji;
+use Saloon\Http\BaseResource;
+use Saloon\Http\Response;
+
+class Emoji extends BaseResource
+{
+	/**
+	 * @param int $page The page to select.
+	 * @param string $sort Either blank for no sorting or "name" to sort by emoji names. Minimum server version for sorting is 4.7.
+	 */
+	public function getEmojiList(?int $page = null, ?string $sort = null): Response
+	{
+		return $this->connector->send(new GetEmojiList($page, $sort));
+	}
+
+
+	public function createEmoji(): Response
+	{
+		return $this->connector->send(new CreateEmoji());
+	}
+
+
+	/**
+	 * @param string $name The emoji name to search.
+	 */
+	public function autocompleteEmoji(string $name): Response
+	{
+		return $this->connector->send(new AutocompleteEmoji($name));
+	}
+
+
+	/**
+	 * @param string $emojiName Emoji name
+	 */
+	public function getEmojiByName(string $emojiName): Response
+	{
+		return $this->connector->send(new GetEmojiByName($emojiName));
+	}
+
+
+	public function searchEmoji(): Response
+	{
+		return $this->connector->send(new SearchEmoji());
+	}
+
+
+	/**
+	 * @param string $emojiId Emoji GUID
+	 */
+	public function getEmoji(string $emojiId): Response
+	{
+		return $this->connector->send(new GetEmoji($emojiId));
+	}
+
+
+	/**
+	 * @param string $emojiId Emoji GUID
+	 */
+	public function deleteEmoji(string $emojiId): Response
+	{
+		return $this->connector->send(new DeleteEmoji($emojiId));
+	}
+
+
+	/**
+	 * @param string $emojiId Emoji GUID
+	 */
+	public function getEmojiImage(string $emojiId): Response
+	{
+		return $this->connector->send(new GetEmojiImage($emojiId));
+	}
+}

--- a/src/Client/Resource/Files.php
+++ b/src/Client/Resource/Files.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Resource;
+
+use ConduitUI\Mattermost\Client\Requests\Files\GetFile;
+use ConduitUI\Mattermost\Client\Requests\Files\GetFileInfo;
+use ConduitUI\Mattermost\Client\Requests\Files\GetFileLink;
+use ConduitUI\Mattermost\Client\Requests\Files\GetFilePreview;
+use ConduitUI\Mattermost\Client\Requests\Files\GetFilePublic;
+use ConduitUI\Mattermost\Client\Requests\Files\GetFileThumbnail;
+use ConduitUI\Mattermost\Client\Requests\Files\UploadFile;
+use Saloon\Http\BaseResource;
+use Saloon\Http\Response;
+
+class Files extends BaseResource
+{
+	/**
+	 * @param string $channelId The ID of the channel that this file will be uploaded to
+	 * @param string $filename The name of the file to be uploaded
+	 */
+	public function uploadFile(?string $channelId = null, ?string $filename = null): Response
+	{
+		return $this->connector->send(new UploadFile($channelId, $filename));
+	}
+
+
+	/**
+	 * @param string $fileId The ID of the file to get
+	 */
+	public function getFile(string $fileId): Response
+	{
+		return $this->connector->send(new GetFile($fileId));
+	}
+
+
+	/**
+	 * @param string $fileId The ID of the file info to get
+	 */
+	public function getFileInfo(string $fileId): Response
+	{
+		return $this->connector->send(new GetFileInfo($fileId));
+	}
+
+
+	/**
+	 * @param string $fileId The ID of the file to get a link for
+	 */
+	public function getFileLink(string $fileId): Response
+	{
+		return $this->connector->send(new GetFileLink($fileId));
+	}
+
+
+	/**
+	 * @param string $fileId The ID of the file to get
+	 */
+	public function getFilePreview(string $fileId): Response
+	{
+		return $this->connector->send(new GetFilePreview($fileId));
+	}
+
+
+	/**
+	 * @param string $fileId The ID of the file to get
+	 * @param string $h File hash
+	 */
+	public function getFilePublic(string $fileId, string $h): Response
+	{
+		return $this->connector->send(new GetFilePublic($fileId, $h));
+	}
+
+
+	/**
+	 * @param string $fileId The ID of the file to get
+	 */
+	public function getFileThumbnail(string $fileId): Response
+	{
+		return $this->connector->send(new GetFileThumbnail($fileId));
+	}
+}

--- a/src/Client/Resource/Groups.php
+++ b/src/Client/Resource/Groups.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Resource;
+
+use ConduitUI\Mattermost\Client\Requests\Groups\GetGroupsAssociatedToChannelsByTeam;
+use ConduitUI\Mattermost\Client\Requests\Groups\GetGroupsByChannel;
+use ConduitUI\Mattermost\Client\Requests\Groups\GetGroupsByTeam;
+use ConduitUI\Mattermost\Client\Requests\Groups\GetGroupsByUserId;
+use Saloon\Http\BaseResource;
+use Saloon\Http\Response;
+
+class Groups extends BaseResource
+{
+	/**
+	 * @param string $channelId Channel GUID
+	 * @param int $page The page to select.
+	 * @param bool $filterAllowReference Boolean which filters the group entries with the `allow_reference` attribute set.
+	 */
+	public function getGroupsByChannel(
+		string $channelId,
+		?int $page = null,
+		?bool $filterAllowReference = null,
+	): Response
+	{
+		return $this->connector->send(new GetGroupsByChannel($channelId, $page, $filterAllowReference));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param int $page The page to select.
+	 * @param bool $filterAllowReference Boolean which filters in the group entries with the `allow_reference` attribute set.
+	 */
+	public function getGroupsByTeam(string $teamId, ?int $page = null, ?bool $filterAllowReference = null): Response
+	{
+		return $this->connector->send(new GetGroupsByTeam($teamId, $page, $filterAllowReference));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param int $page The page to select.
+	 * @param bool $filterAllowReference Boolean which filters in the group entries with the `allow_reference` attribute set.
+	 * @param bool $paginate Boolean to determine whether the pagination should be applied or not
+	 */
+	public function getGroupsAssociatedToChannelsByTeam(
+		string $teamId,
+		?int $page = null,
+		?bool $filterAllowReference = null,
+		?bool $paginate = null,
+	): Response
+	{
+		return $this->connector->send(new GetGroupsAssociatedToChannelsByTeam($teamId, $page, $filterAllowReference, $paginate));
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function getGroupsByUserId(string $userId): Response
+	{
+		return $this->connector->send(new GetGroupsByUserId($userId));
+	}
+}

--- a/src/Client/Resource/Insights.php
+++ b/src/Client/Resource/Insights.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Resource;
+
+use ConduitUI\Mattermost\Client\Requests\Insights\GetNewTeamMembers;
+use ConduitUI\Mattermost\Client\Requests\Insights\GetTopChannelsForTeam;
+use ConduitUI\Mattermost\Client\Requests\Insights\GetTopChannelsForUser;
+use ConduitUI\Mattermost\Client\Requests\Insights\GetTopDmsForUser;
+use ConduitUI\Mattermost\Client\Requests\Insights\GetTopReactionsForTeam;
+use ConduitUI\Mattermost\Client\Requests\Insights\GetTopReactionsForUser;
+use ConduitUI\Mattermost\Client\Requests\Insights\GetTopThreadsForTeam;
+use ConduitUI\Mattermost\Client\Requests\Insights\GetTopThreadsForUser;
+use Saloon\Http\BaseResource;
+use Saloon\Http\Response;
+
+class Insights extends BaseResource
+{
+	/**
+	 * @param string $teamId Team GUID
+	 * @param string $timeRange Time range can be "today", "7_day", or "28_day".
+	 * - `today`: channels with posts on the current day.
+	 * - `7_day`: channels with posts in the last 7 days.
+	 * - `28_day`: channels with posts in the last 28 days.
+	 * @param int $page The page to select.
+	 */
+	public function getTopChannelsForTeam(string $teamId, string $timeRange, ?int $page = null): Response
+	{
+		return $this->connector->send(new GetTopChannelsForTeam($teamId, $timeRange, $page));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param string $timeRange Time range can be "today", "7_day", or "28_day".
+	 * - `today`: reactions posted on the current day.
+	 * - `7_day`: reactions posted in the last 7 days.
+	 * - `28_day`: reactions posted in the last 28 days.
+	 * @param int $page The page to select.
+	 */
+	public function getTopReactionsForTeam(string $teamId, string $timeRange, ?int $page = null): Response
+	{
+		return $this->connector->send(new GetTopReactionsForTeam($teamId, $timeRange, $page));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param string $timeRange Time range can be "today", "7_day", or "28_day".
+	 * - `today`: team members who joined during the current day.
+	 * - `7_day`: team members who joined in the last 7 days.
+	 * - `28_day`: team members who joined in the last 28 days.
+	 * @param int $page The page to select.
+	 */
+	public function getNewTeamMembers(string $teamId, string $timeRange, ?int $page = null): Response
+	{
+		return $this->connector->send(new GetNewTeamMembers($teamId, $timeRange, $page));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param string $timeRange Time range can be "today", "7_day", or "28_day".
+	 * - `today`: threads with activity on the current day.
+	 * - `7_day`: threads with activity in the last 7 days.
+	 * - `28_day`: threads with activity in the last 28 days.
+	 * @param int $page The page to select.
+	 */
+	public function getTopThreadsForTeam(string $teamId, string $timeRange, ?int $page = null): Response
+	{
+		return $this->connector->send(new GetTopThreadsForTeam($teamId, $timeRange, $page));
+	}
+
+
+	/**
+	 * @param string $timeRange Time range can be "today", "7_day", or "28_day".
+	 * - `today`: channels with posts on the current day.
+	 * - `7_day`: channels with posts in the last 7 days.
+	 * - `28_day`: channels with posts in the last 28 days.
+	 * @param int $page The page to select.
+	 * @param string $teamId Team ID will scope the response to a given team.
+	 * ##### Permissions
+	 * Must have `view_team` permission for the team.
+	 */
+	public function getTopChannelsForUser(string $timeRange, ?int $page = null, ?string $teamId = null): Response
+	{
+		return $this->connector->send(new GetTopChannelsForUser($timeRange, $page, $teamId));
+	}
+
+
+	/**
+	 * @param string $timeRange Time range can be "today", "7_day", or "28_day".
+	 * - `today`: threads with activity on the current day.
+	 * - `7_day`: threads with activity in the last 7 days.
+	 * - `28_day`: threads with activity in the last 28 days.
+	 * @param int $page The page to select.
+	 */
+	public function getTopDmsForUser(string $timeRange, ?int $page = null): Response
+	{
+		return $this->connector->send(new GetTopDmsForUser($timeRange, $page));
+	}
+
+
+	/**
+	 * @param string $timeRange Time range can be "today", "7_day", or "28_day".
+	 * - `today`: reactions posted on the current day.
+	 * - `7_day`: reactions posted in the last 7 days.
+	 * - `28_day`: reactions posted in the last 28 days.
+	 * @param int $page The page to select.
+	 * @param string $teamId Team ID will scope the response to a given team and exclude direct and group messages.
+	 * ##### Permissions
+	 * Must have `view_team` permission for the team.
+	 */
+	public function getTopReactionsForUser(string $timeRange, ?int $page = null, ?string $teamId = null): Response
+	{
+		return $this->connector->send(new GetTopReactionsForUser($timeRange, $page, $teamId));
+	}
+
+
+	/**
+	 * @param string $timeRange Time range can be "today", "7_day", or "28_day".
+	 * - `today`: threads with activity on the current day.
+	 * - `7_day`: threads with activity in the last 7 days.
+	 * - `28_day`: threads with activity in the last 28 days.
+	 * @param int $page The page to select.
+	 * @param string $teamId Team ID will scope the response to a given team.
+	 * ##### Permissions
+	 * Must have `view_team` permission for the team.
+	 */
+	public function getTopThreadsForUser(string $timeRange, ?int $page = null, ?string $teamId = null): Response
+	{
+		return $this->connector->send(new GetTopThreadsForUser($timeRange, $page, $teamId));
+	}
+}

--- a/src/Client/Resource/Oauth.php
+++ b/src/Client/Resource/Oauth.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Resource;
+
+use ConduitUI\Mattermost\Client\Requests\Oauth\GetAuthorizedOauthAppsForUser;
+use Saloon\Http\BaseResource;
+use Saloon\Http\Response;
+
+class Oauth extends BaseResource
+{
+	/**
+	 * @param string $userId User GUID
+	 * @param int $page The page to select.
+	 */
+	public function getAuthorizedOauthAppsForUser(string $userId, ?int $page = null): Response
+	{
+		return $this->connector->send(new GetAuthorizedOauthAppsForUser($userId, $page));
+	}
+}

--- a/src/Client/Resource/Posts.php
+++ b/src/Client/Resource/Posts.php
@@ -1,0 +1,257 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Resource;
+
+use ConduitUI\Mattermost\Client\Requests\Posts\CreatePost;
+use ConduitUI\Mattermost\Client\Requests\Posts\CreatePostEphemeral;
+use ConduitUI\Mattermost\Client\Requests\Posts\DeletePost;
+use ConduitUI\Mattermost\Client\Requests\Posts\DoPostAction;
+use ConduitUI\Mattermost\Client\Requests\Posts\GetFileInfosForPost;
+use ConduitUI\Mattermost\Client\Requests\Posts\GetFlaggedPostsForUser;
+use ConduitUI\Mattermost\Client\Requests\Posts\GetPost;
+use ConduitUI\Mattermost\Client\Requests\Posts\GetPostThread;
+use ConduitUI\Mattermost\Client\Requests\Posts\GetPostsAroundLastUnread;
+use ConduitUI\Mattermost\Client\Requests\Posts\GetPostsByIds;
+use ConduitUI\Mattermost\Client\Requests\Posts\GetPostsForChannel;
+use ConduitUI\Mattermost\Client\Requests\Posts\PatchPost;
+use ConduitUI\Mattermost\Client\Requests\Posts\PinPost;
+use ConduitUI\Mattermost\Client\Requests\Posts\SaveAcknowledgementForPost;
+use ConduitUI\Mattermost\Client\Requests\Posts\SearchPosts;
+use ConduitUI\Mattermost\Client\Requests\Posts\SetPostReminder;
+use ConduitUI\Mattermost\Client\Requests\Posts\SetPostUnread;
+use ConduitUI\Mattermost\Client\Requests\Posts\UnpinPost;
+use ConduitUI\Mattermost\Client\Requests\Posts\UpdatePost;
+use Saloon\Http\BaseResource;
+use Saloon\Http\Response;
+
+class Posts extends BaseResource
+{
+	/**
+	 * @param string $channelId The channel ID to get the posts for
+	 * @param int $page The page to select
+	 * @param int $since Provide a non-zero value in Unix time milliseconds to select posts modified after that time
+	 * @param string $before A post id to select the posts that came before this one
+	 * @param bool $includeDeleted Whether to include deleted posts or not. Must have system admin permissions.
+	 */
+	public function getPostsForChannel(
+		string $channelId,
+		?int $page = null,
+		?int $since = null,
+		?string $before = null,
+		?bool $includeDeleted = null,
+	): Response
+	{
+		return $this->connector->send(new GetPostsForChannel($channelId, $page, $since, $before, $includeDeleted));
+	}
+
+
+	/**
+	 * @param bool $setOnline Whether to set the user status as online or not.
+	 */
+	public function createPost(?bool $setOnline = null): Response
+	{
+		return $this->connector->send(new CreatePost($setOnline));
+	}
+
+
+	public function createPostEphemeral(): Response
+	{
+		return $this->connector->send(new CreatePostEphemeral());
+	}
+
+
+	public function getPostsByIds(): Response
+	{
+		return $this->connector->send(new GetPostsByIds());
+	}
+
+
+	/**
+	 * @param string $postId ID of the post to get
+	 * @param bool $includeDeleted Defines if result should include deleted posts, must have 'manage_system' (admin) permission.
+	 */
+	public function getPost(string $postId, ?bool $includeDeleted = null): Response
+	{
+		return $this->connector->send(new GetPost($postId, $includeDeleted));
+	}
+
+
+	/**
+	 * @param string $postId ID of the post to update
+	 */
+	public function updatePost(string $postId): Response
+	{
+		return $this->connector->send(new UpdatePost($postId));
+	}
+
+
+	/**
+	 * @param string $postId ID of the post to delete
+	 */
+	public function deletePost(string $postId): Response
+	{
+		return $this->connector->send(new DeletePost($postId));
+	}
+
+
+	/**
+	 * @param string $postId Post GUID
+	 * @param string $actionId Action GUID
+	 */
+	public function doPostAction(string $postId, string $actionId): Response
+	{
+		return $this->connector->send(new DoPostAction($postId, $actionId));
+	}
+
+
+	/**
+	 * @param string $postId ID of the post
+	 * @param bool $includeDeleted Defines if result should include deleted posts, must have 'manage_system' (admin) permission.
+	 */
+	public function getFileInfosForPost(string $postId, ?bool $includeDeleted = null): Response
+	{
+		return $this->connector->send(new GetFileInfosForPost($postId, $includeDeleted));
+	}
+
+
+	/**
+	 * @param string $postId Post GUID
+	 */
+	public function patchPost(string $postId): Response
+	{
+		return $this->connector->send(new PatchPost($postId));
+	}
+
+
+	/**
+	 * @param string $postId Post GUID
+	 */
+	public function pinPost(string $postId): Response
+	{
+		return $this->connector->send(new PinPost($postId));
+	}
+
+
+	/**
+	 * @param string $postId ID of a post in the thread
+	 * @param int $perPage The number of posts per page
+	 * @param string $fromPost The post_id to return the next page of posts from
+	 * @param int $fromCreateAt The create_at timestamp to return the next page of posts from
+	 * @param string $direction The direction to return the posts. Either up or down.
+	 * @param bool $skipFetchThreads Whether to skip fetching threads or not
+	 * @param bool $collapsedThreads Whether the client uses CRT or not
+	 * @param bool $collapsedThreadsExtended Whether to return the associated users as part of the response or not
+	 */
+	public function getPostThread(
+		string $postId,
+		?int $perPage = null,
+		?string $fromPost = null,
+		?int $fromCreateAt = null,
+		?string $direction = null,
+		?bool $skipFetchThreads = null,
+		?bool $collapsedThreads = null,
+		?bool $collapsedThreadsExtended = null,
+	): Response
+	{
+		return $this->connector->send(new GetPostThread($postId, $perPage, $fromPost, $fromCreateAt, $direction, $skipFetchThreads, $collapsedThreads, $collapsedThreadsExtended));
+	}
+
+
+	/**
+	 * @param string $postId Post GUID
+	 */
+	public function unpinPost(string $postId): Response
+	{
+		return $this->connector->send(new UnpinPost($postId));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 */
+	public function searchPosts(string $teamId): Response
+	{
+		return $this->connector->send(new SearchPosts($teamId));
+	}
+
+
+	/**
+	 * @param string $userId ID of the user
+	 * @param string $channelId The channel ID to get the posts for
+	 * @param int $limitBefore Number of posts before the oldest unread posts. Maximum is 200 posts if limit is set greater than that.
+	 * @param int $limitAfter Number of posts after and including the oldest unread post. Maximum is 200 posts if limit is set greater than that.
+	 * @param bool $skipFetchThreads Whether to skip fetching threads or not
+	 * @param bool $collapsedThreads Whether the client uses CRT or not
+	 * @param bool $collapsedThreadsExtended Whether to return the associated users as part of the response or not
+	 */
+	public function getPostsAroundLastUnread(
+		string $userId,
+		string $channelId,
+		?int $limitBefore = null,
+		?int $limitAfter = null,
+		?bool $skipFetchThreads = null,
+		?bool $collapsedThreads = null,
+		?bool $collapsedThreadsExtended = null,
+	): Response
+	{
+		return $this->connector->send(new GetPostsAroundLastUnread($userId, $channelId, $limitBefore, $limitAfter, $skipFetchThreads, $collapsedThreads, $collapsedThreadsExtended));
+	}
+
+
+	/**
+	 * @param string $userId ID of the user
+	 * @param string $teamId Team ID
+	 * @param string $channelId Channel ID
+	 * @param int $page The page to select
+	 */
+	public function getFlaggedPostsForUser(
+		string $userId,
+		?string $teamId = null,
+		?string $channelId = null,
+		?int $page = null,
+	): Response
+	{
+		return $this->connector->send(new GetFlaggedPostsForUser($userId, $teamId, $channelId, $page));
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 * @param string $postId Post GUID
+	 */
+	public function saveAcknowledgementForPost(string $userId, string $postId): Response
+	{
+		return $this->connector->send(new SaveAcknowledgementForPost($userId, $postId));
+	}
+
+
+	/**
+	 * @todo Fix duplicated method name
+	 * @param string $userId User GUID
+	 * @param string $postId Post GUID
+	 */
+	public function saveAcknowledgementForPostDuplicate1(string $userId, string $postId): Response
+	{
+		return $this->connector->send(new SaveAcknowledgementForPost($userId, $postId));
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 * @param string $postId Post GUID
+	 */
+	public function setPostReminder(string $userId, string $postId): Response
+	{
+		return $this->connector->send(new SetPostReminder($userId, $postId));
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 * @param string $postId Post GUID
+	 */
+	public function setPostUnread(string $userId, string $postId): Response
+	{
+		return $this->connector->send(new SetPostUnread($userId, $postId));
+	}
+}

--- a/src/Client/Resource/Preferences.php
+++ b/src/Client/Resource/Preferences.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Resource;
+
+use ConduitUI\Mattermost\Client\Requests\Preferences\DeletePreferences;
+use ConduitUI\Mattermost\Client\Requests\Preferences\GetPreferences;
+use ConduitUI\Mattermost\Client\Requests\Preferences\GetPreferencesByCategory;
+use ConduitUI\Mattermost\Client\Requests\Preferences\GetPreferencesByCategoryByName;
+use ConduitUI\Mattermost\Client\Requests\Preferences\UpdatePreferences;
+use Saloon\Http\BaseResource;
+use Saloon\Http\Response;
+
+class Preferences extends BaseResource
+{
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function getPreferences(string $userId): Response
+	{
+		return $this->connector->send(new GetPreferences($userId));
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function updatePreferences(string $userId): Response
+	{
+		return $this->connector->send(new UpdatePreferences($userId));
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function deletePreferences(string $userId): Response
+	{
+		return $this->connector->send(new DeletePreferences($userId));
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 * @param string $category The category of a group of preferences
+	 */
+	public function getPreferencesByCategory(string $userId, string $category): Response
+	{
+		return $this->connector->send(new GetPreferencesByCategory($userId, $category));
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 * @param string $category The category of a group of preferences
+	 * @param string $preferenceName The name of the preference
+	 */
+	public function getPreferencesByCategoryByName(string $userId, string $category, string $preferenceName): Response
+	{
+		return $this->connector->send(new GetPreferencesByCategoryByName($userId, $category, $preferenceName));
+	}
+}

--- a/src/Client/Resource/Reactions.php
+++ b/src/Client/Resource/Reactions.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Resource;
+
+use ConduitUI\Mattermost\Client\Requests\Reactions\DeleteReaction;
+use ConduitUI\Mattermost\Client\Requests\Reactions\GetBulkReactions;
+use ConduitUI\Mattermost\Client\Requests\Reactions\GetReactions;
+use ConduitUI\Mattermost\Client\Requests\Reactions\SaveReaction;
+use Saloon\Http\BaseResource;
+use Saloon\Http\Response;
+
+class Reactions extends BaseResource
+{
+	public function getBulkReactions(): Response
+	{
+		return $this->connector->send(new GetBulkReactions());
+	}
+
+
+	/**
+	 * @param string $postId ID of a post
+	 */
+	public function getReactions(string $postId): Response
+	{
+		return $this->connector->send(new GetReactions($postId));
+	}
+
+
+	public function saveReaction(): Response
+	{
+		return $this->connector->send(new SaveReaction());
+	}
+
+
+	/**
+	 * @param string $userId ID of the user
+	 * @param string $postId ID of the post
+	 * @param string $emojiName emoji name
+	 */
+	public function deleteReaction(string $userId, string $postId, string $emojiName): Response
+	{
+		return $this->connector->send(new DeleteReaction($userId, $postId, $emojiName));
+	}
+}

--- a/src/Client/Resource/Status.php
+++ b/src/Client/Resource/Status.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Resource;
+
+use ConduitUI\Mattermost\Client\Requests\Status\GetUserStatus;
+use ConduitUI\Mattermost\Client\Requests\Status\GetUsersStatusesByIds;
+use ConduitUI\Mattermost\Client\Requests\Status\PostUserRecentCustomStatusDelete;
+use ConduitUI\Mattermost\Client\Requests\Status\RemoveRecentCustomStatus;
+use ConduitUI\Mattermost\Client\Requests\Status\UnsetUserCustomStatus;
+use ConduitUI\Mattermost\Client\Requests\Status\UpdateUserCustomStatus;
+use ConduitUI\Mattermost\Client\Requests\Status\UpdateUserStatus;
+use Saloon\Http\BaseResource;
+use Saloon\Http\Response;
+
+class Status extends BaseResource
+{
+	public function getUsersStatusesByIds(): Response
+	{
+		return $this->connector->send(new GetUsersStatusesByIds());
+	}
+
+
+	/**
+	 * @param string $userId User ID
+	 */
+	public function getUserStatus(string $userId): Response
+	{
+		return $this->connector->send(new GetUserStatus($userId));
+	}
+
+
+	/**
+	 * @param string $userId User ID
+	 */
+	public function updateUserStatus(string $userId): Response
+	{
+		return $this->connector->send(new UpdateUserStatus($userId));
+	}
+
+
+	/**
+	 * @param string $userId User ID
+	 */
+	public function updateUserCustomStatus(string $userId): Response
+	{
+		return $this->connector->send(new UpdateUserCustomStatus($userId));
+	}
+
+
+	/**
+	 * @param string $userId User ID
+	 */
+	public function unsetUserCustomStatus(string $userId): Response
+	{
+		return $this->connector->send(new UnsetUserCustomStatus($userId));
+	}
+
+
+	/**
+	 * @param string $userId User ID
+	 */
+	public function removeRecentCustomStatus(string $userId): Response
+	{
+		return $this->connector->send(new RemoveRecentCustomStatus($userId));
+	}
+
+
+	/**
+	 * @param string $userId User ID
+	 */
+	public function postUserRecentCustomStatusDelete(string $userId): Response
+	{
+		return $this->connector->send(new PostUserRecentCustomStatusDelete($userId));
+	}
+}

--- a/src/Client/Resource/System.php
+++ b/src/Client/Resource/System.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Resource;
+
+use ConduitUI\Mattermost\Client\Requests\System\GenerateSupportPacket;
+use ConduitUI\Mattermost\Client\Requests\System\GetNotices;
+use ConduitUI\Mattermost\Client\Requests\System\GetPing;
+use ConduitUI\Mattermost\Client\Requests\System\GetSupportedTimezone;
+use ConduitUI\Mattermost\Client\Requests\System\MarkNoticesViewed;
+use Saloon\Http\BaseResource;
+use Saloon\Http\Response;
+
+class System extends BaseResource
+{
+	public function markNoticesViewed(): Response
+	{
+		return $this->connector->send(new MarkNoticesViewed());
+	}
+
+
+	/**
+	 * @param string $teamId ID of the team
+	 * @param string $clientVersion Version of the client (desktop/mobile/web) that issues the request
+	 * @param string $locale Client locale
+	 * @param string $client Client type (web/mobile-ios/mobile-android/desktop)
+	 */
+	public function getNotices(string $teamId, string $clientVersion, ?string $locale = null, string $client): Response
+	{
+		return $this->connector->send(new GetNotices($teamId, $clientVersion, $locale, $client));
+	}
+
+
+	/**
+	 * @param bool $getServerStatus Check the status of the database and file storage as well
+	 * @param string $deviceId Check whether this device id can receive push notifications
+	 */
+	public function getPing(?bool $getServerStatus = null, ?string $deviceId = null): Response
+	{
+		return $this->connector->send(new GetPing($getServerStatus, $deviceId));
+	}
+
+
+	public function generateSupportPacket(): Response
+	{
+		return $this->connector->send(new GenerateSupportPacket());
+	}
+
+
+	public function getSupportedTimezone(): Response
+	{
+		return $this->connector->send(new GetSupportedTimezone());
+	}
+}

--- a/src/Client/Resource/Teams.php
+++ b/src/Client/Resource/Teams.php
@@ -1,0 +1,392 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Resource;
+
+use ConduitUI\Mattermost\Client\Requests\Teams\AddTeamMember;
+use ConduitUI\Mattermost\Client\Requests\Teams\AddTeamMemberFromInvite;
+use ConduitUI\Mattermost\Client\Requests\Teams\AddTeamMembers;
+use ConduitUI\Mattermost\Client\Requests\Teams\CreateTeam;
+use ConduitUI\Mattermost\Client\Requests\Teams\GetAllTeams;
+use ConduitUI\Mattermost\Client\Requests\Teams\GetTeam;
+use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamByName;
+use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamIcon;
+use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamInviteInfo;
+use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamMember;
+use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamMembers;
+use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamMembersByIds;
+use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamMembersForUser;
+use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamStats;
+use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamUnread;
+use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamsForUser;
+use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamsUnreadForUser;
+use ConduitUI\Mattermost\Client\Requests\Teams\ImportTeam;
+use ConduitUI\Mattermost\Client\Requests\Teams\InvalidateEmailInvites;
+use ConduitUI\Mattermost\Client\Requests\Teams\InviteGuestsToTeam;
+use ConduitUI\Mattermost\Client\Requests\Teams\InviteUsersToTeam;
+use ConduitUI\Mattermost\Client\Requests\Teams\PatchTeam;
+use ConduitUI\Mattermost\Client\Requests\Teams\RegenerateTeamInviteId;
+use ConduitUI\Mattermost\Client\Requests\Teams\RemoveTeamIcon;
+use ConduitUI\Mattermost\Client\Requests\Teams\RemoveTeamMember;
+use ConduitUI\Mattermost\Client\Requests\Teams\RestoreTeam;
+use ConduitUI\Mattermost\Client\Requests\Teams\SearchFiles;
+use ConduitUI\Mattermost\Client\Requests\Teams\SearchTeams;
+use ConduitUI\Mattermost\Client\Requests\Teams\SetTeamIcon;
+use ConduitUI\Mattermost\Client\Requests\Teams\SoftDeleteTeam;
+use ConduitUI\Mattermost\Client\Requests\Teams\TeamExists;
+use ConduitUI\Mattermost\Client\Requests\Teams\TeamMembersMinusGroupMembers;
+use ConduitUI\Mattermost\Client\Requests\Teams\UpdateTeam;
+use ConduitUI\Mattermost\Client\Requests\Teams\UpdateTeamMemberRoles;
+use ConduitUI\Mattermost\Client\Requests\Teams\UpdateTeamMemberSchemeRoles;
+use ConduitUI\Mattermost\Client\Requests\Teams\UpdateTeamPrivacy;
+use ConduitUI\Mattermost\Client\Requests\Teams\UpdateTeamScheme;
+use Saloon\Http\BaseResource;
+use Saloon\Http\Response;
+
+class Teams extends BaseResource
+{
+	/**
+	 * @param int $page The page to select.
+	 * @param bool $includeTotalCount Appends a total count of returned teams inside the response object - ex: `{ "teams": [], "total_count" : 0 }`.
+	 * @param bool $excludePolicyConstrained If set to true, teams which are part of a data retention policy will be excluded. The `sysconsole_read_compliance` permission is required to use this parameter.
+	 * __Minimum server version__: 5.35
+	 */
+	public function getAllTeams(
+		?int $page = null,
+		?bool $includeTotalCount = null,
+		?bool $excludePolicyConstrained = null,
+	): Response
+	{
+		return $this->connector->send(new GetAllTeams($page, $includeTotalCount, $excludePolicyConstrained));
+	}
+
+
+	public function createTeam(): Response
+	{
+		return $this->connector->send(new CreateTeam());
+	}
+
+
+	/**
+	 * @param string $inviteId Invite id for a team
+	 */
+	public function getTeamInviteInfo(string $inviteId): Response
+	{
+		return $this->connector->send(new GetTeamInviteInfo($inviteId));
+	}
+
+
+	public function invalidateEmailInvites(): Response
+	{
+		return $this->connector->send(new InvalidateEmailInvites());
+	}
+
+
+	/**
+	 * @param string $token Token id from the invitation
+	 */
+	public function addTeamMemberFromInvite(string $token): Response
+	{
+		return $this->connector->send(new AddTeamMemberFromInvite($token));
+	}
+
+
+	/**
+	 * @param string $name Team Name
+	 */
+	public function getTeamByName(string $name): Response
+	{
+		return $this->connector->send(new GetTeamByName($name));
+	}
+
+
+	/**
+	 * @param string $name Team Name
+	 */
+	public function teamExists(string $name): Response
+	{
+		return $this->connector->send(new TeamExists($name));
+	}
+
+
+	public function searchTeams(): Response
+	{
+		return $this->connector->send(new SearchTeams());
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 */
+	public function getTeam(string $teamId): Response
+	{
+		return $this->connector->send(new GetTeam($teamId));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 */
+	public function updateTeam(string $teamId): Response
+	{
+		return $this->connector->send(new UpdateTeam($teamId));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param bool $permanent Permanently delete the team, to be used for compliance reasons only. As of server version 5.0, `ServiceSettings.EnableAPITeamDeletion` must be set to `true` in the server's configuration.
+	 */
+	public function softDeleteTeam(string $teamId, ?bool $permanent = null): Response
+	{
+		return $this->connector->send(new SoftDeleteTeam($teamId, $permanent));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 */
+	public function searchFiles(string $teamId): Response
+	{
+		return $this->connector->send(new SearchFiles($teamId));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 */
+	public function getTeamIcon(string $teamId): Response
+	{
+		return $this->connector->send(new GetTeamIcon($teamId));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 */
+	public function setTeamIcon(string $teamId): Response
+	{
+		return $this->connector->send(new SetTeamIcon($teamId));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 */
+	public function removeTeamIcon(string $teamId): Response
+	{
+		return $this->connector->send(new RemoveTeamIcon($teamId));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 */
+	public function importTeam(string $teamId): Response
+	{
+		return $this->connector->send(new ImportTeam($teamId));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 */
+	public function inviteGuestsToTeam(string $teamId): Response
+	{
+		return $this->connector->send(new InviteGuestsToTeam($teamId));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 */
+	public function inviteUsersToTeam(string $teamId): Response
+	{
+		return $this->connector->send(new InviteUsersToTeam($teamId));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param int $page The page to select.
+	 */
+	public function getTeamMembers(string $teamId, ?int $page = null): Response
+	{
+		return $this->connector->send(new GetTeamMembers($teamId, $page));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 */
+	public function addTeamMember(string $teamId): Response
+	{
+		return $this->connector->send(new AddTeamMember($teamId));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param bool $graceful Instead of aborting the operation if a user cannot be added, return an arrray that will contain both the success and added members and the ones with error, in form of `[{"member": {...}, "user_id", "...", "error": {...}}]`
+	 */
+	public function addTeamMembers(string $teamId, ?bool $graceful = null): Response
+	{
+		return $this->connector->send(new AddTeamMembers($teamId, $graceful));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 */
+	public function getTeamMembersByIds(string $teamId): Response
+	{
+		return $this->connector->send(new GetTeamMembersByIds($teamId));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param string $userId User GUID
+	 */
+	public function getTeamMember(string $teamId, string $userId): Response
+	{
+		return $this->connector->send(new GetTeamMember($teamId, $userId));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param string $userId User GUID
+	 */
+	public function removeTeamMember(string $teamId, string $userId): Response
+	{
+		return $this->connector->send(new RemoveTeamMember($teamId, $userId));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param string $userId User GUID
+	 */
+	public function updateTeamMemberRoles(string $teamId, string $userId): Response
+	{
+		return $this->connector->send(new UpdateTeamMemberRoles($teamId, $userId));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param string $userId User GUID
+	 */
+	public function updateTeamMemberSchemeRoles(string $teamId, string $userId): Response
+	{
+		return $this->connector->send(new UpdateTeamMemberSchemeRoles($teamId, $userId));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 * @param string $groupIds A comma-separated list of group ids.
+	 * @param int $page The page to select.
+	 */
+	public function teamMembersMinusGroupMembers(string $teamId, string $groupIds, ?int $page = null): Response
+	{
+		return $this->connector->send(new TeamMembersMinusGroupMembers($teamId, $groupIds, $page));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 */
+	public function patchTeam(string $teamId): Response
+	{
+		return $this->connector->send(new PatchTeam($teamId));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 */
+	public function updateTeamPrivacy(string $teamId): Response
+	{
+		return $this->connector->send(new UpdateTeamPrivacy($teamId));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 */
+	public function regenerateTeamInviteId(string $teamId): Response
+	{
+		return $this->connector->send(new RegenerateTeamInviteId($teamId));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 */
+	public function restoreTeam(string $teamId): Response
+	{
+		return $this->connector->send(new RestoreTeam($teamId));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 */
+	public function updateTeamScheme(string $teamId): Response
+	{
+		return $this->connector->send(new UpdateTeamScheme($teamId));
+	}
+
+
+	/**
+	 * @param string $teamId Team GUID
+	 */
+	public function getTeamStats(string $teamId): Response
+	{
+		return $this->connector->send(new GetTeamStats($teamId));
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function getTeamsForUser(string $userId): Response
+	{
+		return $this->connector->send(new GetTeamsForUser($userId));
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function getTeamMembersForUser(string $userId): Response
+	{
+		return $this->connector->send(new GetTeamMembersForUser($userId));
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 * @param string $excludeTeam Optional team id to be excluded from the results
+	 * @param bool $includeCollapsedThreads Boolean to determine whether the collapsed threads should be included or not
+	 */
+	public function getTeamsUnreadForUser(
+		string $userId,
+		string $excludeTeam,
+		?bool $includeCollapsedThreads = null,
+	): Response
+	{
+		return $this->connector->send(new GetTeamsUnreadForUser($userId, $excludeTeam, $includeCollapsedThreads));
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 * @param string $teamId Team GUID
+	 */
+	public function getTeamUnread(string $userId, string $teamId): Response
+	{
+		return $this->connector->send(new GetTeamUnread($userId, $teamId));
+	}
+}

--- a/src/Client/Resource/Threads.php
+++ b/src/Client/Resource/Threads.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Resource;
+
+use ConduitUI\Mattermost\Client\Requests\Threads\GetThreadMentionCountsByChannel;
+use ConduitUI\Mattermost\Client\Requests\Threads\GetUserThread;
+use ConduitUI\Mattermost\Client\Requests\Threads\GetUserThreads;
+use ConduitUI\Mattermost\Client\Requests\Threads\SetThreadUnreadByPostId;
+use ConduitUI\Mattermost\Client\Requests\Threads\StartFollowingThread;
+use ConduitUI\Mattermost\Client\Requests\Threads\StopFollowingThread;
+use ConduitUI\Mattermost\Client\Requests\Threads\UpdateThreadReadForUser;
+use ConduitUI\Mattermost\Client\Requests\Threads\UpdateThreadsReadForUser;
+use Saloon\Http\BaseResource;
+use Saloon\Http\Response;
+
+class Threads extends BaseResource
+{
+	/**
+	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
+	 * @param string $teamId The ID of the team in which the thread is.
+	 * @param int $since Since filters the threads based on their LastUpdateAt timestamp.
+	 * @param bool $deleted Deleted will specify that even deleted threads should be returned (For mobile sync).
+	 * @param bool $extended Extended will enrich the response with participant details.
+	 * @param int $page Page specifies which part of the results to return, by PageSize.
+	 * @param int $pageSize PageSize specifies the size of the returned chunk of results.
+	 * @param bool $totalsOnly Setting this to true will only return the total counts.
+	 * @param bool $threadsOnly Setting this to true will only return threads.
+	 */
+	public function getUserThreads(
+		string $userId,
+		string $teamId,
+		?int $since = null,
+		?bool $deleted = null,
+		?bool $extended = null,
+		?int $page = null,
+		?int $pageSize = null,
+		?bool $totalsOnly = null,
+		?bool $threadsOnly = null,
+	): Response
+	{
+		return $this->connector->send(new GetUserThreads($userId, $teamId, $since, $deleted, $extended, $page, $pageSize, $totalsOnly, $threadsOnly));
+	}
+
+
+	/**
+	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
+	 * @param string $teamId The ID of the team in which the thread is.
+	 */
+	public function getThreadMentionCountsByChannel(string $userId, string $teamId): Response
+	{
+		return $this->connector->send(new GetThreadMentionCountsByChannel($userId, $teamId));
+	}
+
+
+	/**
+	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
+	 * @param string $teamId The ID of the team in which the thread is.
+	 */
+	public function updateThreadsReadForUser(string $userId, string $teamId): Response
+	{
+		return $this->connector->send(new UpdateThreadsReadForUser($userId, $teamId));
+	}
+
+
+	/**
+	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
+	 * @param string $teamId The ID of the team in which the thread is.
+	 * @param string $threadId The ID of the thread to follow
+	 */
+	public function getUserThread(string $userId, string $teamId, string $threadId): Response
+	{
+		return $this->connector->send(new GetUserThread($userId, $teamId, $threadId));
+	}
+
+
+	/**
+	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
+	 * @param string $teamId The ID of the team in which the thread is.
+	 * @param string $threadId The ID of the thread to follow
+	 */
+	public function startFollowingThread(string $userId, string $teamId, string $threadId): Response
+	{
+		return $this->connector->send(new StartFollowingThread($userId, $teamId, $threadId));
+	}
+
+
+	/**
+	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
+	 * @param string $teamId The ID of the team in which the thread is.
+	 * @param string $threadId The ID of the thread to update
+	 */
+	public function stopFollowingThread(string $userId, string $teamId, string $threadId): Response
+	{
+		return $this->connector->send(new StopFollowingThread($userId, $teamId, $threadId));
+	}
+
+
+	/**
+	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
+	 * @param string $teamId The ID of the team in which the thread is.
+	 * @param string $threadId The ID of the thread to update
+	 * @param string $timestamp The timestamp to which the thread's "last read" state will be reset.
+	 */
+	public function updateThreadReadForUser(
+		string $userId,
+		string $teamId,
+		string $threadId,
+		string $timestamp,
+	): Response
+	{
+		return $this->connector->send(new UpdateThreadReadForUser($userId, $teamId, $threadId, $timestamp));
+	}
+
+
+	/**
+	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
+	 * @param string $teamId The ID of the team in which the thread is.
+	 * @param string $threadId The ID of the thread to update
+	 * @param string $postId The ID of a post belonging to the thread to mark as unread.
+	 */
+	public function setThreadUnreadByPostId(string $userId, string $teamId, string $threadId, string $postId): Response
+	{
+		return $this->connector->send(new SetThreadUnreadByPostId($userId, $teamId, $threadId, $postId));
+	}
+}

--- a/src/Client/Resource/Users.php
+++ b/src/Client/Resource/Users.php
@@ -1,0 +1,594 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Resource;
+
+use ConduitUI\Mattermost\Client\Requests\Users\AttachDeviceId;
+use ConduitUI\Mattermost\Client\Requests\Users\AutocompleteUsers;
+use ConduitUI\Mattermost\Client\Requests\Users\CheckUserMfa;
+use ConduitUI\Mattermost\Client\Requests\Users\CreateUser;
+use ConduitUI\Mattermost\Client\Requests\Users\CreateUserAccessToken;
+use ConduitUI\Mattermost\Client\Requests\Users\DeleteUser;
+use ConduitUI\Mattermost\Client\Requests\Users\DemoteUserToGuest;
+use ConduitUI\Mattermost\Client\Requests\Users\DisableUserAccessToken;
+use ConduitUI\Mattermost\Client\Requests\Users\EnableUserAccessToken;
+use ConduitUI\Mattermost\Client\Requests\Users\GenerateMfaSecret;
+use ConduitUI\Mattermost\Client\Requests\Users\GetChannelMembersWithTeamDataForUser;
+use ConduitUI\Mattermost\Client\Requests\Users\GetKnownUsers;
+use ConduitUI\Mattermost\Client\Requests\Users\GetSessions;
+use ConduitUI\Mattermost\Client\Requests\Users\GetTotalUsersStats;
+use ConduitUI\Mattermost\Client\Requests\Users\GetTotalUsersStatsFiltered;
+use ConduitUI\Mattermost\Client\Requests\Users\GetUploadsForUser;
+use ConduitUI\Mattermost\Client\Requests\Users\GetUser;
+use ConduitUI\Mattermost\Client\Requests\Users\GetUserAccessToken;
+use ConduitUI\Mattermost\Client\Requests\Users\GetUserAccessTokens;
+use ConduitUI\Mattermost\Client\Requests\Users\GetUserAccessTokensForUser;
+use ConduitUI\Mattermost\Client\Requests\Users\GetUserAudits;
+use ConduitUI\Mattermost\Client\Requests\Users\GetUserByEmail;
+use ConduitUI\Mattermost\Client\Requests\Users\GetUserByUsername;
+use ConduitUI\Mattermost\Client\Requests\Users\GetUserTermsOfService;
+use ConduitUI\Mattermost\Client\Requests\Users\GetUsers;
+use ConduitUI\Mattermost\Client\Requests\Users\GetUsersByGroupChannelIds;
+use ConduitUI\Mattermost\Client\Requests\Users\GetUsersByIds;
+use ConduitUI\Mattermost\Client\Requests\Users\GetUsersByUsernames;
+use ConduitUI\Mattermost\Client\Requests\Users\Login;
+use ConduitUI\Mattermost\Client\Requests\Users\LoginByCwsToken;
+use ConduitUI\Mattermost\Client\Requests\Users\Logout;
+use ConduitUI\Mattermost\Client\Requests\Users\MigrateAuthToLdap;
+use ConduitUI\Mattermost\Client\Requests\Users\MigrateAuthToSaml;
+use ConduitUI\Mattermost\Client\Requests\Users\PatchUser;
+use ConduitUI\Mattermost\Client\Requests\Users\PermanentDeleteAllUsers;
+use ConduitUI\Mattermost\Client\Requests\Users\PromoteGuestToUser;
+use ConduitUI\Mattermost\Client\Requests\Users\PublishUserTyping;
+use ConduitUI\Mattermost\Client\Requests\Users\RegisterTermsOfServiceAction;
+use ConduitUI\Mattermost\Client\Requests\Users\ResetPassword;
+use ConduitUI\Mattermost\Client\Requests\Users\RevokeAllSessions;
+use ConduitUI\Mattermost\Client\Requests\Users\RevokeSession;
+use ConduitUI\Mattermost\Client\Requests\Users\RevokeSessionsFromAllUsers;
+use ConduitUI\Mattermost\Client\Requests\Users\RevokeUserAccessToken;
+use ConduitUI\Mattermost\Client\Requests\Users\SearchUserAccessTokens;
+use ConduitUI\Mattermost\Client\Requests\Users\SearchUsers;
+use ConduitUI\Mattermost\Client\Requests\Users\SendPasswordResetEmail;
+use ConduitUI\Mattermost\Client\Requests\Users\SendVerificationEmail;
+use ConduitUI\Mattermost\Client\Requests\Users\SwitchAccountType;
+use ConduitUI\Mattermost\Client\Requests\Users\UpdateUser;
+use ConduitUI\Mattermost\Client\Requests\Users\UpdateUserActive;
+use ConduitUI\Mattermost\Client\Requests\Users\UpdateUserAuth;
+use ConduitUI\Mattermost\Client\Requests\Users\UpdateUserMfa;
+use ConduitUI\Mattermost\Client\Requests\Users\UpdateUserPassword;
+use ConduitUI\Mattermost\Client\Requests\Users\UpdateUserRoles;
+use ConduitUI\Mattermost\Client\Requests\Users\VerifyUserEmail;
+use ConduitUI\Mattermost\Client\Requests\Users\VerifyUserEmailWithoutToken;
+use Saloon\Http\BaseResource;
+use Saloon\Http\Response;
+
+class Users extends BaseResource
+{
+	/**
+	 * @param int $page The page to select.
+	 * @param string $inTeam The ID of the team to get users for.
+	 * @param string $notInTeam The ID of the team to exclude users for. Must not be used with "in_team" query parameter.
+	 * @param string $inChannel The ID of the channel to get users for.
+	 * @param string $notInChannel The ID of the channel to exclude users for. Must be used with "in_channel" query parameter.
+	 * @param string $inGroup The ID of the group to get users for. Must have `manage_system` permission.
+	 * @param bool $groupConstrained When used with `not_in_channel` or `not_in_team`, returns only the users that are allowed to join the channel or team based on its group constrains.
+	 * @param bool $withoutTeam Whether or not to list users that are not on any team. This option takes precendence over `in_team`, `in_channel`, and `not_in_channel`.
+	 * @param bool $active Whether or not to list only users that are active. This option cannot be used along with the `inactive` option.
+	 * @param bool $inactive Whether or not to list only users that are deactivated. This option cannot be used along with the `active` option.
+	 * @param string $role Returns users that have this role.
+	 * @param string $sort Sort is only available in conjunction with certain options below. The paging parameter is also always available.
+	 *
+	 * ##### `in_team`
+	 * Can be "", "last_activity_at" or "create_at".
+	 * When left blank, sorting is done by username.
+	 * __Minimum server version__: 4.0
+	 * ##### `in_channel`
+	 * Can be "", "status".
+	 * When left blank, sorting is done by username. `status` will sort by User's current status (Online, Away, DND, Offline), then by Username.
+	 * __Minimum server version__: 4.7
+	 * ##### `in_group`
+	 * Can be "", "display_name".
+	 * When left blank, sorting is done by username. `display_name` will sort alphabetically by user's display name.
+	 * __Minimum server version__: 7.7
+	 * @param string $roles Comma separated string used to filter users based on any of the specified system roles
+	 *
+	 * Example: `?roles=system_admin,system_user` will return users that are either system admins or system users
+	 *
+	 * __Minimum server version__: 5.26
+	 * @param string $channelRoles Comma separated string used to filter users based on any of the specified channel roles, can only be used in conjunction with `in_channel`
+	 *
+	 * Example: `?in_channel=4eb6axxw7fg3je5iyasnfudc5y&channel_roles=channel_user` will return users that are only channel users and not admins or guests
+	 *
+	 * __Minimum server version__: 5.26
+	 * @param string $teamRoles Comma separated string used to filter users based on any of the specified team roles, can only be used in conjunction with `in_team`
+	 *
+	 * Example: `?in_team=4eb6axxw7fg3je5iyasnfudc5y&team_roles=team_user` will return users that are only team users and not admins or guests
+	 *
+	 * __Minimum server version__: 5.26
+	 */
+	public function getUsers(
+		?int $page = null,
+		?string $inTeam = null,
+		?string $notInTeam = null,
+		?string $inChannel = null,
+		?string $notInChannel = null,
+		?string $inGroup = null,
+		?bool $groupConstrained = null,
+		?bool $withoutTeam = null,
+		?bool $active = null,
+		?bool $inactive = null,
+		?string $role = null,
+		?string $sort = null,
+		?string $roles = null,
+		?string $channelRoles = null,
+		?string $teamRoles = null,
+	): Response
+	{
+		return $this->connector->send(new GetUsers($page, $inTeam, $notInTeam, $inChannel, $notInChannel, $inGroup, $groupConstrained, $withoutTeam, $active, $inactive, $role, $sort, $roles, $channelRoles, $teamRoles));
+	}
+
+
+	/**
+	 * @param string $t Token id from an email invitation
+	 * @param string $iid Token id from an invitation link
+	 */
+	public function createUser(?string $t = null, ?string $iid = null): Response
+	{
+		return $this->connector->send(new CreateUser($t, $iid));
+	}
+
+
+	public function permanentDeleteAllUsers(): Response
+	{
+		return $this->connector->send(new PermanentDeleteAllUsers());
+	}
+
+
+	/**
+	 * @param string $teamId Team ID
+	 * @param string $channelId Channel ID
+	 * @param string $name Username, nickname first name or last name
+	 * @param int $limit The maximum number of users to return in each subresult
+	 *
+	 * __Available as of server version 5.6. Defaults to `100` if not provided or on an earlier server version.__
+	 */
+	public function autocompleteUsers(
+		?string $teamId = null,
+		?string $channelId = null,
+		string $name,
+		?int $limit = null,
+	): Response
+	{
+		return $this->connector->send(new AutocompleteUsers($teamId, $channelId, $name, $limit));
+	}
+
+
+	public function verifyUserEmail(): Response
+	{
+		return $this->connector->send(new VerifyUserEmail());
+	}
+
+
+	public function sendVerificationEmail(): Response
+	{
+		return $this->connector->send(new SendVerificationEmail());
+	}
+
+
+	/**
+	 * @param string $email User Email
+	 */
+	public function getUserByEmail(string $email): Response
+	{
+		return $this->connector->send(new GetUserByEmail($email));
+	}
+
+
+	public function getUsersByGroupChannelIds(): Response
+	{
+		return $this->connector->send(new GetUsersByGroupChannelIds());
+	}
+
+
+	/**
+	 * @param int $since Only return users that have been modified since the given Unix timestamp (in milliseconds).
+	 *
+	 * __Minimum server version__: 5.14
+	 */
+	public function getUsersByIds(?int $since = null): Response
+	{
+		return $this->connector->send(new GetUsersByIds($since));
+	}
+
+
+	public function getKnownUsers(): Response
+	{
+		return $this->connector->send(new GetKnownUsers());
+	}
+
+
+	public function login(): Response
+	{
+		return $this->connector->send(new Login());
+	}
+
+
+	public function loginByCwsToken(): Response
+	{
+		return $this->connector->send(new LoginByCwsToken());
+	}
+
+
+	public function switchAccountType(): Response
+	{
+		return $this->connector->send(new SwitchAccountType());
+	}
+
+
+	public function logout(): Response
+	{
+		return $this->connector->send(new Logout());
+	}
+
+
+	public function checkUserMfa(): Response
+	{
+		return $this->connector->send(new CheckUserMfa());
+	}
+
+
+	public function migrateAuthToLdap(): Response
+	{
+		return $this->connector->send(new MigrateAuthToLdap());
+	}
+
+
+	public function migrateAuthToSaml(): Response
+	{
+		return $this->connector->send(new MigrateAuthToSaml());
+	}
+
+
+	public function resetPassword(): Response
+	{
+		return $this->connector->send(new ResetPassword());
+	}
+
+
+	public function sendPasswordResetEmail(): Response
+	{
+		return $this->connector->send(new SendPasswordResetEmail());
+	}
+
+
+	public function searchUsers(): Response
+	{
+		return $this->connector->send(new SearchUsers());
+	}
+
+
+	public function attachDeviceId(): Response
+	{
+		return $this->connector->send(new AttachDeviceId());
+	}
+
+
+	public function revokeSessionsFromAllUsers(): Response
+	{
+		return $this->connector->send(new RevokeSessionsFromAllUsers());
+	}
+
+
+	public function getTotalUsersStats(): Response
+	{
+		return $this->connector->send(new GetTotalUsersStats());
+	}
+
+
+	/**
+	 * @param string $inTeam The ID of the team to get user stats for.
+	 * @param string $inChannel The ID of the channel to get user stats for.
+	 * @param bool $includeDeleted If deleted accounts should be included in the count.
+	 * @param bool $includeBots If bot accounts should be included in the count.
+	 * @param string $roles Comma separated string used to filter users based on any of the specified system roles
+	 *
+	 * Example: `?roles=system_admin,system_user` will include users that are either system admins or system users
+	 * @param string $channelRoles Comma separated string used to filter users based on any of the specified channel roles, can only be used in conjunction with `in_channel`
+	 *
+	 * Example: `?in_channel=4eb6axxw7fg3je5iyasnfudc5y&channel_roles=channel_user` will include users that are only channel users and not admins or guests
+	 * @param string $teamRoles Comma separated string used to filter users based on any of the specified team roles, can only be used in conjunction with `in_team`
+	 *
+	 * Example: `?in_team=4eb6axxw7fg3je5iyasnfudc5y&team_roles=team_user` will include users that are only team users and not admins or guests
+	 */
+	public function getTotalUsersStatsFiltered(
+		?string $inTeam = null,
+		?string $inChannel = null,
+		?bool $includeDeleted = null,
+		?bool $includeBots = null,
+		?string $roles = null,
+		?string $channelRoles = null,
+		?string $teamRoles = null,
+	): Response
+	{
+		return $this->connector->send(new GetTotalUsersStatsFiltered($inTeam, $inChannel, $includeDeleted, $includeBots, $roles, $channelRoles, $teamRoles));
+	}
+
+
+	/**
+	 * @param int $page The page to select.
+	 */
+	public function getUserAccessTokens(?int $page = null): Response
+	{
+		return $this->connector->send(new GetUserAccessTokens($page));
+	}
+
+
+	public function disableUserAccessToken(): Response
+	{
+		return $this->connector->send(new DisableUserAccessToken());
+	}
+
+
+	public function enableUserAccessToken(): Response
+	{
+		return $this->connector->send(new EnableUserAccessToken());
+	}
+
+
+	public function revokeUserAccessToken(): Response
+	{
+		return $this->connector->send(new RevokeUserAccessToken());
+	}
+
+
+	public function searchUserAccessTokens(): Response
+	{
+		return $this->connector->send(new SearchUserAccessTokens());
+	}
+
+
+	/**
+	 * @param string $tokenId User access token GUID
+	 */
+	public function getUserAccessToken(string $tokenId): Response
+	{
+		return $this->connector->send(new GetUserAccessToken($tokenId));
+	}
+
+
+	/**
+	 * @param string $username Username
+	 */
+	public function getUserByUsername(string $username): Response
+	{
+		return $this->connector->send(new GetUserByUsername($username));
+	}
+
+
+	public function getUsersByUsernames(): Response
+	{
+		return $this->connector->send(new GetUsersByUsernames());
+	}
+
+
+	/**
+	 * @param string $userId User GUID. This can also be "me" which will point to the current user.
+	 */
+	public function getUser(string $userId): Response
+	{
+		return $this->connector->send(new GetUser($userId));
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function updateUser(string $userId): Response
+	{
+		return $this->connector->send(new UpdateUser($userId));
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function deleteUser(string $userId): Response
+	{
+		return $this->connector->send(new DeleteUser($userId));
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function updateUserActive(string $userId): Response
+	{
+		return $this->connector->send(new UpdateUserActive($userId));
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function getUserAudits(string $userId): Response
+	{
+		return $this->connector->send(new GetUserAudits($userId));
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function updateUserAuth(string $userId): Response
+	{
+		return $this->connector->send(new UpdateUserAuth($userId));
+	}
+
+
+	/**
+	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
+	 * @param int $page Page specifies which part of the results to return, by PageSize.
+	 * @param int $pageSize PageSize specifies the size of the returned chunk of results.
+	 */
+	public function getChannelMembersWithTeamDataForUser(
+		string $userId,
+		?int $page = null,
+		?int $pageSize = null,
+	): Response
+	{
+		return $this->connector->send(new GetChannelMembersWithTeamDataForUser($userId, $page, $pageSize));
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function demoteUserToGuest(string $userId): Response
+	{
+		return $this->connector->send(new DemoteUserToGuest($userId));
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function verifyUserEmailWithoutToken(string $userId): Response
+	{
+		return $this->connector->send(new VerifyUserEmailWithoutToken($userId));
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function updateUserMfa(string $userId): Response
+	{
+		return $this->connector->send(new UpdateUserMfa($userId));
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function generateMfaSecret(string $userId): Response
+	{
+		return $this->connector->send(new GenerateMfaSecret($userId));
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function updateUserPassword(string $userId): Response
+	{
+		return $this->connector->send(new UpdateUserPassword($userId));
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function patchUser(string $userId): Response
+	{
+		return $this->connector->send(new PatchUser($userId));
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function promoteGuestToUser(string $userId): Response
+	{
+		return $this->connector->send(new PromoteGuestToUser($userId));
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function updateUserRoles(string $userId): Response
+	{
+		return $this->connector->send(new UpdateUserRoles($userId));
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function getSessions(string $userId): Response
+	{
+		return $this->connector->send(new GetSessions($userId));
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function revokeSession(string $userId): Response
+	{
+		return $this->connector->send(new RevokeSession($userId));
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function revokeAllSessions(string $userId): Response
+	{
+		return $this->connector->send(new RevokeAllSessions($userId));
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function getUserTermsOfService(string $userId): Response
+	{
+		return $this->connector->send(new GetUserTermsOfService($userId));
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function registerTermsOfServiceAction(string $userId): Response
+	{
+		return $this->connector->send(new RegisterTermsOfServiceAction($userId));
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 * @param int $page The page to select.
+	 */
+	public function getUserAccessTokensForUser(string $userId, ?int $page = null): Response
+	{
+		return $this->connector->send(new GetUserAccessTokensForUser($userId, $page));
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function createUserAccessToken(string $userId): Response
+	{
+		return $this->connector->send(new CreateUserAccessToken($userId));
+	}
+
+
+	/**
+	 * @param string $userId User GUID
+	 */
+	public function publishUserTyping(string $userId): Response
+	{
+		return $this->connector->send(new PublishUserTyping($userId));
+	}
+
+
+	/**
+	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
+	 */
+	public function getUploadsForUser(string $userId): Response
+	{
+		return $this->connector->send(new GetUploadsForUser($userId));
+	}
+}

--- a/src/Client/Resource/Webhooks.php
+++ b/src/Client/Resource/Webhooks.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client\Resource;
+
+use ConduitUI\Mattermost\Client\Requests\Webhooks\CreateIncomingWebhook;
+use ConduitUI\Mattermost\Client\Requests\Webhooks\CreateOutgoingWebhook;
+use ConduitUI\Mattermost\Client\Requests\Webhooks\DeleteIncomingWebhook;
+use ConduitUI\Mattermost\Client\Requests\Webhooks\DeleteOutgoingWebhook;
+use ConduitUI\Mattermost\Client\Requests\Webhooks\GetIncomingWebhook;
+use ConduitUI\Mattermost\Client\Requests\Webhooks\GetIncomingWebhooks;
+use ConduitUI\Mattermost\Client\Requests\Webhooks\GetOutgoingWebhook;
+use ConduitUI\Mattermost\Client\Requests\Webhooks\GetOutgoingWebhooks;
+use ConduitUI\Mattermost\Client\Requests\Webhooks\RegenOutgoingHookToken;
+use ConduitUI\Mattermost\Client\Requests\Webhooks\UpdateIncomingWebhook;
+use ConduitUI\Mattermost\Client\Requests\Webhooks\UpdateOutgoingWebhook;
+use Saloon\Http\BaseResource;
+use Saloon\Http\Response;
+
+class Webhooks extends BaseResource
+{
+	/**
+	 * @param int $page The page to select.
+	 * @param string $teamId The ID of the team to get hooks for.
+	 */
+	public function getIncomingWebhooks(?int $page = null, ?string $teamId = null): Response
+	{
+		return $this->connector->send(new GetIncomingWebhooks($page, $teamId));
+	}
+
+
+	public function createIncomingWebhook(): Response
+	{
+		return $this->connector->send(new CreateIncomingWebhook());
+	}
+
+
+	/**
+	 * @param string $hookId Incoming Webhook GUID
+	 */
+	public function getIncomingWebhook(string $hookId): Response
+	{
+		return $this->connector->send(new GetIncomingWebhook($hookId));
+	}
+
+
+	/**
+	 * @param string $hookId Incoming Webhook GUID
+	 */
+	public function updateIncomingWebhook(string $hookId): Response
+	{
+		return $this->connector->send(new UpdateIncomingWebhook($hookId));
+	}
+
+
+	/**
+	 * @param string $hookId Incoming webhook GUID
+	 */
+	public function deleteIncomingWebhook(string $hookId): Response
+	{
+		return $this->connector->send(new DeleteIncomingWebhook($hookId));
+	}
+
+
+	/**
+	 * @param int $page The page to select.
+	 * @param string $teamId The ID of the team to get hooks for.
+	 * @param string $channelId The ID of the channel to get hooks for.
+	 */
+	public function getOutgoingWebhooks(?int $page = null, ?string $teamId = null, ?string $channelId = null): Response
+	{
+		return $this->connector->send(new GetOutgoingWebhooks($page, $teamId, $channelId));
+	}
+
+
+	public function createOutgoingWebhook(): Response
+	{
+		return $this->connector->send(new CreateOutgoingWebhook());
+	}
+
+
+	/**
+	 * @param string $hookId Outgoing webhook GUID
+	 */
+	public function getOutgoingWebhook(string $hookId): Response
+	{
+		return $this->connector->send(new GetOutgoingWebhook($hookId));
+	}
+
+
+	/**
+	 * @param string $hookId outgoing Webhook GUID
+	 */
+	public function updateOutgoingWebhook(string $hookId): Response
+	{
+		return $this->connector->send(new UpdateOutgoingWebhook($hookId));
+	}
+
+
+	/**
+	 * @param string $hookId Outgoing webhook GUID
+	 */
+	public function deleteOutgoingWebhook(string $hookId): Response
+	{
+		return $this->connector->send(new DeleteOutgoingWebhook($hookId));
+	}
+
+
+	/**
+	 * @param string $hookId Outgoing webhook GUID
+	 */
+	public function regenOutgoingHookToken(string $hookId): Response
+	{
+		return $this->connector->send(new RegenOutgoingHookToken($hookId));
+	}
+}

--- a/src/Client/composer.json
+++ b/src/Client/composer.json
@@ -1,0 +1,35 @@
+{
+    "name": "conduit-ui/mattermost",
+    "description": "Mattermost API Reference SDK",
+    "type": "library",
+    "require": {
+        "php": "^8.2",
+        "saloonphp/saloon": "^3.0|^4.0",
+        "spatie/laravel-data": "^3.0|^4.0"
+    },
+    "require-dev": {
+        "pestphp/pest": "^2.0|^3.0",
+        "orchestra/testbench": "^8.0|^9.0|^10.0",
+        "saloonphp/laravel-plugin": "^3.0|^4.0",
+        "spatie/laravel-data": "^3.0|^4.0",
+        "vlucas/phpdotenv": "^5.6"
+    },
+    "autoload": {
+        "psr-4": {
+            "ConduitUI\\Mattermost\\Client\\": "src/"
+        }
+    },
+    "scripts": {
+        "test": "vendor/bin/pest"
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "ConduitUI\\Mattermost\\Client\\Tests\\": "tests/"
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        }
+    }
+}

--- a/src/Client/tests/BotsTest.php
+++ b/src/Client/tests/BotsTest.php
@@ -1,0 +1,162 @@
+<?php
+
+// Generated 2026-04-10 23:46:41
+
+use ConduitUI\Mattermost\Client\Requests\Bots\GetBots;
+use ConduitUI\Mattermost\Client\Requests\Bots\CreateBot;
+use ConduitUI\Mattermost\Client\Requests\Bots\GetBot;
+use ConduitUI\Mattermost\Client\Requests\Bots\PatchBot;
+use ConduitUI\Mattermost\Client\Requests\Bots\AssignBot;
+use ConduitUI\Mattermost\Client\Requests\Bots\ConvertBotToUser;
+use ConduitUI\Mattermost\Client\Requests\Bots\DisableBot;
+use ConduitUI\Mattermost\Client\Requests\Bots\EnableBot;
+use ConduitUI\Mattermost\Client\Requests\Bots\ConvertUserToBot;
+use Saloon\Http\Faking\MockResponse;
+use Saloon\Laravel\Facades\Saloon;
+use Spatie\LaravelData\DataCollection;
+
+beforeEach(function () {
+    $this->mattermost = new ConduitUI\Mattermost\Client\Mattermost(
+		bearerToken: 'replace'
+	);
+});
+
+
+it('calls the getBots method in the Bots resource', function () {
+    Saloon::fake([
+        GetBots::class => MockResponse::fixture('bots.getBots'),
+    ]);
+
+    $response = $this->mattermost->bots()->getBots(
+		page: 123,
+		includeDeleted: true,
+		onlyOrphaned: true
+	);
+
+    Saloon::assertSent(GetBots::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the createBot method in the Bots resource', function () {
+    Saloon::fake([
+        CreateBot::class => MockResponse::fixture('bots.createBot'),
+    ]);
+
+    $response = $this->mattermost->bots()->createBot(
+		
+	);
+
+    Saloon::assertSent(CreateBot::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getBot method in the Bots resource', function () {
+    Saloon::fake([
+        GetBot::class => MockResponse::fixture('bots.getBot'),
+    ]);
+
+    $response = $this->mattermost->bots()->getBot(
+		botUserId: 'test string',
+		includeDeleted: true
+	);
+
+    Saloon::assertSent(GetBot::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the patchBot method in the Bots resource', function () {
+    Saloon::fake([
+        PatchBot::class => MockResponse::fixture('bots.patchBot'),
+    ]);
+
+    $response = $this->mattermost->bots()->patchBot(
+		botUserId: 'test string'
+	);
+
+    Saloon::assertSent(PatchBot::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the assignBot method in the Bots resource', function () {
+    Saloon::fake([
+        AssignBot::class => MockResponse::fixture('bots.assignBot'),
+    ]);
+
+    $response = $this->mattermost->bots()->assignBot(
+		botUserId: 'test string',
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(AssignBot::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the convertBotToUser method in the Bots resource', function () {
+    Saloon::fake([
+        ConvertBotToUser::class => MockResponse::fixture('bots.convertBotToUser'),
+    ]);
+
+    $response = $this->mattermost->bots()->convertBotToUser(
+		botUserId: 'test string',
+		setSystemAdmin: true
+	);
+
+    Saloon::assertSent(ConvertBotToUser::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the disableBot method in the Bots resource', function () {
+    Saloon::fake([
+        DisableBot::class => MockResponse::fixture('bots.disableBot'),
+    ]);
+
+    $response = $this->mattermost->bots()->disableBot(
+		botUserId: 'test string'
+	);
+
+    Saloon::assertSent(DisableBot::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the enableBot method in the Bots resource', function () {
+    Saloon::fake([
+        EnableBot::class => MockResponse::fixture('bots.enableBot'),
+    ]);
+
+    $response = $this->mattermost->bots()->enableBot(
+		botUserId: 'test string'
+	);
+
+    Saloon::assertSent(EnableBot::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the convertUserToBot method in the Bots resource', function () {
+    Saloon::fake([
+        ConvertUserToBot::class => MockResponse::fixture('bots.convertUserToBot'),
+    ]);
+
+    $response = $this->mattermost->bots()->convertUserToBot(
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(ConvertUserToBot::class);
+
+    expect($response->status())->toBe(200);
+});

--- a/src/Client/tests/ChannelsTest.php
+++ b/src/Client/tests/ChannelsTest.php
@@ -1,0 +1,886 @@
+<?php
+
+// Generated 2026-04-10 23:46:41
+
+use ConduitUI\Mattermost\Client\Requests\Channels\GetAllChannels;
+use ConduitUI\Mattermost\Client\Requests\Channels\CreateChannel;
+use ConduitUI\Mattermost\Client\Requests\Channels\CreateDirectChannel;
+use ConduitUI\Mattermost\Client\Requests\Channels\CreateGroupChannel;
+use ConduitUI\Mattermost\Client\Requests\Channels\SearchGroupChannels;
+use ConduitUI\Mattermost\Client\Requests\Channels\ViewChannel;
+use ConduitUI\Mattermost\Client\Requests\Channels\SearchAllChannels;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetChannel;
+use ConduitUI\Mattermost\Client\Requests\Channels\UpdateChannel;
+use ConduitUI\Mattermost\Client\Requests\Channels\DeleteChannel;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelMemberCountsByGroup;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelMembers;
+use ConduitUI\Mattermost\Client\Requests\Channels\AddChannelMember;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelMembersByIds;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelMember;
+use ConduitUI\Mattermost\Client\Requests\Channels\RemoveUserFromChannel;
+use ConduitUI\Mattermost\Client\Requests\Channels\UpdateChannelNotifyProps;
+use ConduitUI\Mattermost\Client\Requests\Channels\UpdateChannelRoles;
+use ConduitUI\Mattermost\Client\Requests\Channels\UpdateChannelMemberSchemeRoles;
+use ConduitUI\Mattermost\Client\Requests\Channels\ChannelMembersMinusGroupMembers;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelModerations;
+use ConduitUI\Mattermost\Client\Requests\Channels\PatchChannelModerations;
+use ConduitUI\Mattermost\Client\Requests\Channels\MoveChannel;
+use ConduitUI\Mattermost\Client\Requests\Channels\PatchChannel;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetPinnedPosts;
+use ConduitUI\Mattermost\Client\Requests\Channels\UpdateChannelPrivacy;
+use ConduitUI\Mattermost\Client\Requests\Channels\RestoreChannel;
+use ConduitUI\Mattermost\Client\Requests\Channels\UpdateChannelScheme;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelStats;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelMembersTimezones;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelByNameForTeamName;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetPublicChannelsForTeam;
+use ConduitUI\Mattermost\Client\Requests\Channels\AutocompleteChannelsForTeam;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetDeletedChannelsForTeam;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetPublicChannelsByIdsForTeam;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelByName;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetPrivateChannelsForTeam;
+use ConduitUI\Mattermost\Client\Requests\Channels\SearchChannels;
+use ConduitUI\Mattermost\Client\Requests\Channels\SearchArchivedChannels;
+use ConduitUI\Mattermost\Client\Requests\Channels\AutocompleteChannelsForTeamForSearch;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelsForUser;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelUnread;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelsForTeamForUser;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetSidebarCategoriesForTeamForUser;
+use ConduitUI\Mattermost\Client\Requests\Channels\UpdateSidebarCategoriesForTeamForUser;
+use ConduitUI\Mattermost\Client\Requests\Channels\CreateSidebarCategoryForTeamForUser;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetSidebarCategoryOrderForTeamForUser;
+use ConduitUI\Mattermost\Client\Requests\Channels\UpdateSidebarCategoryOrderForTeamForUser;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetSidebarCategoryForTeamForUser;
+use ConduitUI\Mattermost\Client\Requests\Channels\UpdateSidebarCategoryForTeamForUser;
+use ConduitUI\Mattermost\Client\Requests\Channels\RemoveSidebarCategoryForTeamForUser;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelMembersForUser;
+use Saloon\Http\Faking\MockResponse;
+use Saloon\Laravel\Facades\Saloon;
+use Spatie\LaravelData\DataCollection;
+
+beforeEach(function () {
+    $this->mattermost = new ConduitUI\Mattermost\Client\Mattermost(
+		bearerToken: 'replace'
+	);
+});
+
+
+it('calls the getAllChannels method in the Channels resource', function () {
+    Saloon::fake([
+        GetAllChannels::class => MockResponse::fixture('channels.getAllChannels'),
+    ]);
+
+    $response = $this->mattermost->channels()->getAllChannels(
+		notAssociatedToGroup: 'test string',
+		page: 123,
+		excludeDefaultChannels: true,
+		includeDeleted: true,
+		includeTotalCount: true,
+		excludePolicyConstrained: true
+	);
+
+    Saloon::assertSent(GetAllChannels::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the createChannel method in the Channels resource', function () {
+    Saloon::fake([
+        CreateChannel::class => MockResponse::fixture('channels.createChannel'),
+    ]);
+
+    $response = $this->mattermost->channels()->createChannel(
+		
+	);
+
+    Saloon::assertSent(CreateChannel::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the createDirectChannel method in the Channels resource', function () {
+    Saloon::fake([
+        CreateDirectChannel::class => MockResponse::fixture('channels.createDirectChannel'),
+    ]);
+
+    $response = $this->mattermost->channels()->createDirectChannel(
+		
+	);
+
+    Saloon::assertSent(CreateDirectChannel::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the createGroupChannel method in the Channels resource', function () {
+    Saloon::fake([
+        CreateGroupChannel::class => MockResponse::fixture('channels.createGroupChannel'),
+    ]);
+
+    $response = $this->mattermost->channels()->createGroupChannel(
+		
+	);
+
+    Saloon::assertSent(CreateGroupChannel::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the searchGroupChannels method in the Channels resource', function () {
+    Saloon::fake([
+        SearchGroupChannels::class => MockResponse::fixture('channels.searchGroupChannels'),
+    ]);
+
+    $response = $this->mattermost->channels()->searchGroupChannels(
+		
+	);
+
+    Saloon::assertSent(SearchGroupChannels::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the viewChannel method in the Channels resource', function () {
+    Saloon::fake([
+        ViewChannel::class => MockResponse::fixture('channels.viewChannel'),
+    ]);
+
+    $response = $this->mattermost->channels()->viewChannel(
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(ViewChannel::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the searchAllChannels method in the Channels resource', function () {
+    Saloon::fake([
+        SearchAllChannels::class => MockResponse::fixture('channels.searchAllChannels'),
+    ]);
+
+    $response = $this->mattermost->channels()->searchAllChannels(
+		systemConsole: true
+	);
+
+    Saloon::assertSent(SearchAllChannels::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getChannel method in the Channels resource', function () {
+    Saloon::fake([
+        GetChannel::class => MockResponse::fixture('channels.getChannel'),
+    ]);
+
+    $response = $this->mattermost->channels()->getChannel(
+		channelId: 'test string'
+	);
+
+    Saloon::assertSent(GetChannel::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the updateChannel method in the Channels resource', function () {
+    Saloon::fake([
+        UpdateChannel::class => MockResponse::fixture('channels.updateChannel'),
+    ]);
+
+    $response = $this->mattermost->channels()->updateChannel(
+		channelId: 'test string'
+	);
+
+    Saloon::assertSent(UpdateChannel::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the deleteChannel method in the Channels resource', function () {
+    Saloon::fake([
+        DeleteChannel::class => MockResponse::fixture('channels.deleteChannel'),
+    ]);
+
+    $response = $this->mattermost->channels()->deleteChannel(
+		channelId: 'test string'
+	);
+
+    Saloon::assertSent(DeleteChannel::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getChannelMemberCountsByGroup method in the Channels resource', function () {
+    Saloon::fake([
+        GetChannelMemberCountsByGroup::class => MockResponse::fixture('channels.getChannelMemberCountsByGroup'),
+    ]);
+
+    $response = $this->mattermost->channels()->getChannelMemberCountsByGroup(
+		channelId: 'test string',
+		includeTimezones: true
+	);
+
+    Saloon::assertSent(GetChannelMemberCountsByGroup::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getChannelMembers method in the Channels resource', function () {
+    Saloon::fake([
+        GetChannelMembers::class => MockResponse::fixture('channels.getChannelMembers'),
+    ]);
+
+    $response = $this->mattermost->channels()->getChannelMembers(
+		channelId: 'test string',
+		page: 123
+	);
+
+    Saloon::assertSent(GetChannelMembers::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the addChannelMember method in the Channels resource', function () {
+    Saloon::fake([
+        AddChannelMember::class => MockResponse::fixture('channels.addChannelMember'),
+    ]);
+
+    $response = $this->mattermost->channels()->addChannelMember(
+		channelId: 'test string'
+	);
+
+    Saloon::assertSent(AddChannelMember::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getChannelMembersByIds method in the Channels resource', function () {
+    Saloon::fake([
+        GetChannelMembersByIds::class => MockResponse::fixture('channels.getChannelMembersByIds'),
+    ]);
+
+    $response = $this->mattermost->channels()->getChannelMembersByIds(
+		channelId: 'test string'
+	);
+
+    Saloon::assertSent(GetChannelMembersByIds::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getChannelMember method in the Channels resource', function () {
+    Saloon::fake([
+        GetChannelMember::class => MockResponse::fixture('channels.getChannelMember'),
+    ]);
+
+    $response = $this->mattermost->channels()->getChannelMember(
+		channelId: 'test string',
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(GetChannelMember::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the removeUserFromChannel method in the Channels resource', function () {
+    Saloon::fake([
+        RemoveUserFromChannel::class => MockResponse::fixture('channels.removeUserFromChannel'),
+    ]);
+
+    $response = $this->mattermost->channels()->removeUserFromChannel(
+		channelId: 'test string',
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(RemoveUserFromChannel::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the updateChannelNotifyProps method in the Channels resource', function () {
+    Saloon::fake([
+        UpdateChannelNotifyProps::class => MockResponse::fixture('channels.updateChannelNotifyProps'),
+    ]);
+
+    $response = $this->mattermost->channels()->updateChannelNotifyProps(
+		channelId: 'test string',
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(UpdateChannelNotifyProps::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the updateChannelRoles method in the Channels resource', function () {
+    Saloon::fake([
+        UpdateChannelRoles::class => MockResponse::fixture('channels.updateChannelRoles'),
+    ]);
+
+    $response = $this->mattermost->channels()->updateChannelRoles(
+		channelId: 'test string',
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(UpdateChannelRoles::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the updateChannelMemberSchemeRoles method in the Channels resource', function () {
+    Saloon::fake([
+        UpdateChannelMemberSchemeRoles::class => MockResponse::fixture('channels.updateChannelMemberSchemeRoles'),
+    ]);
+
+    $response = $this->mattermost->channels()->updateChannelMemberSchemeRoles(
+		channelId: 'test string',
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(UpdateChannelMemberSchemeRoles::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the channelMembersMinusGroupMembers method in the Channels resource', function () {
+    Saloon::fake([
+        ChannelMembersMinusGroupMembers::class => MockResponse::fixture('channels.channelMembersMinusGroupMembers'),
+    ]);
+
+    $response = $this->mattermost->channels()->channelMembersMinusGroupMembers(
+		channelId: 'test string',
+		groupIds: 'test string',
+		page: 123
+	);
+
+    Saloon::assertSent(ChannelMembersMinusGroupMembers::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getChannelModerations method in the Channels resource', function () {
+    Saloon::fake([
+        GetChannelModerations::class => MockResponse::fixture('channels.getChannelModerations'),
+    ]);
+
+    $response = $this->mattermost->channels()->getChannelModerations(
+		channelId: 'test string'
+	);
+
+    Saloon::assertSent(GetChannelModerations::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the patchChannelModerations method in the Channels resource', function () {
+    Saloon::fake([
+        PatchChannelModerations::class => MockResponse::fixture('channels.patchChannelModerations'),
+    ]);
+
+    $response = $this->mattermost->channels()->patchChannelModerations(
+		channelId: 'test string'
+	);
+
+    Saloon::assertSent(PatchChannelModerations::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the moveChannel method in the Channels resource', function () {
+    Saloon::fake([
+        MoveChannel::class => MockResponse::fixture('channels.moveChannel'),
+    ]);
+
+    $response = $this->mattermost->channels()->moveChannel(
+		channelId: 'test string'
+	);
+
+    Saloon::assertSent(MoveChannel::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the patchChannel method in the Channels resource', function () {
+    Saloon::fake([
+        PatchChannel::class => MockResponse::fixture('channels.patchChannel'),
+    ]);
+
+    $response = $this->mattermost->channels()->patchChannel(
+		channelId: 'test string'
+	);
+
+    Saloon::assertSent(PatchChannel::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getPinnedPosts method in the Channels resource', function () {
+    Saloon::fake([
+        GetPinnedPosts::class => MockResponse::fixture('channels.getPinnedPosts'),
+    ]);
+
+    $response = $this->mattermost->channels()->getPinnedPosts(
+		channelId: 'test string'
+	);
+
+    Saloon::assertSent(GetPinnedPosts::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the updateChannelPrivacy method in the Channels resource', function () {
+    Saloon::fake([
+        UpdateChannelPrivacy::class => MockResponse::fixture('channels.updateChannelPrivacy'),
+    ]);
+
+    $response = $this->mattermost->channels()->updateChannelPrivacy(
+		channelId: 'test string'
+	);
+
+    Saloon::assertSent(UpdateChannelPrivacy::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the restoreChannel method in the Channels resource', function () {
+    Saloon::fake([
+        RestoreChannel::class => MockResponse::fixture('channels.restoreChannel'),
+    ]);
+
+    $response = $this->mattermost->channels()->restoreChannel(
+		channelId: 'test string'
+	);
+
+    Saloon::assertSent(RestoreChannel::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the updateChannelScheme method in the Channels resource', function () {
+    Saloon::fake([
+        UpdateChannelScheme::class => MockResponse::fixture('channels.updateChannelScheme'),
+    ]);
+
+    $response = $this->mattermost->channels()->updateChannelScheme(
+		channelId: 'test string'
+	);
+
+    Saloon::assertSent(UpdateChannelScheme::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getChannelStats method in the Channels resource', function () {
+    Saloon::fake([
+        GetChannelStats::class => MockResponse::fixture('channels.getChannelStats'),
+    ]);
+
+    $response = $this->mattermost->channels()->getChannelStats(
+		channelId: 'test string'
+	);
+
+    Saloon::assertSent(GetChannelStats::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getChannelMembersTimezones method in the Channels resource', function () {
+    Saloon::fake([
+        GetChannelMembersTimezones::class => MockResponse::fixture('channels.getChannelMembersTimezones'),
+    ]);
+
+    $response = $this->mattermost->channels()->getChannelMembersTimezones(
+		channelId: 'test string'
+	);
+
+    Saloon::assertSent(GetChannelMembersTimezones::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getChannelByNameForTeamName method in the Channels resource', function () {
+    Saloon::fake([
+        GetChannelByNameForTeamName::class => MockResponse::fixture('channels.getChannelByNameForTeamName'),
+    ]);
+
+    $response = $this->mattermost->channels()->getChannelByNameForTeamName(
+		teamName: 'test string',
+		channelName: 'test string',
+		includeDeleted: true
+	);
+
+    Saloon::assertSent(GetChannelByNameForTeamName::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getPublicChannelsForTeam method in the Channels resource', function () {
+    Saloon::fake([
+        GetPublicChannelsForTeam::class => MockResponse::fixture('channels.getPublicChannelsForTeam'),
+    ]);
+
+    $response = $this->mattermost->channels()->getPublicChannelsForTeam(
+		teamId: 'test string',
+		page: 123
+	);
+
+    Saloon::assertSent(GetPublicChannelsForTeam::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the autocompleteChannelsForTeam method in the Channels resource', function () {
+    Saloon::fake([
+        AutocompleteChannelsForTeam::class => MockResponse::fixture('channels.autocompleteChannelsForTeam'),
+    ]);
+
+    $response = $this->mattermost->channels()->autocompleteChannelsForTeam(
+		teamId: 'test string',
+		name: 'test string'
+	);
+
+    Saloon::assertSent(AutocompleteChannelsForTeam::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getDeletedChannelsForTeam method in the Channels resource', function () {
+    Saloon::fake([
+        GetDeletedChannelsForTeam::class => MockResponse::fixture('channels.getDeletedChannelsForTeam'),
+    ]);
+
+    $response = $this->mattermost->channels()->getDeletedChannelsForTeam(
+		teamId: 'test string',
+		page: 123
+	);
+
+    Saloon::assertSent(GetDeletedChannelsForTeam::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getPublicChannelsByIdsForTeam method in the Channels resource', function () {
+    Saloon::fake([
+        GetPublicChannelsByIdsForTeam::class => MockResponse::fixture('channels.getPublicChannelsByIdsForTeam'),
+    ]);
+
+    $response = $this->mattermost->channels()->getPublicChannelsByIdsForTeam(
+		teamId: 'test string'
+	);
+
+    Saloon::assertSent(GetPublicChannelsByIdsForTeam::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getChannelByName method in the Channels resource', function () {
+    Saloon::fake([
+        GetChannelByName::class => MockResponse::fixture('channels.getChannelByName'),
+    ]);
+
+    $response = $this->mattermost->channels()->getChannelByName(
+		teamId: 'test string',
+		channelName: 'test string',
+		includeDeleted: true
+	);
+
+    Saloon::assertSent(GetChannelByName::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getPrivateChannelsForTeam method in the Channels resource', function () {
+    Saloon::fake([
+        GetPrivateChannelsForTeam::class => MockResponse::fixture('channels.getPrivateChannelsForTeam'),
+    ]);
+
+    $response = $this->mattermost->channels()->getPrivateChannelsForTeam(
+		teamId: 'test string',
+		page: 123
+	);
+
+    Saloon::assertSent(GetPrivateChannelsForTeam::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the searchChannels method in the Channels resource', function () {
+    Saloon::fake([
+        SearchChannels::class => MockResponse::fixture('channels.searchChannels'),
+    ]);
+
+    $response = $this->mattermost->channels()->searchChannels(
+		teamId: 'test string'
+	);
+
+    Saloon::assertSent(SearchChannels::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the searchArchivedChannels method in the Channels resource', function () {
+    Saloon::fake([
+        SearchArchivedChannels::class => MockResponse::fixture('channels.searchArchivedChannels'),
+    ]);
+
+    $response = $this->mattermost->channels()->searchArchivedChannels(
+		teamId: 'test string'
+	);
+
+    Saloon::assertSent(SearchArchivedChannels::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the autocompleteChannelsForTeamForSearch method in the Channels resource', function () {
+    Saloon::fake([
+        AutocompleteChannelsForTeamForSearch::class => MockResponse::fixture('channels.autocompleteChannelsForTeamForSearch'),
+    ]);
+
+    $response = $this->mattermost->channels()->autocompleteChannelsForTeamForSearch(
+		teamId: 'test string',
+		name: 'test string'
+	);
+
+    Saloon::assertSent(AutocompleteChannelsForTeamForSearch::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getChannelsForUser method in the Channels resource', function () {
+    Saloon::fake([
+        GetChannelsForUser::class => MockResponse::fixture('channels.getChannelsForUser'),
+    ]);
+
+    $response = $this->mattermost->channels()->getChannelsForUser(
+		userId: 'test string',
+		lastDeleteAt: 123,
+		includeDeleted: true
+	);
+
+    Saloon::assertSent(GetChannelsForUser::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getChannelUnread method in the Channels resource', function () {
+    Saloon::fake([
+        GetChannelUnread::class => MockResponse::fixture('channels.getChannelUnread'),
+    ]);
+
+    $response = $this->mattermost->channels()->getChannelUnread(
+		userId: 'test string',
+		channelId: 'test string'
+	);
+
+    Saloon::assertSent(GetChannelUnread::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getChannelsForTeamForUser method in the Channels resource', function () {
+    Saloon::fake([
+        GetChannelsForTeamForUser::class => MockResponse::fixture('channels.getChannelsForTeamForUser'),
+    ]);
+
+    $response = $this->mattermost->channels()->getChannelsForTeamForUser(
+		userId: 'test string',
+		teamId: 'test string',
+		includeDeleted: true,
+		lastDeleteAt: 123
+	);
+
+    Saloon::assertSent(GetChannelsForTeamForUser::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getSidebarCategoriesForTeamForUser method in the Channels resource', function () {
+    Saloon::fake([
+        GetSidebarCategoriesForTeamForUser::class => MockResponse::fixture('channels.getSidebarCategoriesForTeamForUser'),
+    ]);
+
+    $response = $this->mattermost->channels()->getSidebarCategoriesForTeamForUser(
+		teamId: 'test string',
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(GetSidebarCategoriesForTeamForUser::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the updateSidebarCategoriesForTeamForUser method in the Channels resource', function () {
+    Saloon::fake([
+        UpdateSidebarCategoriesForTeamForUser::class => MockResponse::fixture('channels.updateSidebarCategoriesForTeamForUser'),
+    ]);
+
+    $response = $this->mattermost->channels()->updateSidebarCategoriesForTeamForUser(
+		teamId: 'test string',
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(UpdateSidebarCategoriesForTeamForUser::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the createSidebarCategoryForTeamForUser method in the Channels resource', function () {
+    Saloon::fake([
+        CreateSidebarCategoryForTeamForUser::class => MockResponse::fixture('channels.createSidebarCategoryForTeamForUser'),
+    ]);
+
+    $response = $this->mattermost->channels()->createSidebarCategoryForTeamForUser(
+		teamId: 'test string',
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(CreateSidebarCategoryForTeamForUser::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getSidebarCategoryOrderForTeamForUser method in the Channels resource', function () {
+    Saloon::fake([
+        GetSidebarCategoryOrderForTeamForUser::class => MockResponse::fixture('channels.getSidebarCategoryOrderForTeamForUser'),
+    ]);
+
+    $response = $this->mattermost->channels()->getSidebarCategoryOrderForTeamForUser(
+		teamId: 'test string',
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(GetSidebarCategoryOrderForTeamForUser::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the updateSidebarCategoryOrderForTeamForUser method in the Channels resource', function () {
+    Saloon::fake([
+        UpdateSidebarCategoryOrderForTeamForUser::class => MockResponse::fixture('channels.updateSidebarCategoryOrderForTeamForUser'),
+    ]);
+
+    $response = $this->mattermost->channels()->updateSidebarCategoryOrderForTeamForUser(
+		teamId: 'test string',
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(UpdateSidebarCategoryOrderForTeamForUser::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getSidebarCategoryForTeamForUser method in the Channels resource', function () {
+    Saloon::fake([
+        GetSidebarCategoryForTeamForUser::class => MockResponse::fixture('channels.getSidebarCategoryForTeamForUser'),
+    ]);
+
+    $response = $this->mattermost->channels()->getSidebarCategoryForTeamForUser(
+		teamId: 'test string',
+		userId: 'test string',
+		categoryId: 'test string'
+	);
+
+    Saloon::assertSent(GetSidebarCategoryForTeamForUser::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the updateSidebarCategoryForTeamForUser method in the Channels resource', function () {
+    Saloon::fake([
+        UpdateSidebarCategoryForTeamForUser::class => MockResponse::fixture('channels.updateSidebarCategoryForTeamForUser'),
+    ]);
+
+    $response = $this->mattermost->channels()->updateSidebarCategoryForTeamForUser(
+		teamId: 'test string',
+		userId: 'test string',
+		categoryId: 'test string'
+	);
+
+    Saloon::assertSent(UpdateSidebarCategoryForTeamForUser::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the removeSidebarCategoryForTeamForUser method in the Channels resource', function () {
+    Saloon::fake([
+        RemoveSidebarCategoryForTeamForUser::class => MockResponse::fixture('channels.removeSidebarCategoryForTeamForUser'),
+    ]);
+
+    $response = $this->mattermost->channels()->removeSidebarCategoryForTeamForUser(
+		teamId: 'test string',
+		userId: 'test string',
+		categoryId: 'test string'
+	);
+
+    Saloon::assertSent(RemoveSidebarCategoryForTeamForUser::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getChannelMembersForUser method in the Channels resource', function () {
+    Saloon::fake([
+        GetChannelMembersForUser::class => MockResponse::fixture('channels.getChannelMembersForUser'),
+    ]);
+
+    $response = $this->mattermost->channels()->getChannelMembersForUser(
+		userId: 'test string',
+		teamId: 'test string'
+	);
+
+    Saloon::assertSent(GetChannelMembersForUser::class);
+
+    expect($response->status())->toBe(200);
+});

--- a/src/Client/tests/CommandsTest.php
+++ b/src/Client/tests/CommandsTest.php
@@ -1,0 +1,158 @@
+<?php
+
+// Generated 2026-04-10 23:46:41
+
+use ConduitUI\Mattermost\Client\Requests\Commands\ListCommands;
+use ConduitUI\Mattermost\Client\Requests\Commands\CreateCommand;
+use ConduitUI\Mattermost\Client\Requests\Commands\ExecuteCommand;
+use ConduitUI\Mattermost\Client\Requests\Commands\GetCommandById;
+use ConduitUI\Mattermost\Client\Requests\Commands\UpdateCommand;
+use ConduitUI\Mattermost\Client\Requests\Commands\DeleteCommand;
+use ConduitUI\Mattermost\Client\Requests\Commands\MoveCommand;
+use ConduitUI\Mattermost\Client\Requests\Commands\RegenCommandToken;
+use ConduitUI\Mattermost\Client\Requests\Commands\ListAutocompleteCommands;
+use Saloon\Http\Faking\MockResponse;
+use Saloon\Laravel\Facades\Saloon;
+use Spatie\LaravelData\DataCollection;
+
+beforeEach(function () {
+    $this->mattermost = new ConduitUI\Mattermost\Client\Mattermost(
+		bearerToken: 'replace'
+	);
+});
+
+
+it('calls the listCommands method in the Commands resource', function () {
+    Saloon::fake([
+        ListCommands::class => MockResponse::fixture('commands.listCommands'),
+    ]);
+
+    $response = $this->mattermost->commands()->listCommands(
+		teamId: 'test string',
+		customOnly: true
+	);
+
+    Saloon::assertSent(ListCommands::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the createCommand method in the Commands resource', function () {
+    Saloon::fake([
+        CreateCommand::class => MockResponse::fixture('commands.createCommand'),
+    ]);
+
+    $response = $this->mattermost->commands()->createCommand(
+		
+	);
+
+    Saloon::assertSent(CreateCommand::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the executeCommand method in the Commands resource', function () {
+    Saloon::fake([
+        ExecuteCommand::class => MockResponse::fixture('commands.executeCommand'),
+    ]);
+
+    $response = $this->mattermost->commands()->executeCommand(
+		
+	);
+
+    Saloon::assertSent(ExecuteCommand::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getCommandById method in the Commands resource', function () {
+    Saloon::fake([
+        GetCommandById::class => MockResponse::fixture('commands.getCommandById'),
+    ]);
+
+    $response = $this->mattermost->commands()->getCommandById(
+		commandId: 'test string'
+	);
+
+    Saloon::assertSent(GetCommandById::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the updateCommand method in the Commands resource', function () {
+    Saloon::fake([
+        UpdateCommand::class => MockResponse::fixture('commands.updateCommand'),
+    ]);
+
+    $response = $this->mattermost->commands()->updateCommand(
+		commandId: 'test string'
+	);
+
+    Saloon::assertSent(UpdateCommand::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the deleteCommand method in the Commands resource', function () {
+    Saloon::fake([
+        DeleteCommand::class => MockResponse::fixture('commands.deleteCommand'),
+    ]);
+
+    $response = $this->mattermost->commands()->deleteCommand(
+		commandId: 'test string'
+	);
+
+    Saloon::assertSent(DeleteCommand::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the moveCommand method in the Commands resource', function () {
+    Saloon::fake([
+        MoveCommand::class => MockResponse::fixture('commands.moveCommand'),
+    ]);
+
+    $response = $this->mattermost->commands()->moveCommand(
+		commandId: 'test string'
+	);
+
+    Saloon::assertSent(MoveCommand::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the regenCommandToken method in the Commands resource', function () {
+    Saloon::fake([
+        RegenCommandToken::class => MockResponse::fixture('commands.regenCommandToken'),
+    ]);
+
+    $response = $this->mattermost->commands()->regenCommandToken(
+		commandId: 'test string'
+	);
+
+    Saloon::assertSent(RegenCommandToken::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the listAutocompleteCommands method in the Commands resource', function () {
+    Saloon::fake([
+        ListAutocompleteCommands::class => MockResponse::fixture('commands.listAutocompleteCommands'),
+    ]);
+
+    $response = $this->mattermost->commands()->listAutocompleteCommands(
+		teamId: 'test string'
+	);
+
+    Saloon::assertSent(ListAutocompleteCommands::class);
+
+    expect($response->status())->toBe(200);
+});

--- a/src/Client/tests/DataRetentionTest.php
+++ b/src/Client/tests/DataRetentionTest.php
@@ -1,0 +1,47 @@
+<?php
+
+// Generated 2026-04-10 23:46:41
+
+use ConduitUI\Mattermost\Client\Requests\DataRetention\GetChannelPoliciesForUser;
+use ConduitUI\Mattermost\Client\Requests\DataRetention\GetTeamPoliciesForUser;
+use Saloon\Http\Faking\MockResponse;
+use Saloon\Laravel\Facades\Saloon;
+use Spatie\LaravelData\DataCollection;
+
+beforeEach(function () {
+    $this->mattermost = new ConduitUI\Mattermost\Client\Mattermost(
+		bearerToken: 'replace'
+	);
+});
+
+
+it('calls the getChannelPoliciesForUser method in the DataRetention resource', function () {
+    Saloon::fake([
+        GetChannelPoliciesForUser::class => MockResponse::fixture('dataRetention.getChannelPoliciesForUser'),
+    ]);
+
+    $response = $this->mattermost->dataRetention()->getChannelPoliciesForUser(
+		userId: 'test string',
+		page: 123
+	);
+
+    Saloon::assertSent(GetChannelPoliciesForUser::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getTeamPoliciesForUser method in the DataRetention resource', function () {
+    Saloon::fake([
+        GetTeamPoliciesForUser::class => MockResponse::fixture('dataRetention.getTeamPoliciesForUser'),
+    ]);
+
+    $response = $this->mattermost->dataRetention()->getTeamPoliciesForUser(
+		userId: 'test string',
+		page: 123
+	);
+
+    Saloon::assertSent(GetTeamPoliciesForUser::class);
+
+    expect($response->status())->toBe(200);
+});

--- a/src/Client/tests/EmojiTest.php
+++ b/src/Client/tests/EmojiTest.php
@@ -1,0 +1,142 @@
+<?php
+
+// Generated 2026-04-10 23:46:41
+
+use ConduitUI\Mattermost\Client\Requests\Emoji\GetEmojiList;
+use ConduitUI\Mattermost\Client\Requests\Emoji\CreateEmoji;
+use ConduitUI\Mattermost\Client\Requests\Emoji\AutocompleteEmoji;
+use ConduitUI\Mattermost\Client\Requests\Emoji\GetEmojiByName;
+use ConduitUI\Mattermost\Client\Requests\Emoji\SearchEmoji;
+use ConduitUI\Mattermost\Client\Requests\Emoji\GetEmoji;
+use ConduitUI\Mattermost\Client\Requests\Emoji\DeleteEmoji;
+use ConduitUI\Mattermost\Client\Requests\Emoji\GetEmojiImage;
+use Saloon\Http\Faking\MockResponse;
+use Saloon\Laravel\Facades\Saloon;
+use Spatie\LaravelData\DataCollection;
+
+beforeEach(function () {
+    $this->mattermost = new ConduitUI\Mattermost\Client\Mattermost(
+		bearerToken: 'replace'
+	);
+});
+
+
+it('calls the getEmojiList method in the Emoji resource', function () {
+    Saloon::fake([
+        GetEmojiList::class => MockResponse::fixture('emoji.getEmojiList'),
+    ]);
+
+    $response = $this->mattermost->emoji()->getEmojiList(
+		page: 123,
+		sort: 'test string'
+	);
+
+    Saloon::assertSent(GetEmojiList::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the createEmoji method in the Emoji resource', function () {
+    Saloon::fake([
+        CreateEmoji::class => MockResponse::fixture('emoji.createEmoji'),
+    ]);
+
+    $response = $this->mattermost->emoji()->createEmoji(
+		
+	);
+
+    Saloon::assertSent(CreateEmoji::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the autocompleteEmoji method in the Emoji resource', function () {
+    Saloon::fake([
+        AutocompleteEmoji::class => MockResponse::fixture('emoji.autocompleteEmoji'),
+    ]);
+
+    $response = $this->mattermost->emoji()->autocompleteEmoji(
+		name: 'test string'
+	);
+
+    Saloon::assertSent(AutocompleteEmoji::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getEmojiByName method in the Emoji resource', function () {
+    Saloon::fake([
+        GetEmojiByName::class => MockResponse::fixture('emoji.getEmojiByName'),
+    ]);
+
+    $response = $this->mattermost->emoji()->getEmojiByName(
+		emojiName: 'test string'
+	);
+
+    Saloon::assertSent(GetEmojiByName::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the searchEmoji method in the Emoji resource', function () {
+    Saloon::fake([
+        SearchEmoji::class => MockResponse::fixture('emoji.searchEmoji'),
+    ]);
+
+    $response = $this->mattermost->emoji()->searchEmoji(
+		
+	);
+
+    Saloon::assertSent(SearchEmoji::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getEmoji method in the Emoji resource', function () {
+    Saloon::fake([
+        GetEmoji::class => MockResponse::fixture('emoji.getEmoji'),
+    ]);
+
+    $response = $this->mattermost->emoji()->getEmoji(
+		emojiId: 'test string'
+	);
+
+    Saloon::assertSent(GetEmoji::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the deleteEmoji method in the Emoji resource', function () {
+    Saloon::fake([
+        DeleteEmoji::class => MockResponse::fixture('emoji.deleteEmoji'),
+    ]);
+
+    $response = $this->mattermost->emoji()->deleteEmoji(
+		emojiId: 'test string'
+	);
+
+    Saloon::assertSent(DeleteEmoji::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getEmojiImage method in the Emoji resource', function () {
+    Saloon::fake([
+        GetEmojiImage::class => MockResponse::fixture('emoji.getEmojiImage'),
+    ]);
+
+    $response = $this->mattermost->emoji()->getEmojiImage(
+		emojiId: 'test string'
+	);
+
+    Saloon::assertSent(GetEmojiImage::class);
+
+    expect($response->status())->toBe(200);
+});

--- a/src/Client/tests/FilesTest.php
+++ b/src/Client/tests/FilesTest.php
@@ -1,0 +1,127 @@
+<?php
+
+// Generated 2026-04-10 23:46:41
+
+use ConduitUI\Mattermost\Client\Requests\Files\UploadFile;
+use ConduitUI\Mattermost\Client\Requests\Files\GetFile;
+use ConduitUI\Mattermost\Client\Requests\Files\GetFileInfo;
+use ConduitUI\Mattermost\Client\Requests\Files\GetFileLink;
+use ConduitUI\Mattermost\Client\Requests\Files\GetFilePreview;
+use ConduitUI\Mattermost\Client\Requests\Files\GetFilePublic;
+use ConduitUI\Mattermost\Client\Requests\Files\GetFileThumbnail;
+use Saloon\Http\Faking\MockResponse;
+use Saloon\Laravel\Facades\Saloon;
+use Spatie\LaravelData\DataCollection;
+
+beforeEach(function () {
+    $this->mattermost = new ConduitUI\Mattermost\Client\Mattermost(
+		bearerToken: 'replace'
+	);
+});
+
+
+it('calls the uploadFile method in the Files resource', function () {
+    Saloon::fake([
+        UploadFile::class => MockResponse::fixture('files.uploadFile'),
+    ]);
+
+    $response = $this->mattermost->files()->uploadFile(
+		channelId: 'test string',
+		filename: 'test string'
+	);
+
+    Saloon::assertSent(UploadFile::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getFile method in the Files resource', function () {
+    Saloon::fake([
+        GetFile::class => MockResponse::fixture('files.getFile'),
+    ]);
+
+    $response = $this->mattermost->files()->getFile(
+		fileId: 'test string'
+	);
+
+    Saloon::assertSent(GetFile::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getFileInfo method in the Files resource', function () {
+    Saloon::fake([
+        GetFileInfo::class => MockResponse::fixture('files.getFileInfo'),
+    ]);
+
+    $response = $this->mattermost->files()->getFileInfo(
+		fileId: 'test string'
+	);
+
+    Saloon::assertSent(GetFileInfo::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getFileLink method in the Files resource', function () {
+    Saloon::fake([
+        GetFileLink::class => MockResponse::fixture('files.getFileLink'),
+    ]);
+
+    $response = $this->mattermost->files()->getFileLink(
+		fileId: 'test string'
+	);
+
+    Saloon::assertSent(GetFileLink::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getFilePreview method in the Files resource', function () {
+    Saloon::fake([
+        GetFilePreview::class => MockResponse::fixture('files.getFilePreview'),
+    ]);
+
+    $response = $this->mattermost->files()->getFilePreview(
+		fileId: 'test string'
+	);
+
+    Saloon::assertSent(GetFilePreview::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getFilePublic method in the Files resource', function () {
+    Saloon::fake([
+        GetFilePublic::class => MockResponse::fixture('files.getFilePublic'),
+    ]);
+
+    $response = $this->mattermost->files()->getFilePublic(
+		fileId: 'test string',
+		h: 'test string'
+	);
+
+    Saloon::assertSent(GetFilePublic::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getFileThumbnail method in the Files resource', function () {
+    Saloon::fake([
+        GetFileThumbnail::class => MockResponse::fixture('files.getFileThumbnail'),
+    ]);
+
+    $response = $this->mattermost->files()->getFileThumbnail(
+		fileId: 'test string'
+	);
+
+    Saloon::assertSent(GetFileThumbnail::class);
+
+    expect($response->status())->toBe(200);
+});

--- a/src/Client/tests/GroupsTest.php
+++ b/src/Client/tests/GroupsTest.php
@@ -1,0 +1,84 @@
+<?php
+
+// Generated 2026-04-10 23:46:41
+
+use ConduitUI\Mattermost\Client\Requests\Groups\GetGroupsByChannel;
+use ConduitUI\Mattermost\Client\Requests\Groups\GetGroupsByTeam;
+use ConduitUI\Mattermost\Client\Requests\Groups\GetGroupsAssociatedToChannelsByTeam;
+use ConduitUI\Mattermost\Client\Requests\Groups\GetGroupsByUserId;
+use Saloon\Http\Faking\MockResponse;
+use Saloon\Laravel\Facades\Saloon;
+use Spatie\LaravelData\DataCollection;
+
+beforeEach(function () {
+    $this->mattermost = new ConduitUI\Mattermost\Client\Mattermost(
+		bearerToken: 'replace'
+	);
+});
+
+
+it('calls the getGroupsByChannel method in the Groups resource', function () {
+    Saloon::fake([
+        GetGroupsByChannel::class => MockResponse::fixture('groups.getGroupsByChannel'),
+    ]);
+
+    $response = $this->mattermost->groups()->getGroupsByChannel(
+		channelId: 'test string',
+		page: 123,
+		filterAllowReference: true
+	);
+
+    Saloon::assertSent(GetGroupsByChannel::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getGroupsByTeam method in the Groups resource', function () {
+    Saloon::fake([
+        GetGroupsByTeam::class => MockResponse::fixture('groups.getGroupsByTeam'),
+    ]);
+
+    $response = $this->mattermost->groups()->getGroupsByTeam(
+		teamId: 'test string',
+		page: 123,
+		filterAllowReference: true
+	);
+
+    Saloon::assertSent(GetGroupsByTeam::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getGroupsAssociatedToChannelsByTeam method in the Groups resource', function () {
+    Saloon::fake([
+        GetGroupsAssociatedToChannelsByTeam::class => MockResponse::fixture('groups.getGroupsAssociatedToChannelsByTeam'),
+    ]);
+
+    $response = $this->mattermost->groups()->getGroupsAssociatedToChannelsByTeam(
+		teamId: 'test string',
+		page: 123,
+		filterAllowReference: true,
+		paginate: true
+	);
+
+    Saloon::assertSent(GetGroupsAssociatedToChannelsByTeam::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getGroupsByUserId method in the Groups resource', function () {
+    Saloon::fake([
+        GetGroupsByUserId::class => MockResponse::fixture('groups.getGroupsByUserId'),
+    ]);
+
+    $response = $this->mattermost->groups()->getGroupsByUserId(
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(GetGroupsByUserId::class);
+
+    expect($response->status())->toBe(200);
+});

--- a/src/Client/tests/InsightsTest.php
+++ b/src/Client/tests/InsightsTest.php
@@ -1,0 +1,156 @@
+<?php
+
+// Generated 2026-04-10 23:46:41
+
+use ConduitUI\Mattermost\Client\Requests\Insights\GetTopChannelsForTeam;
+use ConduitUI\Mattermost\Client\Requests\Insights\GetTopReactionsForTeam;
+use ConduitUI\Mattermost\Client\Requests\Insights\GetNewTeamMembers;
+use ConduitUI\Mattermost\Client\Requests\Insights\GetTopThreadsForTeam;
+use ConduitUI\Mattermost\Client\Requests\Insights\GetTopChannelsForUser;
+use ConduitUI\Mattermost\Client\Requests\Insights\GetTopDmsForUser;
+use ConduitUI\Mattermost\Client\Requests\Insights\GetTopReactionsForUser;
+use ConduitUI\Mattermost\Client\Requests\Insights\GetTopThreadsForUser;
+use Saloon\Http\Faking\MockResponse;
+use Saloon\Laravel\Facades\Saloon;
+use Spatie\LaravelData\DataCollection;
+
+beforeEach(function () {
+    $this->mattermost = new ConduitUI\Mattermost\Client\Mattermost(
+		bearerToken: 'replace'
+	);
+});
+
+
+it('calls the getTopChannelsForTeam method in the Insights resource', function () {
+    Saloon::fake([
+        GetTopChannelsForTeam::class => MockResponse::fixture('insights.getTopChannelsForTeam'),
+    ]);
+
+    $response = $this->mattermost->insights()->getTopChannelsForTeam(
+		teamId: 'test string',
+		timeRange: 'test string',
+		page: 123
+	);
+
+    Saloon::assertSent(GetTopChannelsForTeam::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getTopReactionsForTeam method in the Insights resource', function () {
+    Saloon::fake([
+        GetTopReactionsForTeam::class => MockResponse::fixture('insights.getTopReactionsForTeam'),
+    ]);
+
+    $response = $this->mattermost->insights()->getTopReactionsForTeam(
+		teamId: 'test string',
+		timeRange: 'test string',
+		page: 123
+	);
+
+    Saloon::assertSent(GetTopReactionsForTeam::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getNewTeamMembers method in the Insights resource', function () {
+    Saloon::fake([
+        GetNewTeamMembers::class => MockResponse::fixture('insights.getNewTeamMembers'),
+    ]);
+
+    $response = $this->mattermost->insights()->getNewTeamMembers(
+		teamId: 'test string',
+		timeRange: 'test string',
+		page: 123
+	);
+
+    Saloon::assertSent(GetNewTeamMembers::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getTopThreadsForTeam method in the Insights resource', function () {
+    Saloon::fake([
+        GetTopThreadsForTeam::class => MockResponse::fixture('insights.getTopThreadsForTeam'),
+    ]);
+
+    $response = $this->mattermost->insights()->getTopThreadsForTeam(
+		teamId: 'test string',
+		timeRange: 'test string',
+		page: 123
+	);
+
+    Saloon::assertSent(GetTopThreadsForTeam::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getTopChannelsForUser method in the Insights resource', function () {
+    Saloon::fake([
+        GetTopChannelsForUser::class => MockResponse::fixture('insights.getTopChannelsForUser'),
+    ]);
+
+    $response = $this->mattermost->insights()->getTopChannelsForUser(
+		timeRange: 'test string',
+		page: 123,
+		teamId: 'test string'
+	);
+
+    Saloon::assertSent(GetTopChannelsForUser::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getTopDmsForUser method in the Insights resource', function () {
+    Saloon::fake([
+        GetTopDmsForUser::class => MockResponse::fixture('insights.getTopDmsForUser'),
+    ]);
+
+    $response = $this->mattermost->insights()->getTopDmsForUser(
+		timeRange: 'test string',
+		page: 123
+	);
+
+    Saloon::assertSent(GetTopDmsForUser::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getTopReactionsForUser method in the Insights resource', function () {
+    Saloon::fake([
+        GetTopReactionsForUser::class => MockResponse::fixture('insights.getTopReactionsForUser'),
+    ]);
+
+    $response = $this->mattermost->insights()->getTopReactionsForUser(
+		timeRange: 'test string',
+		page: 123,
+		teamId: 'test string'
+	);
+
+    Saloon::assertSent(GetTopReactionsForUser::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getTopThreadsForUser method in the Insights resource', function () {
+    Saloon::fake([
+        GetTopThreadsForUser::class => MockResponse::fixture('insights.getTopThreadsForUser'),
+    ]);
+
+    $response = $this->mattermost->insights()->getTopThreadsForUser(
+		timeRange: 'test string',
+		page: 123,
+		teamId: 'test string'
+	);
+
+    Saloon::assertSent(GetTopThreadsForUser::class);
+
+    expect($response->status())->toBe(200);
+});

--- a/src/Client/tests/OauthTest.php
+++ b/src/Client/tests/OauthTest.php
@@ -1,0 +1,30 @@
+<?php
+
+// Generated 2026-04-10 23:46:41
+
+use ConduitUI\Mattermost\Client\Requests\Oauth\GetAuthorizedOauthAppsForUser;
+use Saloon\Http\Faking\MockResponse;
+use Saloon\Laravel\Facades\Saloon;
+use Spatie\LaravelData\DataCollection;
+
+beforeEach(function () {
+    $this->mattermost = new ConduitUI\Mattermost\Client\Mattermost(
+		bearerToken: 'replace'
+	);
+});
+
+
+it('calls the getAuthorizedOauthAppsForUser method in the Oauth resource', function () {
+    Saloon::fake([
+        GetAuthorizedOauthAppsForUser::class => MockResponse::fixture('oauth.getAuthorizedOauthAppsForUser'),
+    ]);
+
+    $response = $this->mattermost->oauth()->getAuthorizedOauthAppsForUser(
+		userId: 'test string',
+		page: 123
+	);
+
+    Saloon::assertSent(GetAuthorizedOauthAppsForUser::class);
+
+    expect($response->status())->toBe(200);
+});

--- a/src/Client/tests/Pest.php
+++ b/src/Client/tests/Pest.php
@@ -1,0 +1,5 @@
+<?php
+
+use ConduitUI\Mattermost\Client\Tests\TestCase;
+
+uses(TestCase::class)->in(__DIR__);

--- a/src/Client/tests/PostsTest.php
+++ b/src/Client/tests/PostsTest.php
@@ -1,0 +1,360 @@
+<?php
+
+// Generated 2026-04-10 23:46:41
+
+use ConduitUI\Mattermost\Client\Requests\Posts\GetPostsForChannel;
+use ConduitUI\Mattermost\Client\Requests\Posts\CreatePost;
+use ConduitUI\Mattermost\Client\Requests\Posts\CreatePostEphemeral;
+use ConduitUI\Mattermost\Client\Requests\Posts\GetPostsByIds;
+use ConduitUI\Mattermost\Client\Requests\Posts\GetPost;
+use ConduitUI\Mattermost\Client\Requests\Posts\UpdatePost;
+use ConduitUI\Mattermost\Client\Requests\Posts\DeletePost;
+use ConduitUI\Mattermost\Client\Requests\Posts\DoPostAction;
+use ConduitUI\Mattermost\Client\Requests\Posts\GetFileInfosForPost;
+use ConduitUI\Mattermost\Client\Requests\Posts\PatchPost;
+use ConduitUI\Mattermost\Client\Requests\Posts\PinPost;
+use ConduitUI\Mattermost\Client\Requests\Posts\GetPostThread;
+use ConduitUI\Mattermost\Client\Requests\Posts\UnpinPost;
+use ConduitUI\Mattermost\Client\Requests\Posts\SearchPosts;
+use ConduitUI\Mattermost\Client\Requests\Posts\GetPostsAroundLastUnread;
+use ConduitUI\Mattermost\Client\Requests\Posts\GetFlaggedPostsForUser;
+use ConduitUI\Mattermost\Client\Requests\Posts\SaveAcknowledgementForPost;
+use ConduitUI\Mattermost\Client\Requests\Posts\SaveAcknowledgementForPost;
+use ConduitUI\Mattermost\Client\Requests\Posts\SetPostReminder;
+use ConduitUI\Mattermost\Client\Requests\Posts\SetPostUnread;
+use Saloon\Http\Faking\MockResponse;
+use Saloon\Laravel\Facades\Saloon;
+use Spatie\LaravelData\DataCollection;
+
+beforeEach(function () {
+    $this->mattermost = new ConduitUI\Mattermost\Client\Mattermost(
+		bearerToken: 'replace'
+	);
+});
+
+
+it('calls the getPostsForChannel method in the Posts resource', function () {
+    Saloon::fake([
+        GetPostsForChannel::class => MockResponse::fixture('posts.getPostsForChannel'),
+    ]);
+
+    $response = $this->mattermost->posts()->getPostsForChannel(
+		channelId: 'test string',
+		page: 123,
+		since: 123,
+		before: 'test string',
+		includeDeleted: true
+	);
+
+    Saloon::assertSent(GetPostsForChannel::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the createPost method in the Posts resource', function () {
+    Saloon::fake([
+        CreatePost::class => MockResponse::fixture('posts.createPost'),
+    ]);
+
+    $response = $this->mattermost->posts()->createPost(
+		setOnline: true
+	);
+
+    Saloon::assertSent(CreatePost::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the createPostEphemeral method in the Posts resource', function () {
+    Saloon::fake([
+        CreatePostEphemeral::class => MockResponse::fixture('posts.createPostEphemeral'),
+    ]);
+
+    $response = $this->mattermost->posts()->createPostEphemeral(
+		
+	);
+
+    Saloon::assertSent(CreatePostEphemeral::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getPostsByIds method in the Posts resource', function () {
+    Saloon::fake([
+        GetPostsByIds::class => MockResponse::fixture('posts.getPostsByIds'),
+    ]);
+
+    $response = $this->mattermost->posts()->getPostsByIds(
+		
+	);
+
+    Saloon::assertSent(GetPostsByIds::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getPost method in the Posts resource', function () {
+    Saloon::fake([
+        GetPost::class => MockResponse::fixture('posts.getPost'),
+    ]);
+
+    $response = $this->mattermost->posts()->getPost(
+		postId: 'test string',
+		includeDeleted: true
+	);
+
+    Saloon::assertSent(GetPost::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the updatePost method in the Posts resource', function () {
+    Saloon::fake([
+        UpdatePost::class => MockResponse::fixture('posts.updatePost'),
+    ]);
+
+    $response = $this->mattermost->posts()->updatePost(
+		postId: 'test string'
+	);
+
+    Saloon::assertSent(UpdatePost::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the deletePost method in the Posts resource', function () {
+    Saloon::fake([
+        DeletePost::class => MockResponse::fixture('posts.deletePost'),
+    ]);
+
+    $response = $this->mattermost->posts()->deletePost(
+		postId: 'test string'
+	);
+
+    Saloon::assertSent(DeletePost::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the doPostAction method in the Posts resource', function () {
+    Saloon::fake([
+        DoPostAction::class => MockResponse::fixture('posts.doPostAction'),
+    ]);
+
+    $response = $this->mattermost->posts()->doPostAction(
+		postId: 'test string',
+		actionId: 'test string'
+	);
+
+    Saloon::assertSent(DoPostAction::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getFileInfosForPost method in the Posts resource', function () {
+    Saloon::fake([
+        GetFileInfosForPost::class => MockResponse::fixture('posts.getFileInfosForPost'),
+    ]);
+
+    $response = $this->mattermost->posts()->getFileInfosForPost(
+		postId: 'test string',
+		includeDeleted: true
+	);
+
+    Saloon::assertSent(GetFileInfosForPost::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the patchPost method in the Posts resource', function () {
+    Saloon::fake([
+        PatchPost::class => MockResponse::fixture('posts.patchPost'),
+    ]);
+
+    $response = $this->mattermost->posts()->patchPost(
+		postId: 'test string'
+	);
+
+    Saloon::assertSent(PatchPost::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the pinPost method in the Posts resource', function () {
+    Saloon::fake([
+        PinPost::class => MockResponse::fixture('posts.pinPost'),
+    ]);
+
+    $response = $this->mattermost->posts()->pinPost(
+		postId: 'test string'
+	);
+
+    Saloon::assertSent(PinPost::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getPostThread method in the Posts resource', function () {
+    Saloon::fake([
+        GetPostThread::class => MockResponse::fixture('posts.getPostThread'),
+    ]);
+
+    $response = $this->mattermost->posts()->getPostThread(
+		postId: 'test string',
+		perPage: 123,
+		fromPost: 'test string',
+		fromCreateAt: 123,
+		direction: 'test string',
+		skipFetchThreads: true,
+		collapsedThreads: true,
+		collapsedThreadsExtended: true
+	);
+
+    Saloon::assertSent(GetPostThread::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the unpinPost method in the Posts resource', function () {
+    Saloon::fake([
+        UnpinPost::class => MockResponse::fixture('posts.unpinPost'),
+    ]);
+
+    $response = $this->mattermost->posts()->unpinPost(
+		postId: 'test string'
+	);
+
+    Saloon::assertSent(UnpinPost::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the searchPosts method in the Posts resource', function () {
+    Saloon::fake([
+        SearchPosts::class => MockResponse::fixture('posts.searchPosts'),
+    ]);
+
+    $response = $this->mattermost->posts()->searchPosts(
+		teamId: 'test string'
+	);
+
+    Saloon::assertSent(SearchPosts::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getPostsAroundLastUnread method in the Posts resource', function () {
+    Saloon::fake([
+        GetPostsAroundLastUnread::class => MockResponse::fixture('posts.getPostsAroundLastUnread'),
+    ]);
+
+    $response = $this->mattermost->posts()->getPostsAroundLastUnread(
+		userId: 'test string',
+		channelId: 'test string',
+		limitBefore: 123,
+		limitAfter: 123,
+		skipFetchThreads: true,
+		collapsedThreads: true,
+		collapsedThreadsExtended: true
+	);
+
+    Saloon::assertSent(GetPostsAroundLastUnread::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getFlaggedPostsForUser method in the Posts resource', function () {
+    Saloon::fake([
+        GetFlaggedPostsForUser::class => MockResponse::fixture('posts.getFlaggedPostsForUser'),
+    ]);
+
+    $response = $this->mattermost->posts()->getFlaggedPostsForUser(
+		userId: 'test string',
+		teamId: 'test string',
+		channelId: 'test string',
+		page: 123
+	);
+
+    Saloon::assertSent(GetFlaggedPostsForUser::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the saveAcknowledgementForPost method in the Posts resource', function () {
+    Saloon::fake([
+        SaveAcknowledgementForPost::class => MockResponse::fixture('posts.saveAcknowledgementForPost'),
+    ]);
+
+    $response = $this->mattermost->posts()->saveAcknowledgementForPost(
+		userId: 'test string',
+		postId: 'test string'
+	);
+
+    Saloon::assertSent(SaveAcknowledgementForPost::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the saveAcknowledgementForPost method in the Posts resource', function () {
+    Saloon::fake([
+        SaveAcknowledgementForPost::class => MockResponse::fixture('posts.saveAcknowledgementForPost'),
+    ]);
+
+    $response = $this->mattermost->posts()->saveAcknowledgementForPost(
+		userId: 'test string',
+		postId: 'test string'
+	);
+
+    Saloon::assertSent(SaveAcknowledgementForPost::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the setPostReminder method in the Posts resource', function () {
+    Saloon::fake([
+        SetPostReminder::class => MockResponse::fixture('posts.setPostReminder'),
+    ]);
+
+    $response = $this->mattermost->posts()->setPostReminder(
+		userId: 'test string',
+		postId: 'test string'
+	);
+
+    Saloon::assertSent(SetPostReminder::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the setPostUnread method in the Posts resource', function () {
+    Saloon::fake([
+        SetPostUnread::class => MockResponse::fixture('posts.setPostUnread'),
+    ]);
+
+    $response = $this->mattermost->posts()->setPostUnread(
+		userId: 'test string',
+		postId: 'test string'
+	);
+
+    Saloon::assertSent(SetPostUnread::class);
+
+    expect($response->status())->toBe(200);
+});

--- a/src/Client/tests/PreferencesTest.php
+++ b/src/Client/tests/PreferencesTest.php
@@ -1,0 +1,96 @@
+<?php
+
+// Generated 2026-04-10 23:46:41
+
+use ConduitUI\Mattermost\Client\Requests\Preferences\GetPreferences;
+use ConduitUI\Mattermost\Client\Requests\Preferences\UpdatePreferences;
+use ConduitUI\Mattermost\Client\Requests\Preferences\DeletePreferences;
+use ConduitUI\Mattermost\Client\Requests\Preferences\GetPreferencesByCategory;
+use ConduitUI\Mattermost\Client\Requests\Preferences\GetPreferencesByCategoryByName;
+use Saloon\Http\Faking\MockResponse;
+use Saloon\Laravel\Facades\Saloon;
+use Spatie\LaravelData\DataCollection;
+
+beforeEach(function () {
+    $this->mattermost = new ConduitUI\Mattermost\Client\Mattermost(
+		bearerToken: 'replace'
+	);
+});
+
+
+it('calls the getPreferences method in the Preferences resource', function () {
+    Saloon::fake([
+        GetPreferences::class => MockResponse::fixture('preferences.getPreferences'),
+    ]);
+
+    $response = $this->mattermost->preferences()->getPreferences(
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(GetPreferences::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the updatePreferences method in the Preferences resource', function () {
+    Saloon::fake([
+        UpdatePreferences::class => MockResponse::fixture('preferences.updatePreferences'),
+    ]);
+
+    $response = $this->mattermost->preferences()->updatePreferences(
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(UpdatePreferences::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the deletePreferences method in the Preferences resource', function () {
+    Saloon::fake([
+        DeletePreferences::class => MockResponse::fixture('preferences.deletePreferences'),
+    ]);
+
+    $response = $this->mattermost->preferences()->deletePreferences(
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(DeletePreferences::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getPreferencesByCategory method in the Preferences resource', function () {
+    Saloon::fake([
+        GetPreferencesByCategory::class => MockResponse::fixture('preferences.getPreferencesByCategory'),
+    ]);
+
+    $response = $this->mattermost->preferences()->getPreferencesByCategory(
+		userId: 'test string',
+		category: 'test string'
+	);
+
+    Saloon::assertSent(GetPreferencesByCategory::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getPreferencesByCategoryByName method in the Preferences resource', function () {
+    Saloon::fake([
+        GetPreferencesByCategoryByName::class => MockResponse::fixture('preferences.getPreferencesByCategoryByName'),
+    ]);
+
+    $response = $this->mattermost->preferences()->getPreferencesByCategoryByName(
+		userId: 'test string',
+		category: 'test string',
+		preferenceName: 'test string'
+	);
+
+    Saloon::assertSent(GetPreferencesByCategoryByName::class);
+
+    expect($response->status())->toBe(200);
+});

--- a/src/Client/tests/ReactionsTest.php
+++ b/src/Client/tests/ReactionsTest.php
@@ -1,0 +1,79 @@
+<?php
+
+// Generated 2026-04-10 23:46:41
+
+use ConduitUI\Mattermost\Client\Requests\Reactions\GetBulkReactions;
+use ConduitUI\Mattermost\Client\Requests\Reactions\GetReactions;
+use ConduitUI\Mattermost\Client\Requests\Reactions\SaveReaction;
+use ConduitUI\Mattermost\Client\Requests\Reactions\DeleteReaction;
+use Saloon\Http\Faking\MockResponse;
+use Saloon\Laravel\Facades\Saloon;
+use Spatie\LaravelData\DataCollection;
+
+beforeEach(function () {
+    $this->mattermost = new ConduitUI\Mattermost\Client\Mattermost(
+		bearerToken: 'replace'
+	);
+});
+
+
+it('calls the getBulkReactions method in the Reactions resource', function () {
+    Saloon::fake([
+        GetBulkReactions::class => MockResponse::fixture('reactions.getBulkReactions'),
+    ]);
+
+    $response = $this->mattermost->reactions()->getBulkReactions(
+		
+	);
+
+    Saloon::assertSent(GetBulkReactions::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getReactions method in the Reactions resource', function () {
+    Saloon::fake([
+        GetReactions::class => MockResponse::fixture('reactions.getReactions'),
+    ]);
+
+    $response = $this->mattermost->reactions()->getReactions(
+		postId: 'test string'
+	);
+
+    Saloon::assertSent(GetReactions::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the saveReaction method in the Reactions resource', function () {
+    Saloon::fake([
+        SaveReaction::class => MockResponse::fixture('reactions.saveReaction'),
+    ]);
+
+    $response = $this->mattermost->reactions()->saveReaction(
+		
+	);
+
+    Saloon::assertSent(SaveReaction::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the deleteReaction method in the Reactions resource', function () {
+    Saloon::fake([
+        DeleteReaction::class => MockResponse::fixture('reactions.deleteReaction'),
+    ]);
+
+    $response = $this->mattermost->reactions()->deleteReaction(
+		userId: 'test string',
+		postId: 'test string',
+		emojiName: 'test string'
+	);
+
+    Saloon::assertSent(DeleteReaction::class);
+
+    expect($response->status())->toBe(200);
+});

--- a/src/Client/tests/StatusTest.php
+++ b/src/Client/tests/StatusTest.php
@@ -1,0 +1,125 @@
+<?php
+
+// Generated 2026-04-10 23:46:41
+
+use ConduitUI\Mattermost\Client\Requests\Status\GetUsersStatusesByIds;
+use ConduitUI\Mattermost\Client\Requests\Status\GetUserStatus;
+use ConduitUI\Mattermost\Client\Requests\Status\UpdateUserStatus;
+use ConduitUI\Mattermost\Client\Requests\Status\UpdateUserCustomStatus;
+use ConduitUI\Mattermost\Client\Requests\Status\UnsetUserCustomStatus;
+use ConduitUI\Mattermost\Client\Requests\Status\RemoveRecentCustomStatus;
+use ConduitUI\Mattermost\Client\Requests\Status\PostUserRecentCustomStatusDelete;
+use Saloon\Http\Faking\MockResponse;
+use Saloon\Laravel\Facades\Saloon;
+use Spatie\LaravelData\DataCollection;
+
+beforeEach(function () {
+    $this->mattermost = new ConduitUI\Mattermost\Client\Mattermost(
+		bearerToken: 'replace'
+	);
+});
+
+
+it('calls the getUsersStatusesByIds method in the Status resource', function () {
+    Saloon::fake([
+        GetUsersStatusesByIds::class => MockResponse::fixture('status.getUsersStatusesByIds'),
+    ]);
+
+    $response = $this->mattermost->status()->getUsersStatusesByIds(
+		
+	);
+
+    Saloon::assertSent(GetUsersStatusesByIds::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getUserStatus method in the Status resource', function () {
+    Saloon::fake([
+        GetUserStatus::class => MockResponse::fixture('status.getUserStatus'),
+    ]);
+
+    $response = $this->mattermost->status()->getUserStatus(
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(GetUserStatus::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the updateUserStatus method in the Status resource', function () {
+    Saloon::fake([
+        UpdateUserStatus::class => MockResponse::fixture('status.updateUserStatus'),
+    ]);
+
+    $response = $this->mattermost->status()->updateUserStatus(
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(UpdateUserStatus::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the updateUserCustomStatus method in the Status resource', function () {
+    Saloon::fake([
+        UpdateUserCustomStatus::class => MockResponse::fixture('status.updateUserCustomStatus'),
+    ]);
+
+    $response = $this->mattermost->status()->updateUserCustomStatus(
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(UpdateUserCustomStatus::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the unsetUserCustomStatus method in the Status resource', function () {
+    Saloon::fake([
+        UnsetUserCustomStatus::class => MockResponse::fixture('status.unsetUserCustomStatus'),
+    ]);
+
+    $response = $this->mattermost->status()->unsetUserCustomStatus(
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(UnsetUserCustomStatus::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the removeRecentCustomStatus method in the Status resource', function () {
+    Saloon::fake([
+        RemoveRecentCustomStatus::class => MockResponse::fixture('status.removeRecentCustomStatus'),
+    ]);
+
+    $response = $this->mattermost->status()->removeRecentCustomStatus(
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(RemoveRecentCustomStatus::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the postUserRecentCustomStatusDelete method in the Status resource', function () {
+    Saloon::fake([
+        PostUserRecentCustomStatusDelete::class => MockResponse::fixture('status.postUserRecentCustomStatusDelete'),
+    ]);
+
+    $response = $this->mattermost->status()->postUserRecentCustomStatusDelete(
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(PostUserRecentCustomStatusDelete::class);
+
+    expect($response->status())->toBe(200);
+});

--- a/src/Client/tests/SystemTest.php
+++ b/src/Client/tests/SystemTest.php
@@ -1,0 +1,97 @@
+<?php
+
+// Generated 2026-04-10 23:46:41
+
+use ConduitUI\Mattermost\Client\Requests\System\MarkNoticesViewed;
+use ConduitUI\Mattermost\Client\Requests\System\GetNotices;
+use ConduitUI\Mattermost\Client\Requests\System\GetPing;
+use ConduitUI\Mattermost\Client\Requests\System\GenerateSupportPacket;
+use ConduitUI\Mattermost\Client\Requests\System\GetSupportedTimezone;
+use Saloon\Http\Faking\MockResponse;
+use Saloon\Laravel\Facades\Saloon;
+use Spatie\LaravelData\DataCollection;
+
+beforeEach(function () {
+    $this->mattermost = new ConduitUI\Mattermost\Client\Mattermost(
+		bearerToken: 'replace'
+	);
+});
+
+
+it('calls the markNoticesViewed method in the System resource', function () {
+    Saloon::fake([
+        MarkNoticesViewed::class => MockResponse::fixture('system.markNoticesViewed'),
+    ]);
+
+    $response = $this->mattermost->system()->markNoticesViewed(
+		
+	);
+
+    Saloon::assertSent(MarkNoticesViewed::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getNotices method in the System resource', function () {
+    Saloon::fake([
+        GetNotices::class => MockResponse::fixture('system.getNotices'),
+    ]);
+
+    $response = $this->mattermost->system()->getNotices(
+		teamId: 'test string',
+		clientVersion: 'test string',
+		locale: 'test string',
+		client: 'test string'
+	);
+
+    Saloon::assertSent(GetNotices::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getPing method in the System resource', function () {
+    Saloon::fake([
+        GetPing::class => MockResponse::fixture('system.getPing'),
+    ]);
+
+    $response = $this->mattermost->system()->getPing(
+		getServerStatus: true,
+		deviceId: 'test string'
+	);
+
+    Saloon::assertSent(GetPing::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the generateSupportPacket method in the System resource', function () {
+    Saloon::fake([
+        GenerateSupportPacket::class => MockResponse::fixture('system.generateSupportPacket'),
+    ]);
+
+    $response = $this->mattermost->system()->generateSupportPacket(
+		
+	);
+
+    Saloon::assertSent(GenerateSupportPacket::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getSupportedTimezone method in the System resource', function () {
+    Saloon::fake([
+        GetSupportedTimezone::class => MockResponse::fixture('system.getSupportedTimezone'),
+    ]);
+
+    $response = $this->mattermost->system()->getSupportedTimezone(
+		
+	);
+
+    Saloon::assertSent(GetSupportedTimezone::class);
+
+    expect($response->status())->toBe(200);
+});

--- a/src/Client/tests/TeamsTest.php
+++ b/src/Client/tests/TeamsTest.php
@@ -1,0 +1,619 @@
+<?php
+
+// Generated 2026-04-10 23:46:41
+
+use ConduitUI\Mattermost\Client\Requests\Teams\GetAllTeams;
+use ConduitUI\Mattermost\Client\Requests\Teams\CreateTeam;
+use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamInviteInfo;
+use ConduitUI\Mattermost\Client\Requests\Teams\InvalidateEmailInvites;
+use ConduitUI\Mattermost\Client\Requests\Teams\AddTeamMemberFromInvite;
+use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamByName;
+use ConduitUI\Mattermost\Client\Requests\Teams\TeamExists;
+use ConduitUI\Mattermost\Client\Requests\Teams\SearchTeams;
+use ConduitUI\Mattermost\Client\Requests\Teams\GetTeam;
+use ConduitUI\Mattermost\Client\Requests\Teams\UpdateTeam;
+use ConduitUI\Mattermost\Client\Requests\Teams\SoftDeleteTeam;
+use ConduitUI\Mattermost\Client\Requests\Teams\SearchFiles;
+use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamIcon;
+use ConduitUI\Mattermost\Client\Requests\Teams\SetTeamIcon;
+use ConduitUI\Mattermost\Client\Requests\Teams\RemoveTeamIcon;
+use ConduitUI\Mattermost\Client\Requests\Teams\ImportTeam;
+use ConduitUI\Mattermost\Client\Requests\Teams\InviteGuestsToTeam;
+use ConduitUI\Mattermost\Client\Requests\Teams\InviteUsersToTeam;
+use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamMembers;
+use ConduitUI\Mattermost\Client\Requests\Teams\AddTeamMember;
+use ConduitUI\Mattermost\Client\Requests\Teams\AddTeamMembers;
+use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamMembersByIds;
+use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamMember;
+use ConduitUI\Mattermost\Client\Requests\Teams\RemoveTeamMember;
+use ConduitUI\Mattermost\Client\Requests\Teams\UpdateTeamMemberRoles;
+use ConduitUI\Mattermost\Client\Requests\Teams\UpdateTeamMemberSchemeRoles;
+use ConduitUI\Mattermost\Client\Requests\Teams\TeamMembersMinusGroupMembers;
+use ConduitUI\Mattermost\Client\Requests\Teams\PatchTeam;
+use ConduitUI\Mattermost\Client\Requests\Teams\UpdateTeamPrivacy;
+use ConduitUI\Mattermost\Client\Requests\Teams\RegenerateTeamInviteId;
+use ConduitUI\Mattermost\Client\Requests\Teams\RestoreTeam;
+use ConduitUI\Mattermost\Client\Requests\Teams\UpdateTeamScheme;
+use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamStats;
+use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamsForUser;
+use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamMembersForUser;
+use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamsUnreadForUser;
+use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamUnread;
+use Saloon\Http\Faking\MockResponse;
+use Saloon\Laravel\Facades\Saloon;
+use Spatie\LaravelData\DataCollection;
+
+beforeEach(function () {
+    $this->mattermost = new ConduitUI\Mattermost\Client\Mattermost(
+		bearerToken: 'replace'
+	);
+});
+
+
+it('calls the getAllTeams method in the Teams resource', function () {
+    Saloon::fake([
+        GetAllTeams::class => MockResponse::fixture('teams.getAllTeams'),
+    ]);
+
+    $response = $this->mattermost->teams()->getAllTeams(
+		page: 123,
+		includeTotalCount: true,
+		excludePolicyConstrained: true
+	);
+
+    Saloon::assertSent(GetAllTeams::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the createTeam method in the Teams resource', function () {
+    Saloon::fake([
+        CreateTeam::class => MockResponse::fixture('teams.createTeam'),
+    ]);
+
+    $response = $this->mattermost->teams()->createTeam(
+		
+	);
+
+    Saloon::assertSent(CreateTeam::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getTeamInviteInfo method in the Teams resource', function () {
+    Saloon::fake([
+        GetTeamInviteInfo::class => MockResponse::fixture('teams.getTeamInviteInfo'),
+    ]);
+
+    $response = $this->mattermost->teams()->getTeamInviteInfo(
+		inviteId: 'test string'
+	);
+
+    Saloon::assertSent(GetTeamInviteInfo::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the invalidateEmailInvites method in the Teams resource', function () {
+    Saloon::fake([
+        InvalidateEmailInvites::class => MockResponse::fixture('teams.invalidateEmailInvites'),
+    ]);
+
+    $response = $this->mattermost->teams()->invalidateEmailInvites(
+		
+	);
+
+    Saloon::assertSent(InvalidateEmailInvites::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the addTeamMemberFromInvite method in the Teams resource', function () {
+    Saloon::fake([
+        AddTeamMemberFromInvite::class => MockResponse::fixture('teams.addTeamMemberFromInvite'),
+    ]);
+
+    $response = $this->mattermost->teams()->addTeamMemberFromInvite(
+		token: 'test string'
+	);
+
+    Saloon::assertSent(AddTeamMemberFromInvite::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getTeamByName method in the Teams resource', function () {
+    Saloon::fake([
+        GetTeamByName::class => MockResponse::fixture('teams.getTeamByName'),
+    ]);
+
+    $response = $this->mattermost->teams()->getTeamByName(
+		name: 'test string'
+	);
+
+    Saloon::assertSent(GetTeamByName::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the teamExists method in the Teams resource', function () {
+    Saloon::fake([
+        TeamExists::class => MockResponse::fixture('teams.teamExists'),
+    ]);
+
+    $response = $this->mattermost->teams()->teamExists(
+		name: 'test string'
+	);
+
+    Saloon::assertSent(TeamExists::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the searchTeams method in the Teams resource', function () {
+    Saloon::fake([
+        SearchTeams::class => MockResponse::fixture('teams.searchTeams'),
+    ]);
+
+    $response = $this->mattermost->teams()->searchTeams(
+		
+	);
+
+    Saloon::assertSent(SearchTeams::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getTeam method in the Teams resource', function () {
+    Saloon::fake([
+        GetTeam::class => MockResponse::fixture('teams.getTeam'),
+    ]);
+
+    $response = $this->mattermost->teams()->getTeam(
+		teamId: 'test string'
+	);
+
+    Saloon::assertSent(GetTeam::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the updateTeam method in the Teams resource', function () {
+    Saloon::fake([
+        UpdateTeam::class => MockResponse::fixture('teams.updateTeam'),
+    ]);
+
+    $response = $this->mattermost->teams()->updateTeam(
+		teamId: 'test string'
+	);
+
+    Saloon::assertSent(UpdateTeam::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the softDeleteTeam method in the Teams resource', function () {
+    Saloon::fake([
+        SoftDeleteTeam::class => MockResponse::fixture('teams.softDeleteTeam'),
+    ]);
+
+    $response = $this->mattermost->teams()->softDeleteTeam(
+		teamId: 'test string',
+		permanent: true
+	);
+
+    Saloon::assertSent(SoftDeleteTeam::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the searchFiles method in the Teams resource', function () {
+    Saloon::fake([
+        SearchFiles::class => MockResponse::fixture('teams.searchFiles'),
+    ]);
+
+    $response = $this->mattermost->teams()->searchFiles(
+		teamId: 'test string'
+	);
+
+    Saloon::assertSent(SearchFiles::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getTeamIcon method in the Teams resource', function () {
+    Saloon::fake([
+        GetTeamIcon::class => MockResponse::fixture('teams.getTeamIcon'),
+    ]);
+
+    $response = $this->mattermost->teams()->getTeamIcon(
+		teamId: 'test string'
+	);
+
+    Saloon::assertSent(GetTeamIcon::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the setTeamIcon method in the Teams resource', function () {
+    Saloon::fake([
+        SetTeamIcon::class => MockResponse::fixture('teams.setTeamIcon'),
+    ]);
+
+    $response = $this->mattermost->teams()->setTeamIcon(
+		teamId: 'test string'
+	);
+
+    Saloon::assertSent(SetTeamIcon::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the removeTeamIcon method in the Teams resource', function () {
+    Saloon::fake([
+        RemoveTeamIcon::class => MockResponse::fixture('teams.removeTeamIcon'),
+    ]);
+
+    $response = $this->mattermost->teams()->removeTeamIcon(
+		teamId: 'test string'
+	);
+
+    Saloon::assertSent(RemoveTeamIcon::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the importTeam method in the Teams resource', function () {
+    Saloon::fake([
+        ImportTeam::class => MockResponse::fixture('teams.importTeam'),
+    ]);
+
+    $response = $this->mattermost->teams()->importTeam(
+		teamId: 'test string'
+	);
+
+    Saloon::assertSent(ImportTeam::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the inviteGuestsToTeam method in the Teams resource', function () {
+    Saloon::fake([
+        InviteGuestsToTeam::class => MockResponse::fixture('teams.inviteGuestsToTeam'),
+    ]);
+
+    $response = $this->mattermost->teams()->inviteGuestsToTeam(
+		teamId: 'test string'
+	);
+
+    Saloon::assertSent(InviteGuestsToTeam::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the inviteUsersToTeam method in the Teams resource', function () {
+    Saloon::fake([
+        InviteUsersToTeam::class => MockResponse::fixture('teams.inviteUsersToTeam'),
+    ]);
+
+    $response = $this->mattermost->teams()->inviteUsersToTeam(
+		teamId: 'test string'
+	);
+
+    Saloon::assertSent(InviteUsersToTeam::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getTeamMembers method in the Teams resource', function () {
+    Saloon::fake([
+        GetTeamMembers::class => MockResponse::fixture('teams.getTeamMembers'),
+    ]);
+
+    $response = $this->mattermost->teams()->getTeamMembers(
+		teamId: 'test string',
+		page: 123
+	);
+
+    Saloon::assertSent(GetTeamMembers::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the addTeamMember method in the Teams resource', function () {
+    Saloon::fake([
+        AddTeamMember::class => MockResponse::fixture('teams.addTeamMember'),
+    ]);
+
+    $response = $this->mattermost->teams()->addTeamMember(
+		teamId: 'test string'
+	);
+
+    Saloon::assertSent(AddTeamMember::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the addTeamMembers method in the Teams resource', function () {
+    Saloon::fake([
+        AddTeamMembers::class => MockResponse::fixture('teams.addTeamMembers'),
+    ]);
+
+    $response = $this->mattermost->teams()->addTeamMembers(
+		teamId: 'test string',
+		graceful: true
+	);
+
+    Saloon::assertSent(AddTeamMembers::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getTeamMembersByIds method in the Teams resource', function () {
+    Saloon::fake([
+        GetTeamMembersByIds::class => MockResponse::fixture('teams.getTeamMembersByIds'),
+    ]);
+
+    $response = $this->mattermost->teams()->getTeamMembersByIds(
+		teamId: 'test string'
+	);
+
+    Saloon::assertSent(GetTeamMembersByIds::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getTeamMember method in the Teams resource', function () {
+    Saloon::fake([
+        GetTeamMember::class => MockResponse::fixture('teams.getTeamMember'),
+    ]);
+
+    $response = $this->mattermost->teams()->getTeamMember(
+		teamId: 'test string',
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(GetTeamMember::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the removeTeamMember method in the Teams resource', function () {
+    Saloon::fake([
+        RemoveTeamMember::class => MockResponse::fixture('teams.removeTeamMember'),
+    ]);
+
+    $response = $this->mattermost->teams()->removeTeamMember(
+		teamId: 'test string',
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(RemoveTeamMember::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the updateTeamMemberRoles method in the Teams resource', function () {
+    Saloon::fake([
+        UpdateTeamMemberRoles::class => MockResponse::fixture('teams.updateTeamMemberRoles'),
+    ]);
+
+    $response = $this->mattermost->teams()->updateTeamMemberRoles(
+		teamId: 'test string',
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(UpdateTeamMemberRoles::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the updateTeamMemberSchemeRoles method in the Teams resource', function () {
+    Saloon::fake([
+        UpdateTeamMemberSchemeRoles::class => MockResponse::fixture('teams.updateTeamMemberSchemeRoles'),
+    ]);
+
+    $response = $this->mattermost->teams()->updateTeamMemberSchemeRoles(
+		teamId: 'test string',
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(UpdateTeamMemberSchemeRoles::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the teamMembersMinusGroupMembers method in the Teams resource', function () {
+    Saloon::fake([
+        TeamMembersMinusGroupMembers::class => MockResponse::fixture('teams.teamMembersMinusGroupMembers'),
+    ]);
+
+    $response = $this->mattermost->teams()->teamMembersMinusGroupMembers(
+		teamId: 'test string',
+		groupIds: 'test string',
+		page: 123
+	);
+
+    Saloon::assertSent(TeamMembersMinusGroupMembers::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the patchTeam method in the Teams resource', function () {
+    Saloon::fake([
+        PatchTeam::class => MockResponse::fixture('teams.patchTeam'),
+    ]);
+
+    $response = $this->mattermost->teams()->patchTeam(
+		teamId: 'test string'
+	);
+
+    Saloon::assertSent(PatchTeam::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the updateTeamPrivacy method in the Teams resource', function () {
+    Saloon::fake([
+        UpdateTeamPrivacy::class => MockResponse::fixture('teams.updateTeamPrivacy'),
+    ]);
+
+    $response = $this->mattermost->teams()->updateTeamPrivacy(
+		teamId: 'test string'
+	);
+
+    Saloon::assertSent(UpdateTeamPrivacy::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the regenerateTeamInviteId method in the Teams resource', function () {
+    Saloon::fake([
+        RegenerateTeamInviteId::class => MockResponse::fixture('teams.regenerateTeamInviteId'),
+    ]);
+
+    $response = $this->mattermost->teams()->regenerateTeamInviteId(
+		teamId: 'test string'
+	);
+
+    Saloon::assertSent(RegenerateTeamInviteId::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the restoreTeam method in the Teams resource', function () {
+    Saloon::fake([
+        RestoreTeam::class => MockResponse::fixture('teams.restoreTeam'),
+    ]);
+
+    $response = $this->mattermost->teams()->restoreTeam(
+		teamId: 'test string'
+	);
+
+    Saloon::assertSent(RestoreTeam::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the updateTeamScheme method in the Teams resource', function () {
+    Saloon::fake([
+        UpdateTeamScheme::class => MockResponse::fixture('teams.updateTeamScheme'),
+    ]);
+
+    $response = $this->mattermost->teams()->updateTeamScheme(
+		teamId: 'test string'
+	);
+
+    Saloon::assertSent(UpdateTeamScheme::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getTeamStats method in the Teams resource', function () {
+    Saloon::fake([
+        GetTeamStats::class => MockResponse::fixture('teams.getTeamStats'),
+    ]);
+
+    $response = $this->mattermost->teams()->getTeamStats(
+		teamId: 'test string'
+	);
+
+    Saloon::assertSent(GetTeamStats::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getTeamsForUser method in the Teams resource', function () {
+    Saloon::fake([
+        GetTeamsForUser::class => MockResponse::fixture('teams.getTeamsForUser'),
+    ]);
+
+    $response = $this->mattermost->teams()->getTeamsForUser(
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(GetTeamsForUser::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getTeamMembersForUser method in the Teams resource', function () {
+    Saloon::fake([
+        GetTeamMembersForUser::class => MockResponse::fixture('teams.getTeamMembersForUser'),
+    ]);
+
+    $response = $this->mattermost->teams()->getTeamMembersForUser(
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(GetTeamMembersForUser::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getTeamsUnreadForUser method in the Teams resource', function () {
+    Saloon::fake([
+        GetTeamsUnreadForUser::class => MockResponse::fixture('teams.getTeamsUnreadForUser'),
+    ]);
+
+    $response = $this->mattermost->teams()->getTeamsUnreadForUser(
+		userId: 'test string',
+		excludeTeam: 'test string',
+		includeCollapsedThreads: true
+	);
+
+    Saloon::assertSent(GetTeamsUnreadForUser::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getTeamUnread method in the Teams resource', function () {
+    Saloon::fake([
+        GetTeamUnread::class => MockResponse::fixture('teams.getTeamUnread'),
+    ]);
+
+    $response = $this->mattermost->teams()->getTeamUnread(
+		userId: 'test string',
+		teamId: 'test string'
+	);
+
+    Saloon::assertSent(GetTeamUnread::class);
+
+    expect($response->status())->toBe(200);
+});

--- a/src/Client/tests/TestCase.php
+++ b/src/Client/tests/TestCase.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace ConduitUI\Mattermost\Client;
+
+use Dotenv\Dotenv;
+use Orchestra\Testbench\TestCase as Orchestra;
+use Saloon\Laravel\SaloonServiceProvider;
+use Spatie\LaravelData\LaravelDataServiceProvider;
+use ConduitUI\Mattermost\Client\MattermostServiceProvider;
+
+class TestCase extends Orchestra
+{
+    protected function getPackageProviders($app)
+    {
+        return [
+            SaloonServiceProvider::class,
+            LaravelDataServiceProvider::class,
+            MattermostServiceProvider::class,
+        ];
+    }
+
+    public function getEnvironmentSetUp($app)
+    {
+        // Load .env.test into the environment.
+        if (file_exists(dirname(__DIR__).'/.env')) {
+            (Dotenv::createImmutable(dirname(__DIR__), '.env'))->load();
+        }
+
+        // todo: inject neccesary auth config
+    }
+}

--- a/src/Client/tests/ThreadsTest.php
+++ b/src/Client/tests/ThreadsTest.php
@@ -1,0 +1,163 @@
+<?php
+
+// Generated 2026-04-10 23:46:41
+
+use ConduitUI\Mattermost\Client\Requests\Threads\GetUserThreads;
+use ConduitUI\Mattermost\Client\Requests\Threads\GetThreadMentionCountsByChannel;
+use ConduitUI\Mattermost\Client\Requests\Threads\UpdateThreadsReadForUser;
+use ConduitUI\Mattermost\Client\Requests\Threads\GetUserThread;
+use ConduitUI\Mattermost\Client\Requests\Threads\StartFollowingThread;
+use ConduitUI\Mattermost\Client\Requests\Threads\StopFollowingThread;
+use ConduitUI\Mattermost\Client\Requests\Threads\UpdateThreadReadForUser;
+use ConduitUI\Mattermost\Client\Requests\Threads\SetThreadUnreadByPostId;
+use Saloon\Http\Faking\MockResponse;
+use Saloon\Laravel\Facades\Saloon;
+use Spatie\LaravelData\DataCollection;
+
+beforeEach(function () {
+    $this->mattermost = new ConduitUI\Mattermost\Client\Mattermost(
+		bearerToken: 'replace'
+	);
+});
+
+
+it('calls the getUserThreads method in the Threads resource', function () {
+    Saloon::fake([
+        GetUserThreads::class => MockResponse::fixture('threads.getUserThreads'),
+    ]);
+
+    $response = $this->mattermost->threads()->getUserThreads(
+		userId: 'test string',
+		teamId: 'test string',
+		since: 123,
+		deleted: true,
+		extended: true,
+		page: 123,
+		pageSize: 123,
+		totalsOnly: true,
+		threadsOnly: true
+	);
+
+    Saloon::assertSent(GetUserThreads::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getThreadMentionCountsByChannel method in the Threads resource', function () {
+    Saloon::fake([
+        GetThreadMentionCountsByChannel::class => MockResponse::fixture('threads.getThreadMentionCountsByChannel'),
+    ]);
+
+    $response = $this->mattermost->threads()->getThreadMentionCountsByChannel(
+		userId: 'test string',
+		teamId: 'test string'
+	);
+
+    Saloon::assertSent(GetThreadMentionCountsByChannel::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the updateThreadsReadForUser method in the Threads resource', function () {
+    Saloon::fake([
+        UpdateThreadsReadForUser::class => MockResponse::fixture('threads.updateThreadsReadForUser'),
+    ]);
+
+    $response = $this->mattermost->threads()->updateThreadsReadForUser(
+		userId: 'test string',
+		teamId: 'test string'
+	);
+
+    Saloon::assertSent(UpdateThreadsReadForUser::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getUserThread method in the Threads resource', function () {
+    Saloon::fake([
+        GetUserThread::class => MockResponse::fixture('threads.getUserThread'),
+    ]);
+
+    $response = $this->mattermost->threads()->getUserThread(
+		userId: 'test string',
+		teamId: 'test string',
+		threadId: 'test string'
+	);
+
+    Saloon::assertSent(GetUserThread::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the startFollowingThread method in the Threads resource', function () {
+    Saloon::fake([
+        StartFollowingThread::class => MockResponse::fixture('threads.startFollowingThread'),
+    ]);
+
+    $response = $this->mattermost->threads()->startFollowingThread(
+		userId: 'test string',
+		teamId: 'test string',
+		threadId: 'test string'
+	);
+
+    Saloon::assertSent(StartFollowingThread::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the stopFollowingThread method in the Threads resource', function () {
+    Saloon::fake([
+        StopFollowingThread::class => MockResponse::fixture('threads.stopFollowingThread'),
+    ]);
+
+    $response = $this->mattermost->threads()->stopFollowingThread(
+		userId: 'test string',
+		teamId: 'test string',
+		threadId: 'test string'
+	);
+
+    Saloon::assertSent(StopFollowingThread::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the updateThreadReadForUser method in the Threads resource', function () {
+    Saloon::fake([
+        UpdateThreadReadForUser::class => MockResponse::fixture('threads.updateThreadReadForUser'),
+    ]);
+
+    $response = $this->mattermost->threads()->updateThreadReadForUser(
+		userId: 'test string',
+		teamId: 'test string',
+		threadId: 'test string',
+		timestamp: 'test string'
+	);
+
+    Saloon::assertSent(UpdateThreadReadForUser::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the setThreadUnreadByPostId method in the Threads resource', function () {
+    Saloon::fake([
+        SetThreadUnreadByPostId::class => MockResponse::fixture('threads.setThreadUnreadByPostId'),
+    ]);
+
+    $response = $this->mattermost->threads()->setThreadUnreadByPostId(
+		userId: 'test string',
+		teamId: 'test string',
+		threadId: 'test string',
+		postId: 'test string'
+	);
+
+    Saloon::assertSent(SetThreadUnreadByPostId::class);
+
+    expect($response->status())->toBe(200);
+});

--- a/src/Client/tests/UsersTest.php
+++ b/src/Client/tests/UsersTest.php
@@ -1,0 +1,936 @@
+<?php
+
+// Generated 2026-04-10 23:46:41
+
+use ConduitUI\Mattermost\Client\Requests\Users\GetUsers;
+use ConduitUI\Mattermost\Client\Requests\Users\CreateUser;
+use ConduitUI\Mattermost\Client\Requests\Users\PermanentDeleteAllUsers;
+use ConduitUI\Mattermost\Client\Requests\Users\AutocompleteUsers;
+use ConduitUI\Mattermost\Client\Requests\Users\VerifyUserEmail;
+use ConduitUI\Mattermost\Client\Requests\Users\SendVerificationEmail;
+use ConduitUI\Mattermost\Client\Requests\Users\GetUserByEmail;
+use ConduitUI\Mattermost\Client\Requests\Users\GetUsersByGroupChannelIds;
+use ConduitUI\Mattermost\Client\Requests\Users\GetUsersByIds;
+use ConduitUI\Mattermost\Client\Requests\Users\GetKnownUsers;
+use ConduitUI\Mattermost\Client\Requests\Users\Login;
+use ConduitUI\Mattermost\Client\Requests\Users\LoginByCwsToken;
+use ConduitUI\Mattermost\Client\Requests\Users\SwitchAccountType;
+use ConduitUI\Mattermost\Client\Requests\Users\Logout;
+use ConduitUI\Mattermost\Client\Requests\Users\CheckUserMfa;
+use ConduitUI\Mattermost\Client\Requests\Users\MigrateAuthToLdap;
+use ConduitUI\Mattermost\Client\Requests\Users\MigrateAuthToSaml;
+use ConduitUI\Mattermost\Client\Requests\Users\ResetPassword;
+use ConduitUI\Mattermost\Client\Requests\Users\SendPasswordResetEmail;
+use ConduitUI\Mattermost\Client\Requests\Users\SearchUsers;
+use ConduitUI\Mattermost\Client\Requests\Users\AttachDeviceId;
+use ConduitUI\Mattermost\Client\Requests\Users\RevokeSessionsFromAllUsers;
+use ConduitUI\Mattermost\Client\Requests\Users\GetTotalUsersStats;
+use ConduitUI\Mattermost\Client\Requests\Users\GetTotalUsersStatsFiltered;
+use ConduitUI\Mattermost\Client\Requests\Users\GetUserAccessTokens;
+use ConduitUI\Mattermost\Client\Requests\Users\DisableUserAccessToken;
+use ConduitUI\Mattermost\Client\Requests\Users\EnableUserAccessToken;
+use ConduitUI\Mattermost\Client\Requests\Users\RevokeUserAccessToken;
+use ConduitUI\Mattermost\Client\Requests\Users\SearchUserAccessTokens;
+use ConduitUI\Mattermost\Client\Requests\Users\GetUserAccessToken;
+use ConduitUI\Mattermost\Client\Requests\Users\GetUserByUsername;
+use ConduitUI\Mattermost\Client\Requests\Users\GetUsersByUsernames;
+use ConduitUI\Mattermost\Client\Requests\Users\GetUser;
+use ConduitUI\Mattermost\Client\Requests\Users\UpdateUser;
+use ConduitUI\Mattermost\Client\Requests\Users\DeleteUser;
+use ConduitUI\Mattermost\Client\Requests\Users\UpdateUserActive;
+use ConduitUI\Mattermost\Client\Requests\Users\GetUserAudits;
+use ConduitUI\Mattermost\Client\Requests\Users\UpdateUserAuth;
+use ConduitUI\Mattermost\Client\Requests\Users\GetChannelMembersWithTeamDataForUser;
+use ConduitUI\Mattermost\Client\Requests\Users\DemoteUserToGuest;
+use ConduitUI\Mattermost\Client\Requests\Users\VerifyUserEmailWithoutToken;
+use ConduitUI\Mattermost\Client\Requests\Users\UpdateUserMfa;
+use ConduitUI\Mattermost\Client\Requests\Users\GenerateMfaSecret;
+use ConduitUI\Mattermost\Client\Requests\Users\UpdateUserPassword;
+use ConduitUI\Mattermost\Client\Requests\Users\PatchUser;
+use ConduitUI\Mattermost\Client\Requests\Users\PromoteGuestToUser;
+use ConduitUI\Mattermost\Client\Requests\Users\UpdateUserRoles;
+use ConduitUI\Mattermost\Client\Requests\Users\GetSessions;
+use ConduitUI\Mattermost\Client\Requests\Users\RevokeSession;
+use ConduitUI\Mattermost\Client\Requests\Users\RevokeAllSessions;
+use ConduitUI\Mattermost\Client\Requests\Users\GetUserTermsOfService;
+use ConduitUI\Mattermost\Client\Requests\Users\RegisterTermsOfServiceAction;
+use ConduitUI\Mattermost\Client\Requests\Users\GetUserAccessTokensForUser;
+use ConduitUI\Mattermost\Client\Requests\Users\CreateUserAccessToken;
+use ConduitUI\Mattermost\Client\Requests\Users\PublishUserTyping;
+use ConduitUI\Mattermost\Client\Requests\Users\GetUploadsForUser;
+use Saloon\Http\Faking\MockResponse;
+use Saloon\Laravel\Facades\Saloon;
+use Spatie\LaravelData\DataCollection;
+
+beforeEach(function () {
+    $this->mattermost = new ConduitUI\Mattermost\Client\Mattermost(
+		bearerToken: 'replace'
+	);
+});
+
+
+it('calls the getUsers method in the Users resource', function () {
+    Saloon::fake([
+        GetUsers::class => MockResponse::fixture('users.getUsers'),
+    ]);
+
+    $response = $this->mattermost->users()->getUsers(
+		page: 123,
+		inTeam: 'test string',
+		notInTeam: 'test string',
+		inChannel: 'test string',
+		notInChannel: 'test string',
+		inGroup: 'test string',
+		groupConstrained: true,
+		withoutTeam: true,
+		active: true,
+		inactive: true,
+		role: 'test string',
+		sort: 'test string',
+		roles: 'test string',
+		channelRoles: 'test string',
+		teamRoles: 'test string'
+	);
+
+    Saloon::assertSent(GetUsers::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the createUser method in the Users resource', function () {
+    Saloon::fake([
+        CreateUser::class => MockResponse::fixture('users.createUser'),
+    ]);
+
+    $response = $this->mattermost->users()->createUser(
+		t: 'test string',
+		iid: 'test string'
+	);
+
+    Saloon::assertSent(CreateUser::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the permanentDeleteAllUsers method in the Users resource', function () {
+    Saloon::fake([
+        PermanentDeleteAllUsers::class => MockResponse::fixture('users.permanentDeleteAllUsers'),
+    ]);
+
+    $response = $this->mattermost->users()->permanentDeleteAllUsers(
+		
+	);
+
+    Saloon::assertSent(PermanentDeleteAllUsers::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the autocompleteUsers method in the Users resource', function () {
+    Saloon::fake([
+        AutocompleteUsers::class => MockResponse::fixture('users.autocompleteUsers'),
+    ]);
+
+    $response = $this->mattermost->users()->autocompleteUsers(
+		teamId: 'test string',
+		channelId: 'test string',
+		name: 'test string',
+		limit: 123
+	);
+
+    Saloon::assertSent(AutocompleteUsers::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the verifyUserEmail method in the Users resource', function () {
+    Saloon::fake([
+        VerifyUserEmail::class => MockResponse::fixture('users.verifyUserEmail'),
+    ]);
+
+    $response = $this->mattermost->users()->verifyUserEmail(
+		
+	);
+
+    Saloon::assertSent(VerifyUserEmail::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the sendVerificationEmail method in the Users resource', function () {
+    Saloon::fake([
+        SendVerificationEmail::class => MockResponse::fixture('users.sendVerificationEmail'),
+    ]);
+
+    $response = $this->mattermost->users()->sendVerificationEmail(
+		
+	);
+
+    Saloon::assertSent(SendVerificationEmail::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getUserByEmail method in the Users resource', function () {
+    Saloon::fake([
+        GetUserByEmail::class => MockResponse::fixture('users.getUserByEmail'),
+    ]);
+
+    $response = $this->mattermost->users()->getUserByEmail(
+		email: 'test string'
+	);
+
+    Saloon::assertSent(GetUserByEmail::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getUsersByGroupChannelIds method in the Users resource', function () {
+    Saloon::fake([
+        GetUsersByGroupChannelIds::class => MockResponse::fixture('users.getUsersByGroupChannelIds'),
+    ]);
+
+    $response = $this->mattermost->users()->getUsersByGroupChannelIds(
+		
+	);
+
+    Saloon::assertSent(GetUsersByGroupChannelIds::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getUsersByIds method in the Users resource', function () {
+    Saloon::fake([
+        GetUsersByIds::class => MockResponse::fixture('users.getUsersByIds'),
+    ]);
+
+    $response = $this->mattermost->users()->getUsersByIds(
+		since: 123
+	);
+
+    Saloon::assertSent(GetUsersByIds::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getKnownUsers method in the Users resource', function () {
+    Saloon::fake([
+        GetKnownUsers::class => MockResponse::fixture('users.getKnownUsers'),
+    ]);
+
+    $response = $this->mattermost->users()->getKnownUsers(
+		
+	);
+
+    Saloon::assertSent(GetKnownUsers::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the login method in the Users resource', function () {
+    Saloon::fake([
+        Login::class => MockResponse::fixture('users.login'),
+    ]);
+
+    $response = $this->mattermost->users()->login(
+		
+	);
+
+    Saloon::assertSent(Login::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the loginByCwsToken method in the Users resource', function () {
+    Saloon::fake([
+        LoginByCwsToken::class => MockResponse::fixture('users.loginByCwsToken'),
+    ]);
+
+    $response = $this->mattermost->users()->loginByCwsToken(
+		
+	);
+
+    Saloon::assertSent(LoginByCwsToken::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the switchAccountType method in the Users resource', function () {
+    Saloon::fake([
+        SwitchAccountType::class => MockResponse::fixture('users.switchAccountType'),
+    ]);
+
+    $response = $this->mattermost->users()->switchAccountType(
+		
+	);
+
+    Saloon::assertSent(SwitchAccountType::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the logout method in the Users resource', function () {
+    Saloon::fake([
+        Logout::class => MockResponse::fixture('users.logout'),
+    ]);
+
+    $response = $this->mattermost->users()->logout(
+		
+	);
+
+    Saloon::assertSent(Logout::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the checkUserMfa method in the Users resource', function () {
+    Saloon::fake([
+        CheckUserMfa::class => MockResponse::fixture('users.checkUserMfa'),
+    ]);
+
+    $response = $this->mattermost->users()->checkUserMfa(
+		
+	);
+
+    Saloon::assertSent(CheckUserMfa::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the migrateAuthToLdap method in the Users resource', function () {
+    Saloon::fake([
+        MigrateAuthToLdap::class => MockResponse::fixture('users.migrateAuthToLdap'),
+    ]);
+
+    $response = $this->mattermost->users()->migrateAuthToLdap(
+		
+	);
+
+    Saloon::assertSent(MigrateAuthToLdap::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the migrateAuthToSaml method in the Users resource', function () {
+    Saloon::fake([
+        MigrateAuthToSaml::class => MockResponse::fixture('users.migrateAuthToSaml'),
+    ]);
+
+    $response = $this->mattermost->users()->migrateAuthToSaml(
+		
+	);
+
+    Saloon::assertSent(MigrateAuthToSaml::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the resetPassword method in the Users resource', function () {
+    Saloon::fake([
+        ResetPassword::class => MockResponse::fixture('users.resetPassword'),
+    ]);
+
+    $response = $this->mattermost->users()->resetPassword(
+		
+	);
+
+    Saloon::assertSent(ResetPassword::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the sendPasswordResetEmail method in the Users resource', function () {
+    Saloon::fake([
+        SendPasswordResetEmail::class => MockResponse::fixture('users.sendPasswordResetEmail'),
+    ]);
+
+    $response = $this->mattermost->users()->sendPasswordResetEmail(
+		
+	);
+
+    Saloon::assertSent(SendPasswordResetEmail::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the searchUsers method in the Users resource', function () {
+    Saloon::fake([
+        SearchUsers::class => MockResponse::fixture('users.searchUsers'),
+    ]);
+
+    $response = $this->mattermost->users()->searchUsers(
+		
+	);
+
+    Saloon::assertSent(SearchUsers::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the attachDeviceId method in the Users resource', function () {
+    Saloon::fake([
+        AttachDeviceId::class => MockResponse::fixture('users.attachDeviceId'),
+    ]);
+
+    $response = $this->mattermost->users()->attachDeviceId(
+		
+	);
+
+    Saloon::assertSent(AttachDeviceId::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the revokeSessionsFromAllUsers method in the Users resource', function () {
+    Saloon::fake([
+        RevokeSessionsFromAllUsers::class => MockResponse::fixture('users.revokeSessionsFromAllUsers'),
+    ]);
+
+    $response = $this->mattermost->users()->revokeSessionsFromAllUsers(
+		
+	);
+
+    Saloon::assertSent(RevokeSessionsFromAllUsers::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getTotalUsersStats method in the Users resource', function () {
+    Saloon::fake([
+        GetTotalUsersStats::class => MockResponse::fixture('users.getTotalUsersStats'),
+    ]);
+
+    $response = $this->mattermost->users()->getTotalUsersStats(
+		
+	);
+
+    Saloon::assertSent(GetTotalUsersStats::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getTotalUsersStatsFiltered method in the Users resource', function () {
+    Saloon::fake([
+        GetTotalUsersStatsFiltered::class => MockResponse::fixture('users.getTotalUsersStatsFiltered'),
+    ]);
+
+    $response = $this->mattermost->users()->getTotalUsersStatsFiltered(
+		inTeam: 'test string',
+		inChannel: 'test string',
+		includeDeleted: true,
+		includeBots: true,
+		roles: 'test string',
+		channelRoles: 'test string',
+		teamRoles: 'test string'
+	);
+
+    Saloon::assertSent(GetTotalUsersStatsFiltered::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getUserAccessTokens method in the Users resource', function () {
+    Saloon::fake([
+        GetUserAccessTokens::class => MockResponse::fixture('users.getUserAccessTokens'),
+    ]);
+
+    $response = $this->mattermost->users()->getUserAccessTokens(
+		page: 123
+	);
+
+    Saloon::assertSent(GetUserAccessTokens::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the disableUserAccessToken method in the Users resource', function () {
+    Saloon::fake([
+        DisableUserAccessToken::class => MockResponse::fixture('users.disableUserAccessToken'),
+    ]);
+
+    $response = $this->mattermost->users()->disableUserAccessToken(
+		
+	);
+
+    Saloon::assertSent(DisableUserAccessToken::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the enableUserAccessToken method in the Users resource', function () {
+    Saloon::fake([
+        EnableUserAccessToken::class => MockResponse::fixture('users.enableUserAccessToken'),
+    ]);
+
+    $response = $this->mattermost->users()->enableUserAccessToken(
+		
+	);
+
+    Saloon::assertSent(EnableUserAccessToken::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the revokeUserAccessToken method in the Users resource', function () {
+    Saloon::fake([
+        RevokeUserAccessToken::class => MockResponse::fixture('users.revokeUserAccessToken'),
+    ]);
+
+    $response = $this->mattermost->users()->revokeUserAccessToken(
+		
+	);
+
+    Saloon::assertSent(RevokeUserAccessToken::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the searchUserAccessTokens method in the Users resource', function () {
+    Saloon::fake([
+        SearchUserAccessTokens::class => MockResponse::fixture('users.searchUserAccessTokens'),
+    ]);
+
+    $response = $this->mattermost->users()->searchUserAccessTokens(
+		
+	);
+
+    Saloon::assertSent(SearchUserAccessTokens::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getUserAccessToken method in the Users resource', function () {
+    Saloon::fake([
+        GetUserAccessToken::class => MockResponse::fixture('users.getUserAccessToken'),
+    ]);
+
+    $response = $this->mattermost->users()->getUserAccessToken(
+		tokenId: 'test string'
+	);
+
+    Saloon::assertSent(GetUserAccessToken::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getUserByUsername method in the Users resource', function () {
+    Saloon::fake([
+        GetUserByUsername::class => MockResponse::fixture('users.getUserByUsername'),
+    ]);
+
+    $response = $this->mattermost->users()->getUserByUsername(
+		username: 'test string'
+	);
+
+    Saloon::assertSent(GetUserByUsername::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getUsersByUsernames method in the Users resource', function () {
+    Saloon::fake([
+        GetUsersByUsernames::class => MockResponse::fixture('users.getUsersByUsernames'),
+    ]);
+
+    $response = $this->mattermost->users()->getUsersByUsernames(
+		
+	);
+
+    Saloon::assertSent(GetUsersByUsernames::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getUser method in the Users resource', function () {
+    Saloon::fake([
+        GetUser::class => MockResponse::fixture('users.getUser'),
+    ]);
+
+    $response = $this->mattermost->users()->getUser(
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(GetUser::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the updateUser method in the Users resource', function () {
+    Saloon::fake([
+        UpdateUser::class => MockResponse::fixture('users.updateUser'),
+    ]);
+
+    $response = $this->mattermost->users()->updateUser(
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(UpdateUser::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the deleteUser method in the Users resource', function () {
+    Saloon::fake([
+        DeleteUser::class => MockResponse::fixture('users.deleteUser'),
+    ]);
+
+    $response = $this->mattermost->users()->deleteUser(
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(DeleteUser::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the updateUserActive method in the Users resource', function () {
+    Saloon::fake([
+        UpdateUserActive::class => MockResponse::fixture('users.updateUserActive'),
+    ]);
+
+    $response = $this->mattermost->users()->updateUserActive(
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(UpdateUserActive::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getUserAudits method in the Users resource', function () {
+    Saloon::fake([
+        GetUserAudits::class => MockResponse::fixture('users.getUserAudits'),
+    ]);
+
+    $response = $this->mattermost->users()->getUserAudits(
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(GetUserAudits::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the updateUserAuth method in the Users resource', function () {
+    Saloon::fake([
+        UpdateUserAuth::class => MockResponse::fixture('users.updateUserAuth'),
+    ]);
+
+    $response = $this->mattermost->users()->updateUserAuth(
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(UpdateUserAuth::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getChannelMembersWithTeamDataForUser method in the Users resource', function () {
+    Saloon::fake([
+        GetChannelMembersWithTeamDataForUser::class => MockResponse::fixture('users.getChannelMembersWithTeamDataForUser'),
+    ]);
+
+    $response = $this->mattermost->users()->getChannelMembersWithTeamDataForUser(
+		userId: 'test string',
+		page: 123,
+		pageSize: 123
+	);
+
+    Saloon::assertSent(GetChannelMembersWithTeamDataForUser::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the demoteUserToGuest method in the Users resource', function () {
+    Saloon::fake([
+        DemoteUserToGuest::class => MockResponse::fixture('users.demoteUserToGuest'),
+    ]);
+
+    $response = $this->mattermost->users()->demoteUserToGuest(
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(DemoteUserToGuest::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the verifyUserEmailWithoutToken method in the Users resource', function () {
+    Saloon::fake([
+        VerifyUserEmailWithoutToken::class => MockResponse::fixture('users.verifyUserEmailWithoutToken'),
+    ]);
+
+    $response = $this->mattermost->users()->verifyUserEmailWithoutToken(
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(VerifyUserEmailWithoutToken::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the updateUserMfa method in the Users resource', function () {
+    Saloon::fake([
+        UpdateUserMfa::class => MockResponse::fixture('users.updateUserMfa'),
+    ]);
+
+    $response = $this->mattermost->users()->updateUserMfa(
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(UpdateUserMfa::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the generateMfaSecret method in the Users resource', function () {
+    Saloon::fake([
+        GenerateMfaSecret::class => MockResponse::fixture('users.generateMfaSecret'),
+    ]);
+
+    $response = $this->mattermost->users()->generateMfaSecret(
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(GenerateMfaSecret::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the updateUserPassword method in the Users resource', function () {
+    Saloon::fake([
+        UpdateUserPassword::class => MockResponse::fixture('users.updateUserPassword'),
+    ]);
+
+    $response = $this->mattermost->users()->updateUserPassword(
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(UpdateUserPassword::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the patchUser method in the Users resource', function () {
+    Saloon::fake([
+        PatchUser::class => MockResponse::fixture('users.patchUser'),
+    ]);
+
+    $response = $this->mattermost->users()->patchUser(
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(PatchUser::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the promoteGuestToUser method in the Users resource', function () {
+    Saloon::fake([
+        PromoteGuestToUser::class => MockResponse::fixture('users.promoteGuestToUser'),
+    ]);
+
+    $response = $this->mattermost->users()->promoteGuestToUser(
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(PromoteGuestToUser::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the updateUserRoles method in the Users resource', function () {
+    Saloon::fake([
+        UpdateUserRoles::class => MockResponse::fixture('users.updateUserRoles'),
+    ]);
+
+    $response = $this->mattermost->users()->updateUserRoles(
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(UpdateUserRoles::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getSessions method in the Users resource', function () {
+    Saloon::fake([
+        GetSessions::class => MockResponse::fixture('users.getSessions'),
+    ]);
+
+    $response = $this->mattermost->users()->getSessions(
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(GetSessions::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the revokeSession method in the Users resource', function () {
+    Saloon::fake([
+        RevokeSession::class => MockResponse::fixture('users.revokeSession'),
+    ]);
+
+    $response = $this->mattermost->users()->revokeSession(
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(RevokeSession::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the revokeAllSessions method in the Users resource', function () {
+    Saloon::fake([
+        RevokeAllSessions::class => MockResponse::fixture('users.revokeAllSessions'),
+    ]);
+
+    $response = $this->mattermost->users()->revokeAllSessions(
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(RevokeAllSessions::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getUserTermsOfService method in the Users resource', function () {
+    Saloon::fake([
+        GetUserTermsOfService::class => MockResponse::fixture('users.getUserTermsOfService'),
+    ]);
+
+    $response = $this->mattermost->users()->getUserTermsOfService(
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(GetUserTermsOfService::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the registerTermsOfServiceAction method in the Users resource', function () {
+    Saloon::fake([
+        RegisterTermsOfServiceAction::class => MockResponse::fixture('users.registerTermsOfServiceAction'),
+    ]);
+
+    $response = $this->mattermost->users()->registerTermsOfServiceAction(
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(RegisterTermsOfServiceAction::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getUserAccessTokensForUser method in the Users resource', function () {
+    Saloon::fake([
+        GetUserAccessTokensForUser::class => MockResponse::fixture('users.getUserAccessTokensForUser'),
+    ]);
+
+    $response = $this->mattermost->users()->getUserAccessTokensForUser(
+		userId: 'test string',
+		page: 123
+	);
+
+    Saloon::assertSent(GetUserAccessTokensForUser::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the createUserAccessToken method in the Users resource', function () {
+    Saloon::fake([
+        CreateUserAccessToken::class => MockResponse::fixture('users.createUserAccessToken'),
+    ]);
+
+    $response = $this->mattermost->users()->createUserAccessToken(
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(CreateUserAccessToken::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the publishUserTyping method in the Users resource', function () {
+    Saloon::fake([
+        PublishUserTyping::class => MockResponse::fixture('users.publishUserTyping'),
+    ]);
+
+    $response = $this->mattermost->users()->publishUserTyping(
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(PublishUserTyping::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getUploadsForUser method in the Users resource', function () {
+    Saloon::fake([
+        GetUploadsForUser::class => MockResponse::fixture('users.getUploadsForUser'),
+    ]);
+
+    $response = $this->mattermost->users()->getUploadsForUser(
+		userId: 'test string'
+	);
+
+    Saloon::assertSent(GetUploadsForUser::class);
+
+    expect($response->status())->toBe(200);
+});

--- a/src/Client/tests/WebhooksTest.php
+++ b/src/Client/tests/WebhooksTest.php
@@ -1,0 +1,192 @@
+<?php
+
+// Generated 2026-04-10 23:46:41
+
+use ConduitUI\Mattermost\Client\Requests\Webhooks\GetIncomingWebhooks;
+use ConduitUI\Mattermost\Client\Requests\Webhooks\CreateIncomingWebhook;
+use ConduitUI\Mattermost\Client\Requests\Webhooks\GetIncomingWebhook;
+use ConduitUI\Mattermost\Client\Requests\Webhooks\UpdateIncomingWebhook;
+use ConduitUI\Mattermost\Client\Requests\Webhooks\DeleteIncomingWebhook;
+use ConduitUI\Mattermost\Client\Requests\Webhooks\GetOutgoingWebhooks;
+use ConduitUI\Mattermost\Client\Requests\Webhooks\CreateOutgoingWebhook;
+use ConduitUI\Mattermost\Client\Requests\Webhooks\GetOutgoingWebhook;
+use ConduitUI\Mattermost\Client\Requests\Webhooks\UpdateOutgoingWebhook;
+use ConduitUI\Mattermost\Client\Requests\Webhooks\DeleteOutgoingWebhook;
+use ConduitUI\Mattermost\Client\Requests\Webhooks\RegenOutgoingHookToken;
+use Saloon\Http\Faking\MockResponse;
+use Saloon\Laravel\Facades\Saloon;
+use Spatie\LaravelData\DataCollection;
+
+beforeEach(function () {
+    $this->mattermost = new ConduitUI\Mattermost\Client\Mattermost(
+		bearerToken: 'replace'
+	);
+});
+
+
+it('calls the getIncomingWebhooks method in the Webhooks resource', function () {
+    Saloon::fake([
+        GetIncomingWebhooks::class => MockResponse::fixture('webhooks.getIncomingWebhooks'),
+    ]);
+
+    $response = $this->mattermost->webhooks()->getIncomingWebhooks(
+		page: 123,
+		teamId: 'test string'
+	);
+
+    Saloon::assertSent(GetIncomingWebhooks::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the createIncomingWebhook method in the Webhooks resource', function () {
+    Saloon::fake([
+        CreateIncomingWebhook::class => MockResponse::fixture('webhooks.createIncomingWebhook'),
+    ]);
+
+    $response = $this->mattermost->webhooks()->createIncomingWebhook(
+		
+	);
+
+    Saloon::assertSent(CreateIncomingWebhook::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getIncomingWebhook method in the Webhooks resource', function () {
+    Saloon::fake([
+        GetIncomingWebhook::class => MockResponse::fixture('webhooks.getIncomingWebhook'),
+    ]);
+
+    $response = $this->mattermost->webhooks()->getIncomingWebhook(
+		hookId: 'test string'
+	);
+
+    Saloon::assertSent(GetIncomingWebhook::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the updateIncomingWebhook method in the Webhooks resource', function () {
+    Saloon::fake([
+        UpdateIncomingWebhook::class => MockResponse::fixture('webhooks.updateIncomingWebhook'),
+    ]);
+
+    $response = $this->mattermost->webhooks()->updateIncomingWebhook(
+		hookId: 'test string'
+	);
+
+    Saloon::assertSent(UpdateIncomingWebhook::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the deleteIncomingWebhook method in the Webhooks resource', function () {
+    Saloon::fake([
+        DeleteIncomingWebhook::class => MockResponse::fixture('webhooks.deleteIncomingWebhook'),
+    ]);
+
+    $response = $this->mattermost->webhooks()->deleteIncomingWebhook(
+		hookId: 'test string'
+	);
+
+    Saloon::assertSent(DeleteIncomingWebhook::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getOutgoingWebhooks method in the Webhooks resource', function () {
+    Saloon::fake([
+        GetOutgoingWebhooks::class => MockResponse::fixture('webhooks.getOutgoingWebhooks'),
+    ]);
+
+    $response = $this->mattermost->webhooks()->getOutgoingWebhooks(
+		page: 123,
+		teamId: 'test string',
+		channelId: 'test string'
+	);
+
+    Saloon::assertSent(GetOutgoingWebhooks::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the createOutgoingWebhook method in the Webhooks resource', function () {
+    Saloon::fake([
+        CreateOutgoingWebhook::class => MockResponse::fixture('webhooks.createOutgoingWebhook'),
+    ]);
+
+    $response = $this->mattermost->webhooks()->createOutgoingWebhook(
+		
+	);
+
+    Saloon::assertSent(CreateOutgoingWebhook::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the getOutgoingWebhook method in the Webhooks resource', function () {
+    Saloon::fake([
+        GetOutgoingWebhook::class => MockResponse::fixture('webhooks.getOutgoingWebhook'),
+    ]);
+
+    $response = $this->mattermost->webhooks()->getOutgoingWebhook(
+		hookId: 'test string'
+	);
+
+    Saloon::assertSent(GetOutgoingWebhook::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the updateOutgoingWebhook method in the Webhooks resource', function () {
+    Saloon::fake([
+        UpdateOutgoingWebhook::class => MockResponse::fixture('webhooks.updateOutgoingWebhook'),
+    ]);
+
+    $response = $this->mattermost->webhooks()->updateOutgoingWebhook(
+		hookId: 'test string'
+	);
+
+    Saloon::assertSent(UpdateOutgoingWebhook::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the deleteOutgoingWebhook method in the Webhooks resource', function () {
+    Saloon::fake([
+        DeleteOutgoingWebhook::class => MockResponse::fixture('webhooks.deleteOutgoingWebhook'),
+    ]);
+
+    $response = $this->mattermost->webhooks()->deleteOutgoingWebhook(
+		hookId: 'test string'
+	);
+
+    Saloon::assertSent(DeleteOutgoingWebhook::class);
+
+    expect($response->status())->toBe(200);
+});
+
+
+it('calls the regenOutgoingHookToken method in the Webhooks resource', function () {
+    Saloon::fake([
+        RegenOutgoingHookToken::class => MockResponse::fixture('webhooks.regenOutgoingHookToken'),
+    ]);
+
+    $response = $this->mattermost->webhooks()->regenOutgoingHookToken(
+		hookId: 'test string'
+	);
+
+    Saloon::assertSent(RegenOutgoingHookToken::class);
+
+    expect($response->status())->toBe(200);
+});


### PR DESCRIPTION
## Summary

Full Mattermost API v4 client auto-generated from the official OpenAPI specification.

**Generated:**
- 252 typed Saloon request classes
- 161 DTOs (data transfer objects)
- 18 resource classes (Bots, Channels, Commands, Posts, Files, Users, Teams, etc.)
- 20 Pest test files

**How it was generated:**
1. Built the spec from `mattermost/mattermost-api-reference` source YAMLs
2. Ran `crescat-io/saloon-sdk-generator` with `--pest` flag
3. Excluded 3 image upload endpoints (generator bug with unnamed file params)

**What's next:**
- Wire the connector into MattermostServiceProvider
- Add named connection support
- Add channel/user name-to-ID resolution with caching
- Clean up generated code (pint, phpstan)

Closes #1