### PR TITLE
feat: Laravel service provider + facade + named connections

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,4 +5,8 @@ parameters:
     paths:
         - src/
 
-    level: 8
+    level: 6
+
+    excludePaths:
+        - src/Client/Dto/
+        - src/Client/tests/

--- a/src/Client/Dto/AddOn.php
+++ b/src/Client/Dto/AddOn.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,13 +9,12 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class AddOn extends SpatieData
 {
-	public function __construct(
-		#[MapName('display_name')]
-		public ?string $displayName = null,
-		public ?string $id = null,
-		public ?string $name = null,
-		#[MapName('price_per_seat')]
-		public ?string $pricePerSeat = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('display_name')]
+        public ?string $displayName = null,
+        public ?string $id = null,
+        public ?string $name = null,
+        #[MapName('price_per_seat')]
+        public ?string $pricePerSeat = null,
+    ) {}
 }

--- a/src/Client/Dto/Address.php
+++ b/src/Client/Dto/Address.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,14 +9,13 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class Address extends SpatieData
 {
-	public function __construct(
-		public ?string $city = null,
-		public ?string $country = null,
-		public ?string $line1 = null,
-		public ?string $line2 = null,
-		#[MapName('postal_code')]
-		public ?string $postalCode = null,
-		public ?string $state = null,
-	) {
-	}
+    public function __construct(
+        public ?string $city = null,
+        public ?string $country = null,
+        public ?string $line1 = null,
+        public ?string $line2 = null,
+        #[MapName('postal_code')]
+        public ?string $postalCode = null,
+        public ?string $state = null,
+    ) {}
 }

--- a/src/Client/Dto/AnalyticsSettings.php
+++ b/src/Client/Dto/AnalyticsSettings.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,9 +9,8 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class AnalyticsSettings extends SpatieData
 {
-	public function __construct(
-		#[MapName('MaxUsersForStatistics')]
-		public ?int $maxUsersForStatistics = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('MaxUsersForStatistics')]
+        public ?int $maxUsersForStatistics = null,
+    ) {}
 }

--- a/src/Client/Dto/AppError.php
+++ b/src/Client/Dto/AppError.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,13 +9,12 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class AppError extends SpatieData
 {
-	public function __construct(
-		public ?string $id = null,
-		public ?string $message = null,
-		#[MapName('request_id')]
-		public ?string $requestId = null,
-		#[MapName('status_code')]
-		public ?int $statusCode = null,
-	) {
-	}
+    public function __construct(
+        public ?string $id = null,
+        public ?string $message = null,
+        #[MapName('request_id')]
+        public ?string $requestId = null,
+        #[MapName('status_code')]
+        public ?int $statusCode = null,
+    ) {}
 }

--- a/src/Client/Dto/Audit.php
+++ b/src/Client/Dto/Audit.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,19 +9,18 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class Audit extends SpatieData
 {
-	public function __construct(
-		public ?string $action = null,
-		#[MapName('create_at')]
-		public ?int $createAt = null,
-		#[MapName('extra_info')]
-		public ?string $extraInfo = null,
-		public ?string $id = null,
-		#[MapName('ip_address')]
-		public ?string $ipAddress = null,
-		#[MapName('session_id')]
-		public ?string $sessionId = null,
-		#[MapName('user_id')]
-		public ?string $userId = null,
-	) {
-	}
+    public function __construct(
+        public ?string $action = null,
+        #[MapName('create_at')]
+        public ?int $createAt = null,
+        #[MapName('extra_info')]
+        public ?string $extraInfo = null,
+        public ?string $id = null,
+        #[MapName('ip_address')]
+        public ?string $ipAddress = null,
+        #[MapName('session_id')]
+        public ?string $sessionId = null,
+        #[MapName('user_id')]
+        public ?string $userId = null,
+    ) {}
 }

--- a/src/Client/Dto/AutocompleteSuggestion.php
+++ b/src/Client/Dto/AutocompleteSuggestion.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,17 +9,16 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class AutocompleteSuggestion extends SpatieData
 {
-	public function __construct(
-		#[MapName('Complete')]
-		public ?string $complete = null,
-		#[MapName('Description')]
-		public ?string $description = null,
-		#[MapName('Hint')]
-		public ?string $hint = null,
-		#[MapName('IconData')]
-		public ?string $iconData = null,
-		#[MapName('Suggestion')]
-		public ?string $suggestion = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('Complete')]
+        public ?string $complete = null,
+        #[MapName('Description')]
+        public ?string $description = null,
+        #[MapName('Hint')]
+        public ?string $hint = null,
+        #[MapName('IconData')]
+        public ?string $iconData = null,
+        #[MapName('Suggestion')]
+        public ?string $suggestion = null,
+    ) {}
 }

--- a/src/Client/Dto/BoardsLimits.php
+++ b/src/Client/Dto/BoardsLimits.php
@@ -1,14 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Data as SpatieData;
 
 class BoardsLimits extends SpatieData
 {
-	public function __construct(
-		public ?int $cards = null,
-		public ?int $views = null,
-	) {
-	}
+    public function __construct(
+        public ?int $cards = null,
+        public ?int $views = null,
+    ) {}
 }

--- a/src/Client/Dto/Bot.php
+++ b/src/Client/Dto/Bot.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -10,21 +12,20 @@ use Spatie\LaravelData\Data as SpatieData;
  */
 class Bot extends SpatieData
 {
-	public function __construct(
-		#[MapName('create_at')]
-		public ?int $createAt = null,
-		#[MapName('delete_at')]
-		public ?int $deleteAt = null,
-		public ?string $description = null,
-		#[MapName('display_name')]
-		public ?string $displayName = null,
-		#[MapName('owner_id')]
-		public ?string $ownerId = null,
-		#[MapName('update_at')]
-		public ?int $updateAt = null,
-		#[MapName('user_id')]
-		public ?string $userId = null,
-		public ?string $username = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('create_at')]
+        public ?int $createAt = null,
+        #[MapName('delete_at')]
+        public ?int $deleteAt = null,
+        public ?string $description = null,
+        #[MapName('display_name')]
+        public ?string $displayName = null,
+        #[MapName('owner_id')]
+        public ?string $ownerId = null,
+        #[MapName('update_at')]
+        public ?int $updateAt = null,
+        #[MapName('user_id')]
+        public ?string $userId = null,
+        public ?string $username = null,
+    ) {}
 }

--- a/src/Client/Dto/Channel.php
+++ b/src/Client/Dto/Channel.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,30 +9,29 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class Channel extends SpatieData
 {
-	public function __construct(
-		#[MapName('create_at')]
-		public ?int $createAt = null,
-		#[MapName('creator_id')]
-		public ?string $creatorId = null,
-		#[MapName('delete_at')]
-		public ?int $deleteAt = null,
-		#[MapName('display_name')]
-		public ?string $displayName = null,
-		#[MapName('extra_update_at')]
-		public ?int $extraUpdateAt = null,
-		public ?string $header = null,
-		public ?string $id = null,
-		#[MapName('last_post_at')]
-		public ?int $lastPostAt = null,
-		public ?string $name = null,
-		public ?string $purpose = null,
-		#[MapName('team_id')]
-		public ?string $teamId = null,
-		#[MapName('total_msg_count')]
-		public ?int $totalMsgCount = null,
-		public ?string $type = null,
-		#[MapName('update_at')]
-		public ?int $updateAt = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('create_at')]
+        public ?int $createAt = null,
+        #[MapName('creator_id')]
+        public ?string $creatorId = null,
+        #[MapName('delete_at')]
+        public ?int $deleteAt = null,
+        #[MapName('display_name')]
+        public ?string $displayName = null,
+        #[MapName('extra_update_at')]
+        public ?int $extraUpdateAt = null,
+        public ?string $header = null,
+        public ?string $id = null,
+        #[MapName('last_post_at')]
+        public ?int $lastPostAt = null,
+        public ?string $name = null,
+        public ?string $purpose = null,
+        #[MapName('team_id')]
+        public ?string $teamId = null,
+        #[MapName('total_msg_count')]
+        public ?int $totalMsgCount = null,
+        public ?string $type = null,
+        #[MapName('update_at')]
+        public ?int $updateAt = null,
+    ) {}
 }

--- a/src/Client/Dto/ChannelData.php
+++ b/src/Client/Dto/ChannelData.php
@@ -1,14 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Data as SpatieData;
 
 class ChannelData extends SpatieData
 {
-	public function __construct(
-		public ?Channel $channel = null,
-		public ?ChannelMember $member = null,
-	) {
-	}
+    public function __construct(
+        public ?Channel $channel = null,
+        public ?ChannelMember $member = null,
+    ) {}
 }

--- a/src/Client/Dto/ChannelListWithTeamData.php
+++ b/src/Client/Dto/ChannelListWithTeamData.php
@@ -1,12 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Data as SpatieData;
 
-class ChannelListWithTeamData extends SpatieData
-{
-	public function __construct()
-	{
-	}
-}
+class ChannelListWithTeamData extends SpatieData {}

--- a/src/Client/Dto/ChannelMember.php
+++ b/src/Client/Dto/ChannelMember.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,22 +9,21 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class ChannelMember extends SpatieData
 {
-	public function __construct(
-		#[MapName('channel_id')]
-		public ?string $channelId = null,
-		#[MapName('last_update_at')]
-		public ?int $lastUpdateAt = null,
-		#[MapName('last_viewed_at')]
-		public ?int $lastViewedAt = null,
-		#[MapName('mention_count')]
-		public ?int $mentionCount = null,
-		#[MapName('msg_count')]
-		public ?int $msgCount = null,
-		#[MapName('notify_props')]
-		public ?ChannelNotifyProps $notifyProps = null,
-		public ?string $roles = null,
-		#[MapName('user_id')]
-		public ?string $userId = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('channel_id')]
+        public ?string $channelId = null,
+        #[MapName('last_update_at')]
+        public ?int $lastUpdateAt = null,
+        #[MapName('last_viewed_at')]
+        public ?int $lastViewedAt = null,
+        #[MapName('mention_count')]
+        public ?int $mentionCount = null,
+        #[MapName('msg_count')]
+        public ?int $msgCount = null,
+        #[MapName('notify_props')]
+        public ?ChannelNotifyProps $notifyProps = null,
+        public ?string $roles = null,
+        #[MapName('user_id')]
+        public ?string $userId = null,
+    ) {}
 }

--- a/src/Client/Dto/ChannelMemberCountByGroup.php
+++ b/src/Client/Dto/ChannelMemberCountByGroup.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -10,13 +12,12 @@ use Spatie\LaravelData\Data as SpatieData;
  */
 class ChannelMemberCountByGroup extends SpatieData
 {
-	public function __construct(
-		#[MapName('channel_member_count')]
-		public int|float|null $channelMemberCount = null,
-		#[MapName('channel_member_timezones_count')]
-		public int|float|null $channelMemberTimezonesCount = null,
-		#[MapName('group_id')]
-		public ?string $groupId = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('channel_member_count')]
+        public int|float|null $channelMemberCount = null,
+        #[MapName('channel_member_timezones_count')]
+        public int|float|null $channelMemberTimezonesCount = null,
+        #[MapName('group_id')]
+        public ?string $groupId = null,
+    ) {}
 }

--- a/src/Client/Dto/ChannelMemberWithTeamData.php
+++ b/src/Client/Dto/ChannelMemberWithTeamData.php
@@ -1,12 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Data as SpatieData;
 
-class ChannelMemberWithTeamData extends SpatieData
-{
-	public function __construct()
-	{
-	}
-}
+class ChannelMemberWithTeamData extends SpatieData {}

--- a/src/Client/Dto/ChannelModeratedRole.php
+++ b/src/Client/Dto/ChannelModeratedRole.php
@@ -1,14 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Data as SpatieData;
 
 class ChannelModeratedRole extends SpatieData
 {
-	public function __construct(
-		public ?bool $enabled = null,
-		public ?bool $value = null,
-	) {
-	}
+    public function __construct(
+        public ?bool $enabled = null,
+        public ?bool $value = null,
+    ) {}
 }

--- a/src/Client/Dto/ChannelModeratedRoles.php
+++ b/src/Client/Dto/ChannelModeratedRoles.php
@@ -1,14 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Data as SpatieData;
 
 class ChannelModeratedRoles extends SpatieData
 {
-	public function __construct(
-		public ?ChannelModeratedRole $guests = null,
-		public ?ChannelModeratedRole $members = null,
-	) {
-	}
+    public function __construct(
+        public ?ChannelModeratedRole $guests = null,
+        public ?ChannelModeratedRole $members = null,
+    ) {}
 }

--- a/src/Client/Dto/ChannelModeratedRolesPatch.php
+++ b/src/Client/Dto/ChannelModeratedRolesPatch.php
@@ -1,14 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Data as SpatieData;
 
 class ChannelModeratedRolesPatch extends SpatieData
 {
-	public function __construct(
-		public ?bool $guests = null,
-		public ?bool $members = null,
-	) {
-	}
+    public function __construct(
+        public ?bool $guests = null,
+        public ?bool $members = null,
+    ) {}
 }

--- a/src/Client/Dto/ChannelModeration.php
+++ b/src/Client/Dto/ChannelModeration.php
@@ -1,14 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Data as SpatieData;
 
 class ChannelModeration extends SpatieData
 {
-	public function __construct(
-		public ?string $name = null,
-		public ?ChannelModeratedRoles $roles = null,
-	) {
-	}
+    public function __construct(
+        public ?string $name = null,
+        public ?ChannelModeratedRoles $roles = null,
+    ) {}
 }

--- a/src/Client/Dto/ChannelModerationPatch.php
+++ b/src/Client/Dto/ChannelModerationPatch.php
@@ -1,14 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Data as SpatieData;
 
 class ChannelModerationPatch extends SpatieData
 {
-	public function __construct(
-		public ?string $name = null,
-		public ?ChannelModeratedRolesPatch $roles = null,
-	) {
-	}
+    public function __construct(
+        public ?string $name = null,
+        public ?ChannelModeratedRolesPatch $roles = null,
+    ) {}
 }

--- a/src/Client/Dto/ChannelNotifyProps.php
+++ b/src/Client/Dto/ChannelNotifyProps.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,12 +9,11 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class ChannelNotifyProps extends SpatieData
 {
-	public function __construct(
-		public ?string $desktop = null,
-		public ?string $email = null,
-		#[MapName('mark_unread')]
-		public ?string $markUnread = null,
-		public ?string $push = null,
-	) {
-	}
+    public function __construct(
+        public ?string $desktop = null,
+        public ?string $email = null,
+        #[MapName('mark_unread')]
+        public ?string $markUnread = null,
+        public ?string $push = null,
+    ) {}
 }

--- a/src/Client/Dto/ChannelStats.php
+++ b/src/Client/Dto/ChannelStats.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,11 +9,10 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class ChannelStats extends SpatieData
 {
-	public function __construct(
-		#[MapName('channel_id')]
-		public ?string $channelId = null,
-		#[MapName('member_count')]
-		public ?int $memberCount = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('channel_id')]
+        public ?string $channelId = null,
+        #[MapName('member_count')]
+        public ?int $memberCount = null,
+    ) {}
 }

--- a/src/Client/Dto/ChannelUnread.php
+++ b/src/Client/Dto/ChannelUnread.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,15 +9,14 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class ChannelUnread extends SpatieData
 {
-	public function __construct(
-		#[MapName('channel_id')]
-		public ?string $channelId = null,
-		#[MapName('mention_count')]
-		public ?int $mentionCount = null,
-		#[MapName('msg_count')]
-		public ?int $msgCount = null,
-		#[MapName('team_id')]
-		public ?string $teamId = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('channel_id')]
+        public ?string $channelId = null,
+        #[MapName('mention_count')]
+        public ?int $mentionCount = null,
+        #[MapName('msg_count')]
+        public ?int $msgCount = null,
+        #[MapName('team_id')]
+        public ?string $teamId = null,
+    ) {}
 }

--- a/src/Client/Dto/ChannelUnreadAt.php
+++ b/src/Client/Dto/ChannelUnreadAt.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,17 +9,16 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class ChannelUnreadAt extends SpatieData
 {
-	public function __construct(
-		#[MapName('channel_id')]
-		public ?string $channelId = null,
-		#[MapName('last_viewed_at')]
-		public ?int $lastViewedAt = null,
-		#[MapName('mention_count')]
-		public ?int $mentionCount = null,
-		#[MapName('msg_count')]
-		public ?int $msgCount = null,
-		#[MapName('team_id')]
-		public ?string $teamId = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('channel_id')]
+        public ?string $channelId = null,
+        #[MapName('last_viewed_at')]
+        public ?int $lastViewedAt = null,
+        #[MapName('mention_count')]
+        public ?int $mentionCount = null,
+        #[MapName('msg_count')]
+        public ?int $msgCount = null,
+        #[MapName('team_id')]
+        public ?string $teamId = null,
+    ) {}
 }

--- a/src/Client/Dto/ChannelWithTeamData.php
+++ b/src/Client/Dto/ChannelWithTeamData.php
@@ -1,12 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Data as SpatieData;
 
-class ChannelWithTeamData extends SpatieData
-{
-	public function __construct()
-	{
-	}
-}
+class ChannelWithTeamData extends SpatieData {}

--- a/src/Client/Dto/Checklist.php
+++ b/src/Client/Dto/Checklist.php
@@ -1,15 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Data as SpatieData;
 
 class Checklist extends SpatieData
 {
-	public function __construct(
-		public ?string $id = null,
-		public ?array $items = null,
-		public ?string $title = null,
-	) {
-	}
+    /**
+     * @param  array<int, mixed>  $items
+     */
+    public function __construct(
+        public ?string $id = null,
+        public ?array $items = null,
+        public ?string $title = null,
+    ) {}
 }

--- a/src/Client/Dto/ChecklistItem.php
+++ b/src/Client/Dto/ChecklistItem.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,34 +9,33 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class ChecklistItem extends SpatieData
 {
-	public function __construct(
-		#[MapName('assignee_id')]
-		public ?string $assigneeId = null,
-		#[MapName('assignee_modified')]
-		public ?int $assigneeModified = null,
-		public ?string $command = null,
-		#[MapName('command_last_run')]
-		public ?int $commandLastRun = null,
-		#[MapName('condition_action')]
-		public ?string $conditionAction = null,
-		#[MapName('condition_id')]
-		public ?string $conditionId = null,
-		#[MapName('condition_reason')]
-		public ?string $conditionReason = null,
-		#[MapName('delete_at')]
-		public ?int $deleteAt = null,
-		public ?string $description = null,
-		#[MapName('due_date')]
-		public ?int $dueDate = null,
-		public ?string $id = null,
-		public ?string $state = null,
-		#[MapName('state_modified')]
-		public ?int $stateModified = null,
-		#[MapName('task_actions')]
-		public ?array $taskActions = null,
-		public ?string $title = null,
-		#[MapName('update_at')]
-		public ?int $updateAt = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('assignee_id')]
+        public ?string $assigneeId = null,
+        #[MapName('assignee_modified')]
+        public ?int $assigneeModified = null,
+        public ?string $command = null,
+        #[MapName('command_last_run')]
+        public ?int $commandLastRun = null,
+        #[MapName('condition_action')]
+        public ?string $conditionAction = null,
+        #[MapName('condition_id')]
+        public ?string $conditionId = null,
+        #[MapName('condition_reason')]
+        public ?string $conditionReason = null,
+        #[MapName('delete_at')]
+        public ?int $deleteAt = null,
+        public ?string $description = null,
+        #[MapName('due_date')]
+        public ?int $dueDate = null,
+        public ?string $id = null,
+        public ?string $state = null,
+        #[MapName('state_modified')]
+        public ?int $stateModified = null,
+        #[MapName('task_actions')]
+        public ?array $taskActions = null,
+        public ?string $title = null,
+        #[MapName('update_at')]
+        public ?int $updateAt = null,
+    ) {}
 }

--- a/src/Client/Dto/CloudCustomer.php
+++ b/src/Client/Dto/CloudCustomer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,26 +9,25 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class CloudCustomer extends SpatieData
 {
-	public function __construct(
-		#[MapName('billing_address')]
-		public ?Address $billingAddress = null,
-		#[MapName('company_address')]
-		public ?Address $companyAddress = null,
-		#[MapName('contact_first_name')]
-		public ?string $contactFirstName = null,
-		#[MapName('contact_last_name')]
-		public ?string $contactLastName = null,
-		#[MapName('create_at')]
-		public ?int $createAt = null,
-		#[MapName('creator_id')]
-		public ?string $creatorId = null,
-		public ?string $email = null,
-		public ?string $id = null,
-		public ?string $name = null,
-		#[MapName('num_employees')]
-		public ?string $numEmployees = null,
-		#[MapName('payment_method')]
-		public ?PaymentMethod $paymentMethod = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('billing_address')]
+        public ?Address $billingAddress = null,
+        #[MapName('company_address')]
+        public ?Address $companyAddress = null,
+        #[MapName('contact_first_name')]
+        public ?string $contactFirstName = null,
+        #[MapName('contact_last_name')]
+        public ?string $contactLastName = null,
+        #[MapName('create_at')]
+        public ?int $createAt = null,
+        #[MapName('creator_id')]
+        public ?string $creatorId = null,
+        public ?string $email = null,
+        public ?string $id = null,
+        public ?string $name = null,
+        #[MapName('num_employees')]
+        public ?string $numEmployees = null,
+        #[MapName('payment_method')]
+        public ?PaymentMethod $paymentMethod = null,
+    ) {}
 }

--- a/src/Client/Dto/ClusterInfo.php
+++ b/src/Client/Dto/ClusterInfo.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,18 +9,17 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class ClusterInfo extends SpatieData
 {
-	public function __construct(
-		#[MapName('config_hash')]
-		public ?string $configHash = null,
-		public ?string $hostname = null,
-		public ?string $id = null,
-		#[MapName('internode_url')]
-		public ?string $internodeUrl = null,
-		#[MapName('is_alive')]
-		public ?bool $isAlive = null,
-		#[MapName('last_ping')]
-		public ?int $lastPing = null,
-		public ?string $version = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('config_hash')]
+        public ?string $configHash = null,
+        public ?string $hostname = null,
+        public ?string $id = null,
+        #[MapName('internode_url')]
+        public ?string $internodeUrl = null,
+        #[MapName('is_alive')]
+        public ?bool $isAlive = null,
+        #[MapName('last_ping')]
+        public ?int $lastPing = null,
+        public ?string $version = null,
+    ) {}
 }

--- a/src/Client/Dto/Command.php
+++ b/src/Client/Dto/Command.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,34 +9,33 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class Command extends SpatieData
 {
-	public function __construct(
-		#[MapName('auto_complete')]
-		public ?bool $autoComplete = null,
-		#[MapName('auto_complete_desc')]
-		public ?string $autoCompleteDesc = null,
-		#[MapName('auto_complete_hint')]
-		public ?string $autoCompleteHint = null,
-		#[MapName('create_at')]
-		public ?int $createAt = null,
-		#[MapName('creator_id')]
-		public ?string $creatorId = null,
-		#[MapName('delete_at')]
-		public ?int $deleteAt = null,
-		public ?string $description = null,
-		#[MapName('display_name')]
-		public ?string $displayName = null,
-		#[MapName('icon_url')]
-		public ?string $iconUrl = null,
-		public ?string $id = null,
-		public ?string $method = null,
-		#[MapName('team_id')]
-		public ?string $teamId = null,
-		public ?string $token = null,
-		public ?string $trigger = null,
-		#[MapName('update_at')]
-		public ?int $updateAt = null,
-		public ?string $url = null,
-		public ?string $username = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('auto_complete')]
+        public ?bool $autoComplete = null,
+        #[MapName('auto_complete_desc')]
+        public ?string $autoCompleteDesc = null,
+        #[MapName('auto_complete_hint')]
+        public ?string $autoCompleteHint = null,
+        #[MapName('create_at')]
+        public ?int $createAt = null,
+        #[MapName('creator_id')]
+        public ?string $creatorId = null,
+        #[MapName('delete_at')]
+        public ?int $deleteAt = null,
+        public ?string $description = null,
+        #[MapName('display_name')]
+        public ?string $displayName = null,
+        #[MapName('icon_url')]
+        public ?string $iconUrl = null,
+        public ?string $id = null,
+        public ?string $method = null,
+        #[MapName('team_id')]
+        public ?string $teamId = null,
+        public ?string $token = null,
+        public ?string $trigger = null,
+        #[MapName('update_at')]
+        public ?int $updateAt = null,
+        public ?string $url = null,
+        public ?string $username = null,
+    ) {}
 }

--- a/src/Client/Dto/CommandResponse.php
+++ b/src/Client/Dto/CommandResponse.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,19 +9,18 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class CommandResponse extends SpatieData
 {
-	public function __construct(
-		#[MapName('Attachments')]
-		public ?array $attachments = null,
-		#[MapName('GotoLocation')]
-		public ?string $gotoLocation = null,
-		#[MapName('IconURL')]
-		public ?string $iconUrl = null,
-		#[MapName('ResponseType')]
-		public ?string $responseType = null,
-		#[MapName('Text')]
-		public ?string $text = null,
-		#[MapName('Username')]
-		public ?string $username = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('Attachments')]
+        public ?array $attachments = null,
+        #[MapName('GotoLocation')]
+        public ?string $gotoLocation = null,
+        #[MapName('IconURL')]
+        public ?string $iconUrl = null,
+        #[MapName('ResponseType')]
+        public ?string $responseType = null,
+        #[MapName('Text')]
+        public ?string $text = null,
+        #[MapName('Username')]
+        public ?string $username = null,
+    ) {}
 }

--- a/src/Client/Dto/ComparisonCondition.php
+++ b/src/Client/Dto/ComparisonCondition.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,10 +9,9 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class ComparisonCondition extends SpatieData
 {
-	public function __construct(
-		#[MapName('field_id')]
-		public ?string $fieldId = null,
-		public mixed $value = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('field_id')]
+        public ?string $fieldId = null,
+        public mixed $value = null,
+    ) {}
 }

--- a/src/Client/Dto/Compliance.php
+++ b/src/Client/Dto/Compliance.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,22 +9,21 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class Compliance extends SpatieData
 {
-	public function __construct(
-		public ?int $count = null,
-		#[MapName('create_at')]
-		public ?int $createAt = null,
-		public ?string $desc = null,
-		public ?string $emails = null,
-		#[MapName('end_at')]
-		public ?int $endAt = null,
-		public ?string $id = null,
-		public ?string $keywords = null,
-		#[MapName('start_at')]
-		public ?int $startAt = null,
-		public ?string $status = null,
-		public ?string $type = null,
-		#[MapName('user_id')]
-		public ?string $userId = null,
-	) {
-	}
+    public function __construct(
+        public ?int $count = null,
+        #[MapName('create_at')]
+        public ?int $createAt = null,
+        public ?string $desc = null,
+        public ?string $emails = null,
+        #[MapName('end_at')]
+        public ?int $endAt = null,
+        public ?string $id = null,
+        public ?string $keywords = null,
+        #[MapName('start_at')]
+        public ?int $startAt = null,
+        public ?string $status = null,
+        public ?string $type = null,
+        #[MapName('user_id')]
+        public ?string $userId = null,
+    ) {}
 }

--- a/src/Client/Dto/Condition.php
+++ b/src/Client/Dto/Condition.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,19 +9,18 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class Condition extends SpatieData
 {
-	public function __construct(
-		#[MapName('condition_expr')]
-		public ?ConditionExprV1 $conditionExpr = null,
-		#[MapName('create_at')]
-		public ?int $createAt = null,
-		public ?string $id = null,
-		#[MapName('playbook_id')]
-		public ?string $playbookId = null,
-		#[MapName('run_id')]
-		public ?string $runId = null,
-		#[MapName('update_at')]
-		public ?int $updateAt = null,
-		public ?int $version = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('condition_expr')]
+        public ?ConditionExprV1 $conditionExpr = null,
+        #[MapName('create_at')]
+        public ?int $createAt = null,
+        public ?string $id = null,
+        #[MapName('playbook_id')]
+        public ?string $playbookId = null,
+        #[MapName('run_id')]
+        public ?string $runId = null,
+        #[MapName('update_at')]
+        public ?int $updateAt = null,
+        public ?int $version = null,
+    ) {}
 }

--- a/src/Client/Dto/ConditionExprV1.php
+++ b/src/Client/Dto/ConditionExprV1.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Data as SpatieData;
@@ -10,11 +12,14 @@ use Spatie\LaravelData\Data as SpatieData;
  */
 class ConditionExprV1 extends SpatieData
 {
-	public function __construct(
-		public ?array $and = null,
-		public ?ComparisonCondition $is = null,
-		public ?ComparisonCondition $isNot = null,
-		public ?array $or = null,
-	) {
-	}
+    /**
+     * @param  array<int, mixed>  $and
+     * @param  array<int, mixed>  $or
+     */
+    public function __construct(
+        public ?array $and = null,
+        public ?ComparisonCondition $is = null,
+        public ?ComparisonCondition $isNot = null,
+        public ?array $or = null,
+    ) {}
 }

--- a/src/Client/Dto/ConditionList.php
+++ b/src/Client/Dto/ConditionList.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,14 +9,13 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class ConditionList extends SpatieData
 {
-	public function __construct(
-		#[MapName('has_more')]
-		public ?bool $hasMore = null,
-		public ?array $items = null,
-		#[MapName('page_count')]
-		public ?int $pageCount = null,
-		#[MapName('total_count')]
-		public ?int $totalCount = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('has_more')]
+        public ?bool $hasMore = null,
+        public ?array $items = null,
+        #[MapName('page_count')]
+        public ?int $pageCount = null,
+        #[MapName('total_count')]
+        public ?int $totalCount = null,
+    ) {}
 }

--- a/src/Client/Dto/Config.php
+++ b/src/Client/Dto/Config.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,49 +9,48 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class Config extends SpatieData
 {
-	public function __construct(
-		#[MapName('AnalyticsSettings')]
-		public ?object $analyticsSettings = null,
-		#[MapName('ClusterSettings')]
-		public ?object $clusterSettings = null,
-		#[MapName('ComplianceSettings')]
-		public ?object $complianceSettings = null,
-		#[MapName('EmailSettings')]
-		public ?object $emailSettings = null,
-		#[MapName('FileSettings')]
-		public ?object $fileSettings = null,
-		#[MapName('GitLabSettings')]
-		public ?object $gitLabSettings = null,
-		#[MapName('GoogleSettings')]
-		public ?object $googleSettings = null,
-		#[MapName('LdapSettings')]
-		public ?object $ldapSettings = null,
-		#[MapName('LocalizationSettings')]
-		public ?object $localizationSettings = null,
-		#[MapName('LogSettings')]
-		public ?object $logSettings = null,
-		#[MapName('MetricsSettings')]
-		public ?object $metricsSettings = null,
-		#[MapName('NativeAppSettings')]
-		public ?object $nativeAppSettings = null,
-		#[MapName('Office365Settings')]
-		public ?object $office365settings = null,
-		#[MapName('PasswordSettings')]
-		public ?object $passwordSettings = null,
-		#[MapName('PrivacySettings')]
-		public ?object $privacySettings = null,
-		#[MapName('RateLimitSettings')]
-		public ?object $rateLimitSettings = null,
-		#[MapName('SamlSettings')]
-		public ?object $samlSettings = null,
-		#[MapName('ServiceSettings')]
-		public ?object $serviceSettings = null,
-		#[MapName('SqlSettings')]
-		public ?object $sqlSettings = null,
-		#[MapName('SupportSettings')]
-		public ?object $supportSettings = null,
-		#[MapName('TeamSettings')]
-		public ?object $teamSettings = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('AnalyticsSettings')]
+        public ?object $analyticsSettings = null,
+        #[MapName('ClusterSettings')]
+        public ?object $clusterSettings = null,
+        #[MapName('ComplianceSettings')]
+        public ?object $complianceSettings = null,
+        #[MapName('EmailSettings')]
+        public ?object $emailSettings = null,
+        #[MapName('FileSettings')]
+        public ?object $fileSettings = null,
+        #[MapName('GitLabSettings')]
+        public ?object $gitLabSettings = null,
+        #[MapName('GoogleSettings')]
+        public ?object $googleSettings = null,
+        #[MapName('LdapSettings')]
+        public ?object $ldapSettings = null,
+        #[MapName('LocalizationSettings')]
+        public ?object $localizationSettings = null,
+        #[MapName('LogSettings')]
+        public ?object $logSettings = null,
+        #[MapName('MetricsSettings')]
+        public ?object $metricsSettings = null,
+        #[MapName('NativeAppSettings')]
+        public ?object $nativeAppSettings = null,
+        #[MapName('Office365Settings')]
+        public ?object $office365settings = null,
+        #[MapName('PasswordSettings')]
+        public ?object $passwordSettings = null,
+        #[MapName('PrivacySettings')]
+        public ?object $privacySettings = null,
+        #[MapName('RateLimitSettings')]
+        public ?object $rateLimitSettings = null,
+        #[MapName('SamlSettings')]
+        public ?object $samlSettings = null,
+        #[MapName('ServiceSettings')]
+        public ?object $serviceSettings = null,
+        #[MapName('SqlSettings')]
+        public ?object $sqlSettings = null,
+        #[MapName('SupportSettings')]
+        public ?object $supportSettings = null,
+        #[MapName('TeamSettings')]
+        public ?object $teamSettings = null,
+    ) {}
 }

--- a/src/Client/Dto/DataRetentionPolicy.php
+++ b/src/Client/Dto/DataRetentionPolicy.php
@@ -1,12 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Data as SpatieData;
 
-class DataRetentionPolicy extends SpatieData
-{
-	public function __construct()
-	{
-	}
-}
+class DataRetentionPolicy extends SpatieData {}

--- a/src/Client/Dto/DataRetentionPolicyCreate.php
+++ b/src/Client/Dto/DataRetentionPolicyCreate.php
@@ -1,12 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Data as SpatieData;
 
-class DataRetentionPolicyCreate extends SpatieData
-{
-	public function __construct()
-	{
-	}
-}
+class DataRetentionPolicyCreate extends SpatieData {}

--- a/src/Client/Dto/DataRetentionPolicyForChannel.php
+++ b/src/Client/Dto/DataRetentionPolicyForChannel.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,11 +9,10 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class DataRetentionPolicyForChannel extends SpatieData
 {
-	public function __construct(
-		#[MapName('channel_id')]
-		public ?string $channelId = null,
-		#[MapName('post_duration')]
-		public ?int $postDuration = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('channel_id')]
+        public ?string $channelId = null,
+        #[MapName('post_duration')]
+        public ?int $postDuration = null,
+    ) {}
 }

--- a/src/Client/Dto/DataRetentionPolicyForTeam.php
+++ b/src/Client/Dto/DataRetentionPolicyForTeam.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,11 +9,10 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class DataRetentionPolicyForTeam extends SpatieData
 {
-	public function __construct(
-		#[MapName('post_duration')]
-		public ?int $postDuration = null,
-		#[MapName('team_id')]
-		public ?string $teamId = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('post_duration')]
+        public ?int $postDuration = null,
+        #[MapName('team_id')]
+        public ?string $teamId = null,
+    ) {}
 }

--- a/src/Client/Dto/DataRetentionPolicyWithTeamAndChannelCounts.php
+++ b/src/Client/Dto/DataRetentionPolicyWithTeamAndChannelCounts.php
@@ -1,12 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Data as SpatieData;
 
-class DataRetentionPolicyWithTeamAndChannelCounts extends SpatieData
-{
-	public function __construct()
-	{
-	}
-}
+class DataRetentionPolicyWithTeamAndChannelCounts extends SpatieData {}

--- a/src/Client/Dto/DataRetentionPolicyWithTeamAndChannelIds.php
+++ b/src/Client/Dto/DataRetentionPolicyWithTeamAndChannelIds.php
@@ -1,12 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Data as SpatieData;
 
-class DataRetentionPolicyWithTeamAndChannelIds extends SpatieData
-{
-	public function __construct()
-	{
-	}
-}
+class DataRetentionPolicyWithTeamAndChannelIds extends SpatieData {}

--- a/src/Client/Dto/DataRetentionPolicyWithoutId.php
+++ b/src/Client/Dto/DataRetentionPolicyWithoutId.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,11 +9,10 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class DataRetentionPolicyWithoutId extends SpatieData
 {
-	public function __construct(
-		#[MapName('display_name')]
-		public ?string $displayName = null,
-		#[MapName('post_duration')]
-		public ?int $postDuration = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('display_name')]
+        public ?string $displayName = null,
+        #[MapName('post_duration')]
+        public ?int $postDuration = null,
+    ) {}
 }

--- a/src/Client/Dto/Emoji.php
+++ b/src/Client/Dto/Emoji.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,17 +9,16 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class Emoji extends SpatieData
 {
-	public function __construct(
-		#[MapName('create_at')]
-		public ?int $createAt = null,
-		#[MapName('creator_id')]
-		public ?string $creatorId = null,
-		#[MapName('delete_at')]
-		public ?int $deleteAt = null,
-		public ?string $id = null,
-		public ?string $name = null,
-		#[MapName('update_at')]
-		public ?int $updateAt = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('create_at')]
+        public ?int $createAt = null,
+        #[MapName('creator_id')]
+        public ?string $creatorId = null,
+        #[MapName('delete_at')]
+        public ?int $deleteAt = null,
+        public ?string $id = null,
+        public ?string $name = null,
+        #[MapName('update_at')]
+        public ?int $updateAt = null,
+    ) {}
 }

--- a/src/Client/Dto/EnvironmentConfig.php
+++ b/src/Client/Dto/EnvironmentConfig.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,49 +9,48 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class EnvironmentConfig extends SpatieData
 {
-	public function __construct(
-		#[MapName('AnalyticsSettings')]
-		public ?object $analyticsSettings = null,
-		#[MapName('ClusterSettings')]
-		public ?object $clusterSettings = null,
-		#[MapName('ComplianceSettings')]
-		public ?object $complianceSettings = null,
-		#[MapName('EmailSettings')]
-		public ?object $emailSettings = null,
-		#[MapName('FileSettings')]
-		public ?object $fileSettings = null,
-		#[MapName('GitLabSettings')]
-		public ?object $gitLabSettings = null,
-		#[MapName('GoogleSettings')]
-		public ?object $googleSettings = null,
-		#[MapName('LdapSettings')]
-		public ?object $ldapSettings = null,
-		#[MapName('LocalizationSettings')]
-		public ?object $localizationSettings = null,
-		#[MapName('LogSettings')]
-		public ?object $logSettings = null,
-		#[MapName('MetricsSettings')]
-		public ?object $metricsSettings = null,
-		#[MapName('NativeAppSettings')]
-		public ?object $nativeAppSettings = null,
-		#[MapName('Office365Settings')]
-		public ?object $office365settings = null,
-		#[MapName('PasswordSettings')]
-		public ?object $passwordSettings = null,
-		#[MapName('PrivacySettings')]
-		public ?object $privacySettings = null,
-		#[MapName('RateLimitSettings')]
-		public ?object $rateLimitSettings = null,
-		#[MapName('SamlSettings')]
-		public ?object $samlSettings = null,
-		#[MapName('ServiceSettings')]
-		public ?object $serviceSettings = null,
-		#[MapName('SqlSettings')]
-		public ?object $sqlSettings = null,
-		#[MapName('SupportSettings')]
-		public ?object $supportSettings = null,
-		#[MapName('TeamSettings')]
-		public ?object $teamSettings = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('AnalyticsSettings')]
+        public ?object $analyticsSettings = null,
+        #[MapName('ClusterSettings')]
+        public ?object $clusterSettings = null,
+        #[MapName('ComplianceSettings')]
+        public ?object $complianceSettings = null,
+        #[MapName('EmailSettings')]
+        public ?object $emailSettings = null,
+        #[MapName('FileSettings')]
+        public ?object $fileSettings = null,
+        #[MapName('GitLabSettings')]
+        public ?object $gitLabSettings = null,
+        #[MapName('GoogleSettings')]
+        public ?object $googleSettings = null,
+        #[MapName('LdapSettings')]
+        public ?object $ldapSettings = null,
+        #[MapName('LocalizationSettings')]
+        public ?object $localizationSettings = null,
+        #[MapName('LogSettings')]
+        public ?object $logSettings = null,
+        #[MapName('MetricsSettings')]
+        public ?object $metricsSettings = null,
+        #[MapName('NativeAppSettings')]
+        public ?object $nativeAppSettings = null,
+        #[MapName('Office365Settings')]
+        public ?object $office365settings = null,
+        #[MapName('PasswordSettings')]
+        public ?object $passwordSettings = null,
+        #[MapName('PrivacySettings')]
+        public ?object $privacySettings = null,
+        #[MapName('RateLimitSettings')]
+        public ?object $rateLimitSettings = null,
+        #[MapName('SamlSettings')]
+        public ?object $samlSettings = null,
+        #[MapName('ServiceSettings')]
+        public ?object $serviceSettings = null,
+        #[MapName('SqlSettings')]
+        public ?object $sqlSettings = null,
+        #[MapName('SupportSettings')]
+        public ?object $supportSettings = null,
+        #[MapName('TeamSettings')]
+        public ?object $teamSettings = null,
+    ) {}
 }

--- a/src/Client/Dto/Error.php
+++ b/src/Client/Dto/Error.php
@@ -1,14 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Data as SpatieData;
 
 class Error extends SpatieData
 {
-	public function __construct(
-		public ?string $details = null,
-		public ?string $error = null,
-	) {
-	}
+    public function __construct(
+        public ?string $details = null,
+        public ?string $error = null,
+    ) {}
 }

--- a/src/Client/Dto/FileInfo.php
+++ b/src/Client/Dto/FileInfo.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,27 +9,26 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class FileInfo extends SpatieData
 {
-	public function __construct(
-		#[MapName('create_at')]
-		public ?int $createAt = null,
-		#[MapName('delete_at')]
-		public ?int $deleteAt = null,
-		public ?string $extension = null,
-		#[MapName('has_preview_image')]
-		public ?bool $hasPreviewImage = null,
-		public ?int $height = null,
-		public ?string $id = null,
-		#[MapName('mime_type')]
-		public ?string $mimeType = null,
-		public ?string $name = null,
-		#[MapName('post_id')]
-		public ?string $postId = null,
-		public ?int $size = null,
-		#[MapName('update_at')]
-		public ?int $updateAt = null,
-		#[MapName('user_id')]
-		public ?string $userId = null,
-		public ?int $width = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('create_at')]
+        public ?int $createAt = null,
+        #[MapName('delete_at')]
+        public ?int $deleteAt = null,
+        public ?string $extension = null,
+        #[MapName('has_preview_image')]
+        public ?bool $hasPreviewImage = null,
+        public ?int $height = null,
+        public ?string $id = null,
+        #[MapName('mime_type')]
+        public ?string $mimeType = null,
+        public ?string $name = null,
+        #[MapName('post_id')]
+        public ?string $postId = null,
+        public ?int $size = null,
+        #[MapName('update_at')]
+        public ?int $updateAt = null,
+        #[MapName('user_id')]
+        public ?string $userId = null,
+        public ?int $width = null,
+    ) {}
 }

--- a/src/Client/Dto/FileInfoList.php
+++ b/src/Client/Dto/FileInfoList.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,14 +9,13 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class FileInfoList extends SpatieData
 {
-	public function __construct(
-		#[MapName('file_infos')]
-		public ?object $fileInfos = null,
-		#[MapName('next_file_id')]
-		public ?string $nextFileId = null,
-		public ?array $order = null,
-		#[MapName('prev_file_id')]
-		public ?string $prevFileId = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('file_infos')]
+        public ?object $fileInfos = null,
+        #[MapName('next_file_id')]
+        public ?string $nextFileId = null,
+        public ?array $order = null,
+        #[MapName('prev_file_id')]
+        public ?string $prevFileId = null,
+    ) {}
 }

--- a/src/Client/Dto/FilesLimits.php
+++ b/src/Client/Dto/FilesLimits.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,9 +9,8 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class FilesLimits extends SpatieData
 {
-	public function __construct(
-		#[MapName('total_storage')]
-		public ?int $totalStorage = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('total_storage')]
+        public ?int $totalStorage = null,
+    ) {}
 }

--- a/src/Client/Dto/GlobalDataRetentionPolicy.php
+++ b/src/Client/Dto/GlobalDataRetentionPolicy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,15 +9,14 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class GlobalDataRetentionPolicy extends SpatieData
 {
-	public function __construct(
-		#[MapName('file_deletion_enabled')]
-		public ?bool $fileDeletionEnabled = null,
-		#[MapName('file_retention_cutoff')]
-		public ?int $fileRetentionCutoff = null,
-		#[MapName('message_deletion_enabled')]
-		public ?bool $messageDeletionEnabled = null,
-		#[MapName('message_retention_cutoff')]
-		public ?int $messageRetentionCutoff = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('file_deletion_enabled')]
+        public ?bool $fileDeletionEnabled = null,
+        #[MapName('file_retention_cutoff')]
+        public ?int $fileRetentionCutoff = null,
+        #[MapName('message_deletion_enabled')]
+        public ?bool $messageDeletionEnabled = null,
+        #[MapName('message_retention_cutoff')]
+        public ?int $messageRetentionCutoff = null,
+    ) {}
 }

--- a/src/Client/Dto/Group.php
+++ b/src/Client/Dto/Group.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,23 +9,22 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class Group extends SpatieData
 {
-	public function __construct(
-		#[MapName('create_at')]
-		public ?int $createAt = null,
-		#[MapName('delete_at')]
-		public ?int $deleteAt = null,
-		public ?string $description = null,
-		#[MapName('display_name')]
-		public ?string $displayName = null,
-		#[MapName('has_syncables')]
-		public ?bool $hasSyncables = null,
-		public ?string $id = null,
-		public ?string $name = null,
-		#[MapName('remote_id')]
-		public ?string $remoteId = null,
-		public ?string $source = null,
-		#[MapName('update_at')]
-		public ?int $updateAt = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('create_at')]
+        public ?int $createAt = null,
+        #[MapName('delete_at')]
+        public ?int $deleteAt = null,
+        public ?string $description = null,
+        #[MapName('display_name')]
+        public ?string $displayName = null,
+        #[MapName('has_syncables')]
+        public ?bool $hasSyncables = null,
+        public ?string $id = null,
+        public ?string $name = null,
+        #[MapName('remote_id')]
+        public ?string $remoteId = null,
+        public ?string $source = null,
+        #[MapName('update_at')]
+        public ?int $updateAt = null,
+    ) {}
 }

--- a/src/Client/Dto/GroupSyncableChannel.php
+++ b/src/Client/Dto/GroupSyncableChannel.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,19 +9,18 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class GroupSyncableChannel extends SpatieData
 {
-	public function __construct(
-		#[MapName('auto_add')]
-		public ?bool $autoAdd = null,
-		#[MapName('channel_id')]
-		public ?string $channelId = null,
-		#[MapName('create_at')]
-		public ?int $createAt = null,
-		#[MapName('delete_at')]
-		public ?int $deleteAt = null,
-		#[MapName('group_id')]
-		public ?string $groupId = null,
-		#[MapName('update_at')]
-		public ?int $updateAt = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('auto_add')]
+        public ?bool $autoAdd = null,
+        #[MapName('channel_id')]
+        public ?string $channelId = null,
+        #[MapName('create_at')]
+        public ?int $createAt = null,
+        #[MapName('delete_at')]
+        public ?int $deleteAt = null,
+        #[MapName('group_id')]
+        public ?string $groupId = null,
+        #[MapName('update_at')]
+        public ?int $updateAt = null,
+    ) {}
 }

--- a/src/Client/Dto/GroupSyncableChannels.php
+++ b/src/Client/Dto/GroupSyncableChannels.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,29 +9,28 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class GroupSyncableChannels extends SpatieData
 {
-	public function __construct(
-		#[MapName('auto_add')]
-		public ?bool $autoAdd = null,
-		#[MapName('channel_display_name')]
-		public ?string $channelDisplayName = null,
-		#[MapName('channel_id')]
-		public ?string $channelId = null,
-		#[MapName('channel_type')]
-		public ?string $channelType = null,
-		#[MapName('create_at')]
-		public ?int $createAt = null,
-		#[MapName('delete_at')]
-		public ?int $deleteAt = null,
-		#[MapName('group_id')]
-		public ?string $groupId = null,
-		#[MapName('team_display_name')]
-		public ?string $teamDisplayName = null,
-		#[MapName('team_id')]
-		public ?string $teamId = null,
-		#[MapName('team_type')]
-		public ?string $teamType = null,
-		#[MapName('update_at')]
-		public ?int $updateAt = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('auto_add')]
+        public ?bool $autoAdd = null,
+        #[MapName('channel_display_name')]
+        public ?string $channelDisplayName = null,
+        #[MapName('channel_id')]
+        public ?string $channelId = null,
+        #[MapName('channel_type')]
+        public ?string $channelType = null,
+        #[MapName('create_at')]
+        public ?int $createAt = null,
+        #[MapName('delete_at')]
+        public ?int $deleteAt = null,
+        #[MapName('group_id')]
+        public ?string $groupId = null,
+        #[MapName('team_display_name')]
+        public ?string $teamDisplayName = null,
+        #[MapName('team_id')]
+        public ?string $teamId = null,
+        #[MapName('team_type')]
+        public ?string $teamType = null,
+        #[MapName('update_at')]
+        public ?int $updateAt = null,
+    ) {}
 }

--- a/src/Client/Dto/GroupSyncableTeam.php
+++ b/src/Client/Dto/GroupSyncableTeam.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,19 +9,18 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class GroupSyncableTeam extends SpatieData
 {
-	public function __construct(
-		#[MapName('auto_add')]
-		public ?bool $autoAdd = null,
-		#[MapName('create_at')]
-		public ?int $createAt = null,
-		#[MapName('delete_at')]
-		public ?int $deleteAt = null,
-		#[MapName('group_id')]
-		public ?string $groupId = null,
-		#[MapName('team_id')]
-		public ?string $teamId = null,
-		#[MapName('update_at')]
-		public ?int $updateAt = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('auto_add')]
+        public ?bool $autoAdd = null,
+        #[MapName('create_at')]
+        public ?int $createAt = null,
+        #[MapName('delete_at')]
+        public ?int $deleteAt = null,
+        #[MapName('group_id')]
+        public ?string $groupId = null,
+        #[MapName('team_id')]
+        public ?string $teamId = null,
+        #[MapName('update_at')]
+        public ?int $updateAt = null,
+    ) {}
 }

--- a/src/Client/Dto/GroupSyncableTeams.php
+++ b/src/Client/Dto/GroupSyncableTeams.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,23 +9,22 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class GroupSyncableTeams extends SpatieData
 {
-	public function __construct(
-		#[MapName('auto_add')]
-		public ?bool $autoAdd = null,
-		#[MapName('create_at')]
-		public ?int $createAt = null,
-		#[MapName('delete_at')]
-		public ?int $deleteAt = null,
-		#[MapName('group_id')]
-		public ?string $groupId = null,
-		#[MapName('team_display_name')]
-		public ?string $teamDisplayName = null,
-		#[MapName('team_id')]
-		public ?string $teamId = null,
-		#[MapName('team_type')]
-		public ?string $teamType = null,
-		#[MapName('update_at')]
-		public ?int $updateAt = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('auto_add')]
+        public ?bool $autoAdd = null,
+        #[MapName('create_at')]
+        public ?int $createAt = null,
+        #[MapName('delete_at')]
+        public ?int $deleteAt = null,
+        #[MapName('group_id')]
+        public ?string $groupId = null,
+        #[MapName('team_display_name')]
+        public ?string $teamDisplayName = null,
+        #[MapName('team_id')]
+        public ?string $teamId = null,
+        #[MapName('team_type')]
+        public ?string $teamType = null,
+        #[MapName('update_at')]
+        public ?int $updateAt = null,
+    ) {}
 }

--- a/src/Client/Dto/GroupWithSchemeAdmin.php
+++ b/src/Client/Dto/GroupWithSchemeAdmin.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -10,10 +12,9 @@ use Spatie\LaravelData\Data as SpatieData;
  */
 class GroupWithSchemeAdmin extends SpatieData
 {
-	public function __construct(
-		public ?Group $group = null,
-		#[MapName('scheme_admin')]
-		public ?bool $schemeAdmin = null,
-	) {
-	}
+    public function __construct(
+        public ?Group $group = null,
+        #[MapName('scheme_admin')]
+        public ?bool $schemeAdmin = null,
+    ) {}
 }

--- a/src/Client/Dto/GroupsAssociatedToChannels.php
+++ b/src/Client/Dto/GroupsAssociatedToChannels.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Data as SpatieData;
@@ -7,9 +9,4 @@ use Spatie\LaravelData\Data as SpatieData;
 /**
  * a map of channel id(s) to the set of groups that constrain the corresponding channel in a team
  */
-class GroupsAssociatedToChannels extends SpatieData
-{
-	public function __construct()
-	{
-	}
-}
+class GroupsAssociatedToChannels extends SpatieData {}

--- a/src/Client/Dto/IncomingWebhook.php
+++ b/src/Client/Dto/IncomingWebhook.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,19 +9,18 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class IncomingWebhook extends SpatieData
 {
-	public function __construct(
-		#[MapName('channel_id')]
-		public ?string $channelId = null,
-		#[MapName('create_at')]
-		public ?int $createAt = null,
-		#[MapName('delete_at')]
-		public ?int $deleteAt = null,
-		public ?string $description = null,
-		#[MapName('display_name')]
-		public ?string $displayName = null,
-		public ?string $id = null,
-		#[MapName('update_at')]
-		public ?int $updateAt = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('channel_id')]
+        public ?string $channelId = null,
+        #[MapName('create_at')]
+        public ?int $createAt = null,
+        #[MapName('delete_at')]
+        public ?int $deleteAt = null,
+        public ?string $description = null,
+        #[MapName('display_name')]
+        public ?string $displayName = null,
+        public ?string $id = null,
+        #[MapName('update_at')]
+        public ?int $updateAt = null,
+    ) {}
 }

--- a/src/Client/Dto/InsightUserInformation.php
+++ b/src/Client/Dto/InsightUserInformation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,18 +9,17 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class InsightUserInformation extends SpatieData
 {
-	public function __construct(
-		#[MapName('create_at')]
-		public ?int $createAt = null,
-		#[MapName('first_name')]
-		public ?string $firstName = null,
-		public ?string $id = null,
-		#[MapName('last_name')]
-		public ?string $lastName = null,
-		#[MapName('last_picture_update')]
-		public ?string $lastPictureUpdate = null,
-		public ?string $nickname = null,
-		public ?string $username = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('create_at')]
+        public ?int $createAt = null,
+        #[MapName('first_name')]
+        public ?string $firstName = null,
+        public ?string $id = null,
+        #[MapName('last_name')]
+        public ?string $lastName = null,
+        #[MapName('last_picture_update')]
+        public ?string $lastPictureUpdate = null,
+        public ?string $nickname = null,
+        public ?string $username = null,
+    ) {}
 }

--- a/src/Client/Dto/IntegrationsLimits.php
+++ b/src/Client/Dto/IntegrationsLimits.php
@@ -1,13 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Data as SpatieData;
 
 class IntegrationsLimits extends SpatieData
 {
-	public function __construct(
-		public ?int $enabled = null,
-	) {
-	}
+    public function __construct(
+        public ?int $enabled = null,
+    ) {}
 }

--- a/src/Client/Dto/IntegrityCheckResult.php
+++ b/src/Client/Dto/IntegrityCheckResult.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Data as SpatieData;
@@ -9,9 +11,8 @@ use Spatie\LaravelData\Data as SpatieData;
  */
 class IntegrityCheckResult extends SpatieData
 {
-	public function __construct(
-		public ?RelationalIntegrityCheckData $data = null,
-		public ?string $err = null,
-	) {
-	}
+    public function __construct(
+        public ?RelationalIntegrityCheckData $data = null,
+        public ?string $err = null,
+    ) {}
 }

--- a/src/Client/Dto/Invoice.php
+++ b/src/Client/Dto/Invoice.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,21 +9,20 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class Invoice extends SpatieData
 {
-	public function __construct(
-		#[MapName('create_at')]
-		public ?int $createAt = null,
-		public ?string $id = null,
-		public ?array $item = null,
-		public ?string $number = null,
-		#[MapName('period_end')]
-		public ?int $periodEnd = null,
-		#[MapName('period_start')]
-		public ?int $periodStart = null,
-		public ?string $status = null,
-		#[MapName('subscription_id')]
-		public ?string $subscriptionId = null,
-		public ?int $tax = null,
-		public ?int $total = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('create_at')]
+        public ?int $createAt = null,
+        public ?string $id = null,
+        public ?array $item = null,
+        public ?string $number = null,
+        #[MapName('period_end')]
+        public ?int $periodEnd = null,
+        #[MapName('period_start')]
+        public ?int $periodStart = null,
+        public ?string $status = null,
+        #[MapName('subscription_id')]
+        public ?string $subscriptionId = null,
+        public ?int $tax = null,
+        public ?int $total = null,
+    ) {}
 }

--- a/src/Client/Dto/InvoiceLineItem.php
+++ b/src/Client/Dto/InvoiceLineItem.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,15 +9,17 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class InvoiceLineItem extends SpatieData
 {
-	public function __construct(
-		public ?string $description = null,
-		public ?array $metadata = null,
-		#[MapName('price_id')]
-		public ?string $priceId = null,
-		#[MapName('price_per_unit')]
-		public ?int $pricePerUnit = null,
-		public ?int $quantity = null,
-		public ?int $total = null,
-	) {
-	}
+    /**
+     * @param  array<int, mixed>  $metadata
+     */
+    public function __construct(
+        public ?string $description = null,
+        public ?array $metadata = null,
+        #[MapName('price_id')]
+        public ?string $priceId = null,
+        #[MapName('price_per_unit')]
+        public ?int $pricePerUnit = null,
+        public ?int $quantity = null,
+        public ?int $total = null,
+    ) {}
 }

--- a/src/Client/Dto/Job.php
+++ b/src/Client/Dto/Job.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,18 +9,17 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class Job extends SpatieData
 {
-	public function __construct(
-		#[MapName('create_at')]
-		public ?int $createAt = null,
-		public ?object $data = null,
-		public ?string $id = null,
-		#[MapName('last_activity_at')]
-		public ?int $lastActivityAt = null,
-		public ?int $progress = null,
-		#[MapName('start_at')]
-		public ?int $startAt = null,
-		public ?string $status = null,
-		public ?string $type = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('create_at')]
+        public ?int $createAt = null,
+        public ?object $data = null,
+        public ?string $id = null,
+        #[MapName('last_activity_at')]
+        public ?int $lastActivityAt = null,
+        public ?int $progress = null,
+        #[MapName('start_at')]
+        public ?int $startAt = null,
+        public ?string $status = null,
+        public ?string $type = null,
+    ) {}
 }

--- a/src/Client/Dto/KnownUsers.php
+++ b/src/Client/Dto/KnownUsers.php
@@ -1,13 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Data as SpatieData;
 
 class KnownUsers extends SpatieData
 {
-	public function __construct(
-		public ?string $items = null,
-	) {
-	}
+    public function __construct(
+        public ?string $items = null,
+    ) {}
 }

--- a/src/Client/Dto/Ldapgroup.php
+++ b/src/Client/Dto/Ldapgroup.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -10,14 +12,13 @@ use Spatie\LaravelData\Data as SpatieData;
  */
 class Ldapgroup extends SpatieData
 {
-	public function __construct(
-		#[MapName('has_syncables')]
-		public ?bool $hasSyncables = null,
-		#[MapName('mattermost_group_id')]
-		public ?string $mattermostGroupId = null,
-		public ?string $name = null,
-		#[MapName('primary_key')]
-		public ?string $primaryKey = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('has_syncables')]
+        public ?bool $hasSyncables = null,
+        #[MapName('mattermost_group_id')]
+        public ?string $mattermostGroupId = null,
+        public ?string $name = null,
+        #[MapName('primary_key')]
+        public ?string $primaryKey = null,
+    ) {}
 }

--- a/src/Client/Dto/LdapgroupsPaged.php
+++ b/src/Client/Dto/LdapgroupsPaged.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Data as SpatieData;
@@ -9,9 +11,11 @@ use Spatie\LaravelData\Data as SpatieData;
  */
 class LdapgroupsPaged extends SpatieData
 {
-	public function __construct(
-		public int|float|null $count = null,
-		public ?array $groups = null,
-	) {
-	}
+    /**
+     * @param  array<int, mixed>  $groups
+     */
+    public function __construct(
+        public int|float|null $count = null,
+        public ?array $groups = null,
+    ) {}
 }

--- a/src/Client/Dto/LicenseRenewalLink.php
+++ b/src/Client/Dto/LicenseRenewalLink.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,9 +9,8 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class LicenseRenewalLink extends SpatieData
 {
-	public function __construct(
-		#[MapName('renewal_link')]
-		public ?string $renewalLink = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('renewal_link')]
+        public ?string $renewalLink = null,
+    ) {}
 }

--- a/src/Client/Dto/MarketplacePlugin.php
+++ b/src/Client/Dto/MarketplacePlugin.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,20 +9,19 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class MarketplacePlugin extends SpatieData
 {
-	public function __construct(
-		#[MapName('download_url')]
-		public ?string $downloadUrl = null,
-		#[MapName('homepage_url')]
-		public ?string $homepageUrl = null,
-		#[MapName('icon_data')]
-		public ?string $iconData = null,
-		#[MapName('installed_version')]
-		public ?string $installedVersion = null,
-		public ?array $labels = null,
-		public ?PluginManifest $manifest = null,
-		#[MapName('release_notes_url')]
-		public ?string $releaseNotesUrl = null,
-		public ?string $signature = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('download_url')]
+        public ?string $downloadUrl = null,
+        #[MapName('homepage_url')]
+        public ?string $homepageUrl = null,
+        #[MapName('icon_data')]
+        public ?string $iconData = null,
+        #[MapName('installed_version')]
+        public ?string $installedVersion = null,
+        public ?array $labels = null,
+        public ?PluginManifest $manifest = null,
+        #[MapName('release_notes_url')]
+        public ?string $releaseNotesUrl = null,
+        public ?string $signature = null,
+    ) {}
 }

--- a/src/Client/Dto/MessagesLimits.php
+++ b/src/Client/Dto/MessagesLimits.php
@@ -1,13 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Data as SpatieData;
 
 class MessagesLimits extends SpatieData
 {
-	public function __construct(
-		public ?int $history = null,
-	) {
-	}
+    public function __construct(
+        public ?int $history = null,
+    ) {}
 }

--- a/src/Client/Dto/NewTeamMember.php
+++ b/src/Client/Dto/NewTeamMember.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,17 +9,16 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class NewTeamMember extends SpatieData
 {
-	public function __construct(
-		#[MapName('create_at')]
-		public ?int $createAt = null,
-		#[MapName('first_name')]
-		public ?string $firstName = null,
-		public ?string $id = null,
-		#[MapName('last_name')]
-		public ?string $lastName = null,
-		public ?string $nickname = null,
-		public ?string $position = null,
-		public ?string $username = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('create_at')]
+        public ?int $createAt = null,
+        #[MapName('first_name')]
+        public ?string $firstName = null,
+        public ?string $id = null,
+        #[MapName('last_name')]
+        public ?string $lastName = null,
+        public ?string $nickname = null,
+        public ?string $position = null,
+        public ?string $username = null,
+    ) {}
 }

--- a/src/Client/Dto/NewTeamMembersList.php
+++ b/src/Client/Dto/NewTeamMembersList.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,12 +9,11 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class NewTeamMembersList extends SpatieData
 {
-	public function __construct(
-		#[MapName('has_next')]
-		public ?bool $hasNext = null,
-		public ?array $items = null,
-		#[MapName('total_count')]
-		public ?int $totalCount = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('has_next')]
+        public ?bool $hasNext = null,
+        public ?array $items = null,
+        #[MapName('total_count')]
+        public ?int $totalCount = null,
+    ) {}
 }

--- a/src/Client/Dto/Notice.php
+++ b/src/Client/Dto/Notice.php
@@ -1,21 +1,22 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Data as SpatieData;
 
 class Notice extends SpatieData
 {
-	public function __construct(
-		public ?string $action = null,
-		public ?string $actionParam = null,
-		public ?string $actionText = null,
-		public ?string $description = null,
-		public ?string $id = null,
-		public ?string $image = null,
-		public ?bool $sysAdminOnly = null,
-		public ?bool $teamAdminOnly = null,
-		public ?string $title = null,
-	) {
-	}
+    public function __construct(
+        public ?string $action = null,
+        public ?string $actionParam = null,
+        public ?string $actionText = null,
+        public ?string $description = null,
+        public ?string $id = null,
+        public ?string $image = null,
+        public ?bool $sysAdminOnly = null,
+        public ?bool $teamAdminOnly = null,
+        public ?string $title = null,
+    ) {}
 }

--- a/src/Client/Dto/OauthApp.php
+++ b/src/Client/Dto/OauthApp.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,23 +9,22 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class OauthApp extends SpatieData
 {
-	public function __construct(
-		#[MapName('callback_urls')]
-		public ?array $callbackUrls = null,
-		#[MapName('client_secret')]
-		public ?string $clientSecret = null,
-		#[MapName('create_at')]
-		public ?int $createAt = null,
-		public ?string $description = null,
-		public ?string $homepage = null,
-		#[MapName('icon_url')]
-		public ?string $iconUrl = null,
-		public ?string $id = null,
-		#[MapName('is_trusted')]
-		public ?bool $isTrusted = null,
-		public ?string $name = null,
-		#[MapName('update_at')]
-		public ?int $updateAt = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('callback_urls')]
+        public ?array $callbackUrls = null,
+        #[MapName('client_secret')]
+        public ?string $clientSecret = null,
+        #[MapName('create_at')]
+        public ?int $createAt = null,
+        public ?string $description = null,
+        public ?string $homepage = null,
+        #[MapName('icon_url')]
+        public ?string $iconUrl = null,
+        public ?string $id = null,
+        #[MapName('is_trusted')]
+        public ?bool $isTrusted = null,
+        public ?string $name = null,
+        #[MapName('update_at')]
+        public ?int $updateAt = null,
+    ) {}
 }

--- a/src/Client/Dto/OpenGraph.php
+++ b/src/Client/Dto/OpenGraph.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -10,23 +12,26 @@ use Spatie\LaravelData\Data as SpatieData;
  */
 class OpenGraph extends SpatieData
 {
-	public function __construct(
-		public ?object $article = null,
-		public ?array $audios = null,
-		public ?object $book = null,
-		public ?string $description = null,
-		public ?string $determiner = null,
-		public ?array $images = null,
-		public ?string $locale = null,
-		#[MapName('locales_alternate')]
-		public ?array $localesAlternate = null,
-		public ?object $profile = null,
-		#[MapName('site_name')]
-		public ?string $siteName = null,
-		public ?string $title = null,
-		public ?string $type = null,
-		public ?string $url = null,
-		public ?array $videos = null,
-	) {
-	}
+    /**
+     * @param  array<int, mixed>  $audios
+     * @param  array<int, mixed>  $images
+     */
+    public function __construct(
+        public ?object $article = null,
+        public ?array $audios = null,
+        public ?object $book = null,
+        public ?string $description = null,
+        public ?string $determiner = null,
+        public ?array $images = null,
+        public ?string $locale = null,
+        #[MapName('locales_alternate')]
+        public ?array $localesAlternate = null,
+        public ?object $profile = null,
+        #[MapName('site_name')]
+        public ?string $siteName = null,
+        public ?string $title = null,
+        public ?string $type = null,
+        public ?string $url = null,
+        public ?array $videos = null,
+    ) {}
 }

--- a/src/Client/Dto/OrderedSidebarCategories.php
+++ b/src/Client/Dto/OrderedSidebarCategories.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Data as SpatieData;
@@ -9,9 +11,12 @@ use Spatie\LaravelData\Data as SpatieData;
  */
 class OrderedSidebarCategories extends SpatieData
 {
-	public function __construct(
-		public ?array $categories = null,
-		public ?array $order = null,
-	) {
-	}
+    /**
+     * @param  array<int, mixed>  $categories
+     * @param  array<int, mixed>  $order
+     */
+    public function __construct(
+        public ?array $categories = null,
+        public ?array $order = null,
+    ) {}
 }

--- a/src/Client/Dto/OrphanedRecord.php
+++ b/src/Client/Dto/OrphanedRecord.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -10,11 +12,10 @@ use Spatie\LaravelData\Data as SpatieData;
  */
 class OrphanedRecord extends SpatieData
 {
-	public function __construct(
-		#[MapName('child_id')]
-		public ?string $childId = null,
-		#[MapName('parent_id')]
-		public ?string $parentId = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('child_id')]
+        public ?string $childId = null,
+        #[MapName('parent_id')]
+        public ?string $parentId = null,
+    ) {}
 }

--- a/src/Client/Dto/OutgoingWebhook.php
+++ b/src/Client/Dto/OutgoingWebhook.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,31 +9,30 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class OutgoingWebhook extends SpatieData
 {
-	public function __construct(
-		#[MapName('callback_urls')]
-		public ?array $callbackUrls = null,
-		#[MapName('channel_id')]
-		public ?string $channelId = null,
-		#[MapName('content_type')]
-		public ?string $contentType = null,
-		#[MapName('create_at')]
-		public ?int $createAt = null,
-		#[MapName('creator_id')]
-		public ?string $creatorId = null,
-		#[MapName('delete_at')]
-		public ?int $deleteAt = null,
-		public ?string $description = null,
-		#[MapName('display_name')]
-		public ?string $displayName = null,
-		public ?string $id = null,
-		#[MapName('team_id')]
-		public ?string $teamId = null,
-		#[MapName('trigger_when')]
-		public ?int $triggerWhen = null,
-		#[MapName('trigger_words')]
-		public ?array $triggerWords = null,
-		#[MapName('update_at')]
-		public ?int $updateAt = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('callback_urls')]
+        public ?array $callbackUrls = null,
+        #[MapName('channel_id')]
+        public ?string $channelId = null,
+        #[MapName('content_type')]
+        public ?string $contentType = null,
+        #[MapName('create_at')]
+        public ?int $createAt = null,
+        #[MapName('creator_id')]
+        public ?string $creatorId = null,
+        #[MapName('delete_at')]
+        public ?int $deleteAt = null,
+        public ?string $description = null,
+        #[MapName('display_name')]
+        public ?string $displayName = null,
+        public ?string $id = null,
+        #[MapName('team_id')]
+        public ?string $teamId = null,
+        #[MapName('trigger_when')]
+        public ?int $triggerWhen = null,
+        #[MapName('trigger_words')]
+        public ?array $triggerWords = null,
+        #[MapName('update_at')]
+        public ?int $updateAt = null,
+    ) {}
 }

--- a/src/Client/Dto/OwnerInfo.php
+++ b/src/Client/Dto/OwnerInfo.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,10 +9,9 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class OwnerInfo extends SpatieData
 {
-	public function __construct(
-		#[MapName('user_id')]
-		public ?string $userId = null,
-		public ?string $username = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('user_id')]
+        public ?string $userId = null,
+        public ?string $username = null,
+    ) {}
 }

--- a/src/Client/Dto/PaymentMethod.php
+++ b/src/Client/Dto/PaymentMethod.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,17 +9,16 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class PaymentMethod extends SpatieData
 {
-	public function __construct(
-		#[MapName('card_brand')]
-		public ?string $cardBrand = null,
-		#[MapName('exp_month')]
-		public ?int $expMonth = null,
-		#[MapName('exp_year')]
-		public ?int $expYear = null,
-		#[MapName('last_four')]
-		public ?int $lastFour = null,
-		public ?string $name = null,
-		public ?string $type = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('card_brand')]
+        public ?string $cardBrand = null,
+        #[MapName('exp_month')]
+        public ?int $expMonth = null,
+        #[MapName('exp_year')]
+        public ?int $expYear = null,
+        #[MapName('last_four')]
+        public ?int $lastFour = null,
+        public ?string $name = null,
+        public ?string $type = null,
+    ) {}
 }

--- a/src/Client/Dto/PaymentSetupIntent.php
+++ b/src/Client/Dto/PaymentSetupIntent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,10 +9,9 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class PaymentSetupIntent extends SpatieData
 {
-	public function __construct(
-		#[MapName('client_secret')]
-		public ?string $clientSecret = null,
-		public ?string $id = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('client_secret')]
+        public ?string $clientSecret = null,
+        public ?string $id = null,
+    ) {}
 }

--- a/src/Client/Dto/Playbook.php
+++ b/src/Client/Dto/Playbook.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,25 +9,27 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class Playbook extends SpatieData
 {
-	public function __construct(
-		public ?array $checklists = null,
-		#[MapName('create_at')]
-		public ?int $createAt = null,
-		#[MapName('create_public_playbook_run')]
-		public ?bool $createPublicPlaybookRun = null,
-		#[MapName('delete_at')]
-		public ?int $deleteAt = null,
-		public ?string $description = null,
-		public ?string $id = null,
-		#[MapName('member_ids')]
-		public ?array $memberIds = null,
-		#[MapName('num_stages')]
-		public ?int $numStages = null,
-		#[MapName('num_steps')]
-		public ?int $numSteps = null,
-		#[MapName('team_id')]
-		public ?string $teamId = null,
-		public ?string $title = null,
-	) {
-	}
+    /**
+     * @param  array<int, mixed>  $checklists
+     */
+    public function __construct(
+        public ?array $checklists = null,
+        #[MapName('create_at')]
+        public ?int $createAt = null,
+        #[MapName('create_public_playbook_run')]
+        public ?bool $createPublicPlaybookRun = null,
+        #[MapName('delete_at')]
+        public ?int $deleteAt = null,
+        public ?string $description = null,
+        public ?string $id = null,
+        #[MapName('member_ids')]
+        public ?array $memberIds = null,
+        #[MapName('num_stages')]
+        public ?int $numStages = null,
+        #[MapName('num_steps')]
+        public ?int $numSteps = null,
+        #[MapName('team_id')]
+        public ?string $teamId = null,
+        public ?string $title = null,
+    ) {}
 }

--- a/src/Client/Dto/PlaybookAutofollows.php
+++ b/src/Client/Dto/PlaybookAutofollows.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,10 +9,12 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class PlaybookAutofollows extends SpatieData
 {
-	public function __construct(
-		public ?array $items = null,
-		#[MapName('total_count')]
-		public ?int $totalCount = null,
-	) {
-	}
+    /**
+     * @param  array<int, mixed>  $items
+     */
+    public function __construct(
+        public ?array $items = null,
+        #[MapName('total_count')]
+        public ?int $totalCount = null,
+    ) {}
 }

--- a/src/Client/Dto/PlaybookList.php
+++ b/src/Client/Dto/PlaybookList.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,14 +9,13 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class PlaybookList extends SpatieData
 {
-	public function __construct(
-		#[MapName('has_more')]
-		public ?bool $hasMore = null,
-		public ?array $items = null,
-		#[MapName('page_count')]
-		public ?int $pageCount = null,
-		#[MapName('total_count')]
-		public ?int $totalCount = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('has_more')]
+        public ?bool $hasMore = null,
+        public ?array $items = null,
+        #[MapName('page_count')]
+        public ?int $pageCount = null,
+        #[MapName('total_count')]
+        public ?int $totalCount = null,
+    ) {}
 }

--- a/src/Client/Dto/PlaybookRun.php
+++ b/src/Client/Dto/PlaybookRun.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,33 +9,32 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class PlaybookRun extends SpatieData
 {
-	public function __construct(
-		#[MapName('active_stage')]
-		public ?int $activeStage = null,
-		#[MapName('active_stage_title')]
-		public ?string $activeStageTitle = null,
-		#[MapName('channel_id')]
-		public ?string $channelId = null,
-		public ?array $checklists = null,
-		#[MapName('create_at')]
-		public ?int $createAt = null,
-		#[MapName('delete_at')]
-		public ?int $deleteAt = null,
-		#[MapName('end_at')]
-		public ?int $endAt = null,
-		public ?string $id = null,
-		#[MapName('is_active')]
-		public ?bool $isActive = null,
-		public ?string $name = null,
-		#[MapName('owner_user_id')]
-		public ?string $ownerUserId = null,
-		#[MapName('playbook_id')]
-		public ?string $playbookId = null,
-		#[MapName('post_id')]
-		public ?string $postId = null,
-		public ?string $summary = null,
-		#[MapName('team_id')]
-		public ?string $teamId = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('active_stage')]
+        public ?int $activeStage = null,
+        #[MapName('active_stage_title')]
+        public ?string $activeStageTitle = null,
+        #[MapName('channel_id')]
+        public ?string $channelId = null,
+        public ?array $checklists = null,
+        #[MapName('create_at')]
+        public ?int $createAt = null,
+        #[MapName('delete_at')]
+        public ?int $deleteAt = null,
+        #[MapName('end_at')]
+        public ?int $endAt = null,
+        public ?string $id = null,
+        #[MapName('is_active')]
+        public ?bool $isActive = null,
+        public ?string $name = null,
+        #[MapName('owner_user_id')]
+        public ?string $ownerUserId = null,
+        #[MapName('playbook_id')]
+        public ?string $playbookId = null,
+        #[MapName('post_id')]
+        public ?string $postId = null,
+        public ?string $summary = null,
+        #[MapName('team_id')]
+        public ?string $teamId = null,
+    ) {}
 }

--- a/src/Client/Dto/PlaybookRunList.php
+++ b/src/Client/Dto/PlaybookRunList.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,14 +9,13 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class PlaybookRunList extends SpatieData
 {
-	public function __construct(
-		#[MapName('has_more')]
-		public ?bool $hasMore = null,
-		public ?array $items = null,
-		#[MapName('page_count')]
-		public ?int $pageCount = null,
-		#[MapName('total_count')]
-		public ?int $totalCount = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('has_more')]
+        public ?bool $hasMore = null,
+        public ?array $items = null,
+        #[MapName('page_count')]
+        public ?int $pageCount = null,
+        #[MapName('total_count')]
+        public ?int $totalCount = null,
+    ) {}
 }

--- a/src/Client/Dto/PlaybookRunMetadata.php
+++ b/src/Client/Dto/PlaybookRunMetadata.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,17 +9,16 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class PlaybookRunMetadata extends SpatieData
 {
-	public function __construct(
-		#[MapName('channel_display_name')]
-		public ?string $channelDisplayName = null,
-		#[MapName('channel_name')]
-		public ?string $channelName = null,
-		#[MapName('num_members')]
-		public ?int $numMembers = null,
-		#[MapName('team_name')]
-		public ?string $teamName = null,
-		#[MapName('total_posts')]
-		public ?int $totalPosts = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('channel_display_name')]
+        public ?string $channelDisplayName = null,
+        #[MapName('channel_name')]
+        public ?string $channelName = null,
+        #[MapName('num_members')]
+        public ?int $numMembers = null,
+        #[MapName('team_name')]
+        public ?string $teamName = null,
+        #[MapName('total_posts')]
+        public ?int $totalPosts = null,
+    ) {}
 }

--- a/src/Client/Dto/PluginManifest.php
+++ b/src/Client/Dto/PluginManifest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,18 +9,17 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class PluginManifest extends SpatieData
 {
-	public function __construct(
-		public ?object $backend = null,
-		public ?string $description = null,
-		public ?string $id = null,
-		#[MapName('min_server_version')]
-		public ?string $minServerVersion = null,
-		public ?string $name = null,
-		public ?object $server = null,
-		#[MapName('settings_schema')]
-		public ?object $settingsSchema = null,
-		public ?string $version = null,
-		public ?object $webapp = null,
-	) {
-	}
+    public function __construct(
+        public ?object $backend = null,
+        public ?string $description = null,
+        public ?string $id = null,
+        #[MapName('min_server_version')]
+        public ?string $minServerVersion = null,
+        public ?string $name = null,
+        public ?object $server = null,
+        #[MapName('settings_schema')]
+        public ?object $settingsSchema = null,
+        public ?string $version = null,
+        public ?object $webapp = null,
+    ) {}
 }

--- a/src/Client/Dto/PluginManifestWebapp.php
+++ b/src/Client/Dto/PluginManifestWebapp.php
@@ -1,15 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Data as SpatieData;
 
 class PluginManifestWebapp extends SpatieData
 {
-	public function __construct(
-		public ?string $id = null,
-		public ?string $version = null,
-		public ?object $webapp = null,
-	) {
-	}
+    public function __construct(
+        public ?string $id = null,
+        public ?string $version = null,
+        public ?object $webapp = null,
+    ) {}
 }

--- a/src/Client/Dto/PluginStatus.php
+++ b/src/Client/Dto/PluginStatus.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,17 +9,16 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class PluginStatus extends SpatieData
 {
-	public function __construct(
-		#[MapName('cluster_id')]
-		public ?string $clusterId = null,
-		public ?string $description = null,
-		public ?string $name = null,
-		#[MapName('plugin_id')]
-		public ?string $pluginId = null,
-		#[MapName('plugin_path')]
-		public ?string $pluginPath = null,
-		public int|float|null $state = null,
-		public ?string $version = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('cluster_id')]
+        public ?string $clusterId = null,
+        public ?string $description = null,
+        public ?string $name = null,
+        #[MapName('plugin_id')]
+        public ?string $pluginId = null,
+        #[MapName('plugin_path')]
+        public ?string $pluginPath = null,
+        public int|float|null $state = null,
+        public ?string $version = null,
+    ) {}
 }

--- a/src/Client/Dto/Post.php
+++ b/src/Client/Dto/Post.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,33 +9,32 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class Post extends SpatieData
 {
-	public function __construct(
-		#[MapName('channel_id')]
-		public ?string $channelId = null,
-		#[MapName('create_at')]
-		public ?int $createAt = null,
-		#[MapName('delete_at')]
-		public ?int $deleteAt = null,
-		#[MapName('edit_at')]
-		public ?int $editAt = null,
-		#[MapName('file_ids')]
-		public ?array $fileIds = null,
-		public ?string $hashtag = null,
-		public ?string $id = null,
-		public ?string $message = null,
-		public ?PostMetadata $metadata = null,
-		#[MapName('original_id')]
-		public ?string $originalId = null,
-		#[MapName('pending_post_id')]
-		public ?string $pendingPostId = null,
-		public ?object $props = null,
-		#[MapName('root_id')]
-		public ?string $rootId = null,
-		public ?string $type = null,
-		#[MapName('update_at')]
-		public ?int $updateAt = null,
-		#[MapName('user_id')]
-		public ?string $userId = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('channel_id')]
+        public ?string $channelId = null,
+        #[MapName('create_at')]
+        public ?int $createAt = null,
+        #[MapName('delete_at')]
+        public ?int $deleteAt = null,
+        #[MapName('edit_at')]
+        public ?int $editAt = null,
+        #[MapName('file_ids')]
+        public ?array $fileIds = null,
+        public ?string $hashtag = null,
+        public ?string $id = null,
+        public ?string $message = null,
+        public ?PostMetadata $metadata = null,
+        #[MapName('original_id')]
+        public ?string $originalId = null,
+        #[MapName('pending_post_id')]
+        public ?string $pendingPostId = null,
+        public ?object $props = null,
+        #[MapName('root_id')]
+        public ?string $rootId = null,
+        public ?string $type = null,
+        #[MapName('update_at')]
+        public ?int $updateAt = null,
+        #[MapName('user_id')]
+        public ?string $userId = null,
+    ) {}
 }

--- a/src/Client/Dto/PostAcknowledgement.php
+++ b/src/Client/Dto/PostAcknowledgement.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,13 +9,12 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class PostAcknowledgement extends SpatieData
 {
-	public function __construct(
-		#[MapName('acknowledged_at')]
-		public ?int $acknowledgedAt = null,
-		#[MapName('post_id')]
-		public ?string $postId = null,
-		#[MapName('user_id')]
-		public ?string $userId = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('acknowledged_at')]
+        public ?int $acknowledgedAt = null,
+        #[MapName('post_id')]
+        public ?string $postId = null,
+        #[MapName('user_id')]
+        public ?string $userId = null,
+    ) {}
 }

--- a/src/Client/Dto/PostIdToReactionsMap.php
+++ b/src/Client/Dto/PostIdToReactionsMap.php
@@ -1,12 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Data as SpatieData;
 
-class PostIdToReactionsMap extends SpatieData
-{
-	public function __construct()
-	{
-	}
-}
+class PostIdToReactionsMap extends SpatieData {}

--- a/src/Client/Dto/PostList.php
+++ b/src/Client/Dto/PostList.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,15 +9,14 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class PostList extends SpatieData
 {
-	public function __construct(
-		#[MapName('has_next')]
-		public ?bool $hasNext = null,
-		#[MapName('next_post_id')]
-		public ?string $nextPostId = null,
-		public ?array $order = null,
-		public ?object $posts = null,
-		#[MapName('prev_post_id')]
-		public ?string $prevPostId = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('has_next')]
+        public ?bool $hasNext = null,
+        #[MapName('next_post_id')]
+        public ?string $nextPostId = null,
+        public ?array $order = null,
+        public ?object $posts = null,
+        #[MapName('prev_post_id')]
+        public ?string $prevPostId = null,
+    ) {}
 }

--- a/src/Client/Dto/PostListWithSearchMatches.php
+++ b/src/Client/Dto/PostListWithSearchMatches.php
@@ -1,15 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Data as SpatieData;
 
 class PostListWithSearchMatches extends SpatieData
 {
-	public function __construct(
-		public ?object $matches = null,
-		public ?array $order = null,
-		public ?object $posts = null,
-	) {
-	}
+    /**
+     * @param  array<int, mixed>  $order
+     */
+    public function __construct(
+        public ?object $matches = null,
+        public ?array $order = null,
+        public ?object $posts = null,
+    ) {}
 }

--- a/src/Client/Dto/PostMetadata.php
+++ b/src/Client/Dto/PostMetadata.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Data as SpatieData;
@@ -9,14 +11,20 @@ use Spatie\LaravelData\Data as SpatieData;
  */
 class PostMetadata extends SpatieData
 {
-	public function __construct(
-		public ?array $acknowledgements = null,
-		public ?array $embeds = null,
-		public ?array $emojis = null,
-		public ?array $files = null,
-		public ?object $images = null,
-		public ?object $priority = null,
-		public ?array $reactions = null,
-	) {
-	}
+    /**
+     * @param  array<int, mixed>  $acknowledgements
+     * @param  array<int, mixed>  $embeds
+     * @param  array<int, mixed>  $emojis
+     * @param  array<int, mixed>  $files
+     * @param  array<int, mixed>  $reactions
+     */
+    public function __construct(
+        public ?array $acknowledgements = null,
+        public ?array $embeds = null,
+        public ?array $emojis = null,
+        public ?array $files = null,
+        public ?object $images = null,
+        public ?object $priority = null,
+        public ?array $reactions = null,
+    ) {}
 }

--- a/src/Client/Dto/PostsUsage.php
+++ b/src/Client/Dto/PostsUsage.php
@@ -1,13 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Data as SpatieData;
 
 class PostsUsage extends SpatieData
 {
-	public function __construct(
-		public int|float|null $count = null,
-	) {
-	}
+    public function __construct(
+        public int|float|null $count = null,
+    ) {}
 }

--- a/src/Client/Dto/Preference.php
+++ b/src/Client/Dto/Preference.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,12 +9,11 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class Preference extends SpatieData
 {
-	public function __construct(
-		public ?string $category = null,
-		public ?string $name = null,
-		#[MapName('user_id')]
-		public ?string $userId = null,
-		public ?string $value = null,
-	) {
-	}
+    public function __construct(
+        public ?string $category = null,
+        public ?string $name = null,
+        #[MapName('user_id')]
+        public ?string $userId = null,
+        public ?string $value = null,
+    ) {}
 }

--- a/src/Client/Dto/Product.php
+++ b/src/Client/Dto/Product.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,14 +9,13 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class Product extends SpatieData
 {
-	public function __construct(
-		#[MapName('add_ons')]
-		public ?array $addOns = null,
-		public ?string $description = null,
-		public ?string $id = null,
-		public ?string $name = null,
-		#[MapName('price_per_seat')]
-		public ?string $pricePerSeat = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('add_ons')]
+        public ?array $addOns = null,
+        public ?string $description = null,
+        public ?string $id = null,
+        public ?string $name = null,
+        #[MapName('price_per_seat')]
+        public ?string $pricePerSeat = null,
+    ) {}
 }

--- a/src/Client/Dto/ProductLimits.php
+++ b/src/Client/Dto/ProductLimits.php
@@ -1,17 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Data as SpatieData;
 
 class ProductLimits extends SpatieData
 {
-	public function __construct(
-		public ?BoardsLimits $boards = null,
-		public ?FilesLimits $files = null,
-		public ?IntegrationsLimits $integrations = null,
-		public ?MessagesLimits $messages = null,
-		public ?TeamsLimits $teams = null,
-	) {
-	}
+    public function __construct(
+        public ?BoardsLimits $boards = null,
+        public ?FilesLimits $files = null,
+        public ?IntegrationsLimits $integrations = null,
+        public ?MessagesLimits $messages = null,
+        public ?TeamsLimits $teams = null,
+    ) {}
 }

--- a/src/Client/Dto/PropertyField.php
+++ b/src/Client/Dto/PropertyField.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,18 +9,17 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class PropertyField extends SpatieData
 {
-	public function __construct(
-		public ?object $attrs = null,
-		#[MapName('create_at')]
-		public ?int $createAt = null,
-		#[MapName('delete_at')]
-		public ?int $deleteAt = null,
-		public ?string $description = null,
-		public ?string $id = null,
-		public ?string $name = null,
-		public ?string $type = null,
-		#[MapName('update_at')]
-		public ?int $updateAt = null,
-	) {
-	}
+    public function __construct(
+        public ?object $attrs = null,
+        #[MapName('create_at')]
+        public ?int $createAt = null,
+        #[MapName('delete_at')]
+        public ?int $deleteAt = null,
+        public ?string $description = null,
+        public ?string $id = null,
+        public ?string $name = null,
+        public ?string $type = null,
+        #[MapName('update_at')]
+        public ?int $updateAt = null,
+    ) {}
 }

--- a/src/Client/Dto/PropertyFieldRequest.php
+++ b/src/Client/Dto/PropertyFieldRequest.php
@@ -1,15 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Data as SpatieData;
 
 class PropertyFieldRequest extends SpatieData
 {
-	public function __construct(
-		public ?object $attrs = null,
-		public ?string $name = null,
-		public ?string $type = null,
-	) {
-	}
+    public function __construct(
+        public ?object $attrs = null,
+        public ?string $name = null,
+        public ?string $type = null,
+    ) {}
 }

--- a/src/Client/Dto/PropertyValue.php
+++ b/src/Client/Dto/PropertyValue.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,17 +9,16 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class PropertyValue extends SpatieData
 {
-	public function __construct(
-		#[MapName('create_at')]
-		public ?int $createAt = null,
-		#[MapName('delete_at')]
-		public ?int $deleteAt = null,
-		#[MapName('field_id')]
-		public ?string $fieldId = null,
-		public ?string $id = null,
-		#[MapName('update_at')]
-		public ?int $updateAt = null,
-		public ?string $value = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('create_at')]
+        public ?int $createAt = null,
+        #[MapName('delete_at')]
+        public ?int $deleteAt = null,
+        #[MapName('field_id')]
+        public ?string $fieldId = null,
+        public ?string $id = null,
+        #[MapName('update_at')]
+        public ?int $updateAt = null,
+        public ?string $value = null,
+    ) {}
 }

--- a/src/Client/Dto/PropertyValueRequest.php
+++ b/src/Client/Dto/PropertyValueRequest.php
@@ -1,13 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Data as SpatieData;
 
 class PropertyValueRequest extends SpatieData
 {
-	public function __construct(
-		public ?string $value = null,
-	) {
-	}
+    public function __construct(
+        public ?string $value = null,
+    ) {}
 }

--- a/src/Client/Dto/PushNotification.php
+++ b/src/Client/Dto/PushNotification.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,44 +9,43 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class PushNotification extends SpatieData
 {
-	public function __construct(
-		#[MapName('ack_id')]
-		public ?string $ackId = null,
-		public int|float|null $badge = null,
-		public ?string $category = null,
-		#[MapName('channel_id')]
-		public ?string $channelId = null,
-		#[MapName('channel_name')]
-		public ?string $channelName = null,
-		#[MapName('cont_ava')]
-		public int|float|null $contAva = null,
-		#[MapName('device_id')]
-		public ?string $deviceId = null,
-		#[MapName('from_webhook')]
-		public ?string $fromWebhook = null,
-		#[MapName('is_id_loaded')]
-		public ?bool $isIdLoaded = null,
-		public ?string $message = null,
-		#[MapName('override_icon_url')]
-		public ?string $overrideIconUrl = null,
-		#[MapName('override_username')]
-		public ?string $overrideUsername = null,
-		public ?string $platform = null,
-		#[MapName('post_id')]
-		public ?string $postId = null,
-		#[MapName('root_id')]
-		public ?string $rootId = null,
-		#[MapName('sender_id')]
-		public ?string $senderId = null,
-		#[MapName('sender_name')]
-		public ?string $senderName = null,
-		#[MapName('server_id')]
-		public ?string $serverId = null,
-		public ?string $sound = null,
-		#[MapName('team_id')]
-		public ?string $teamId = null,
-		public ?string $type = null,
-		public ?string $version = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('ack_id')]
+        public ?string $ackId = null,
+        public int|float|null $badge = null,
+        public ?string $category = null,
+        #[MapName('channel_id')]
+        public ?string $channelId = null,
+        #[MapName('channel_name')]
+        public ?string $channelName = null,
+        #[MapName('cont_ava')]
+        public int|float|null $contAva = null,
+        #[MapName('device_id')]
+        public ?string $deviceId = null,
+        #[MapName('from_webhook')]
+        public ?string $fromWebhook = null,
+        #[MapName('is_id_loaded')]
+        public ?bool $isIdLoaded = null,
+        public ?string $message = null,
+        #[MapName('override_icon_url')]
+        public ?string $overrideIconUrl = null,
+        #[MapName('override_username')]
+        public ?string $overrideUsername = null,
+        public ?string $platform = null,
+        #[MapName('post_id')]
+        public ?string $postId = null,
+        #[MapName('root_id')]
+        public ?string $rootId = null,
+        #[MapName('sender_id')]
+        public ?string $senderId = null,
+        #[MapName('sender_name')]
+        public ?string $senderName = null,
+        #[MapName('server_id')]
+        public ?string $serverId = null,
+        public ?string $sound = null,
+        #[MapName('team_id')]
+        public ?string $teamId = null,
+        public ?string $type = null,
+        public ?string $version = null,
+    ) {}
 }

--- a/src/Client/Dto/Reaction.php
+++ b/src/Client/Dto/Reaction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,15 +9,14 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class Reaction extends SpatieData
 {
-	public function __construct(
-		#[MapName('create_at')]
-		public ?int $createAt = null,
-		#[MapName('emoji_name')]
-		public ?string $emojiName = null,
-		#[MapName('post_id')]
-		public ?string $postId = null,
-		#[MapName('user_id')]
-		public ?string $userId = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('create_at')]
+        public ?int $createAt = null,
+        #[MapName('emoji_name')]
+        public ?string $emojiName = null,
+        #[MapName('post_id')]
+        public ?string $postId = null,
+        #[MapName('user_id')]
+        public ?string $userId = null,
+    ) {}
 }

--- a/src/Client/Dto/RelationalIntegrityCheckData.php
+++ b/src/Client/Dto/RelationalIntegrityCheckData.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -10,16 +12,15 @@ use Spatie\LaravelData\Data as SpatieData;
  */
 class RelationalIntegrityCheckData extends SpatieData
 {
-	public function __construct(
-		#[MapName('child_id_attr')]
-		public ?string $childIdAttr = null,
-		#[MapName('child_name')]
-		public ?string $childName = null,
-		#[MapName('parent_id_attr')]
-		public ?string $parentIdAttr = null,
-		#[MapName('parent_name')]
-		public ?string $parentName = null,
-		public ?array $records = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('child_id_attr')]
+        public ?string $childIdAttr = null,
+        #[MapName('child_name')]
+        public ?string $childName = null,
+        #[MapName('parent_id_attr')]
+        public ?string $parentIdAttr = null,
+        #[MapName('parent_name')]
+        public ?string $parentName = null,
+        public ?array $records = null,
+    ) {}
 }

--- a/src/Client/Dto/RemoteClusterInfo.php
+++ b/src/Client/Dto/RemoteClusterInfo.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,13 +9,12 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class RemoteClusterInfo extends SpatieData
 {
-	public function __construct(
-		#[MapName('create_at')]
-		public ?int $createAt = null,
-		#[MapName('display_name')]
-		public ?string $displayName = null,
-		#[MapName('last_ping_at')]
-		public ?int $lastPingAt = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('create_at')]
+        public ?int $createAt = null,
+        #[MapName('display_name')]
+        public ?string $displayName = null,
+        #[MapName('last_ping_at')]
+        public ?int $lastPingAt = null,
+    ) {}
 }

--- a/src/Client/Dto/RetentionPolicyForChannelList.php
+++ b/src/Client/Dto/RetentionPolicyForChannelList.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,10 +9,12 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class RetentionPolicyForChannelList extends SpatieData
 {
-	public function __construct(
-		public ?array $policies = null,
-		#[MapName('total_count')]
-		public ?int $totalCount = null,
-	) {
-	}
+    /**
+     * @param  array<int, mixed>  $policies
+     */
+    public function __construct(
+        public ?array $policies = null,
+        #[MapName('total_count')]
+        public ?int $totalCount = null,
+    ) {}
 }

--- a/src/Client/Dto/RetentionPolicyForTeamList.php
+++ b/src/Client/Dto/RetentionPolicyForTeamList.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,10 +9,12 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class RetentionPolicyForTeamList extends SpatieData
 {
-	public function __construct(
-		public ?array $policies = null,
-		#[MapName('total_count')]
-		public ?int $totalCount = null,
-	) {
-	}
+    /**
+     * @param  array<int, mixed>  $policies
+     */
+    public function __construct(
+        public ?array $policies = null,
+        #[MapName('total_count')]
+        public ?int $totalCount = null,
+    ) {}
 }

--- a/src/Client/Dto/Role.php
+++ b/src/Client/Dto/Role.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,15 +9,14 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class Role extends SpatieData
 {
-	public function __construct(
-		public ?string $description = null,
-		#[MapName('display_name')]
-		public ?string $displayName = null,
-		public ?string $id = null,
-		public ?string $name = null,
-		public ?array $permissions = null,
-		#[MapName('scheme_managed')]
-		public ?bool $schemeManaged = null,
-	) {
-	}
+    public function __construct(
+        public ?string $description = null,
+        #[MapName('display_name')]
+        public ?string $displayName = null,
+        public ?string $id = null,
+        public ?string $name = null,
+        public ?array $permissions = null,
+        #[MapName('scheme_managed')]
+        public ?bool $schemeManaged = null,
+    ) {}
 }

--- a/src/Client/Dto/SamlCertificateStatus.php
+++ b/src/Client/Dto/SamlCertificateStatus.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,13 +9,12 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class SamlCertificateStatus extends SpatieData
 {
-	public function __construct(
-		#[MapName('idp_certificate_file')]
-		public ?bool $idpCertificateFile = null,
-		#[MapName('private_key_file')]
-		public ?bool $privateKeyFile = null,
-		#[MapName('public_certificate_file')]
-		public ?bool $publicCertificateFile = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('idp_certificate_file')]
+        public ?bool $idpCertificateFile = null,
+        #[MapName('private_key_file')]
+        public ?bool $privateKeyFile = null,
+        #[MapName('public_certificate_file')]
+        public ?bool $publicCertificateFile = null,
+    ) {}
 }

--- a/src/Client/Dto/Scheme.php
+++ b/src/Client/Dto/Scheme.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,25 +9,24 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class Scheme extends SpatieData
 {
-	public function __construct(
-		#[MapName('create_at')]
-		public ?int $createAt = null,
-		#[MapName('default_channel_admin_role')]
-		public ?string $defaultChannelAdminRole = null,
-		#[MapName('default_channel_user_role')]
-		public ?string $defaultChannelUserRole = null,
-		#[MapName('default_team_admin_role')]
-		public ?string $defaultTeamAdminRole = null,
-		#[MapName('default_team_user_role')]
-		public ?string $defaultTeamUserRole = null,
-		#[MapName('delete_at')]
-		public ?int $deleteAt = null,
-		public ?string $description = null,
-		public ?string $id = null,
-		public ?string $name = null,
-		public ?string $scope = null,
-		#[MapName('update_at')]
-		public ?int $updateAt = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('create_at')]
+        public ?int $createAt = null,
+        #[MapName('default_channel_admin_role')]
+        public ?string $defaultChannelAdminRole = null,
+        #[MapName('default_channel_user_role')]
+        public ?string $defaultChannelUserRole = null,
+        #[MapName('default_team_admin_role')]
+        public ?string $defaultTeamAdminRole = null,
+        #[MapName('default_team_user_role')]
+        public ?string $defaultTeamUserRole = null,
+        #[MapName('delete_at')]
+        public ?int $deleteAt = null,
+        public ?string $description = null,
+        public ?string $id = null,
+        public ?string $name = null,
+        public ?string $scope = null,
+        #[MapName('update_at')]
+        public ?int $updateAt = null,
+    ) {}
 }

--- a/src/Client/Dto/ServerBusy.php
+++ b/src/Client/Dto/ServerBusy.php
@@ -1,14 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Data as SpatieData;
 
 class ServerBusy extends SpatieData
 {
-	public function __construct(
-		public ?bool $busy = null,
-		public ?int $expires = null,
-	) {
-	}
+    public function __construct(
+        public ?bool $busy = null,
+        public ?int $expires = null,
+    ) {}
 }

--- a/src/Client/Dto/Session.php
+++ b/src/Client/Dto/Session.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,25 +9,24 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class Session extends SpatieData
 {
-	public function __construct(
-		#[MapName('create_at')]
-		public ?int $createAt = null,
-		#[MapName('device_id')]
-		public ?string $deviceId = null,
-		#[MapName('expires_at')]
-		public ?int $expiresAt = null,
-		public ?string $id = null,
-		#[MapName('is_oauth')]
-		public ?bool $isOauth = null,
-		#[MapName('last_activity_at')]
-		public ?int $lastActivityAt = null,
-		public ?object $props = null,
-		public ?string $roles = null,
-		#[MapName('team_members')]
-		public ?array $teamMembers = null,
-		public ?string $token = null,
-		#[MapName('user_id')]
-		public ?string $userId = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('create_at')]
+        public ?int $createAt = null,
+        #[MapName('device_id')]
+        public ?string $deviceId = null,
+        #[MapName('expires_at')]
+        public ?int $expiresAt = null,
+        public ?string $id = null,
+        #[MapName('is_oauth')]
+        public ?bool $isOauth = null,
+        #[MapName('last_activity_at')]
+        public ?int $lastActivityAt = null,
+        public ?object $props = null,
+        public ?string $roles = null,
+        #[MapName('team_members')]
+        public ?array $teamMembers = null,
+        public ?string $token = null,
+        #[MapName('user_id')]
+        public ?string $userId = null,
+    ) {}
 }

--- a/src/Client/Dto/SharedChannel.php
+++ b/src/Client/Dto/SharedChannel.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,25 +9,24 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class SharedChannel extends SpatieData
 {
-	public function __construct(
-		#[MapName('create_at')]
-		public ?int $createAt = null,
-		#[MapName('creator_id')]
-		public ?string $creatorId = null,
-		#[MapName('display_name')]
-		public ?string $displayName = null,
-		public ?string $header = null,
-		public ?bool $home = null,
-		public ?string $id = null,
-		public ?string $name = null,
-		public ?string $purpose = null,
-		public ?bool $readonly = null,
-		#[MapName('remote_id')]
-		public ?string $remoteId = null,
-		#[MapName('team_id')]
-		public ?string $teamId = null,
-		#[MapName('update_at')]
-		public ?int $updateAt = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('create_at')]
+        public ?int $createAt = null,
+        #[MapName('creator_id')]
+        public ?string $creatorId = null,
+        #[MapName('display_name')]
+        public ?string $displayName = null,
+        public ?string $header = null,
+        public ?bool $home = null,
+        public ?string $id = null,
+        public ?string $name = null,
+        public ?string $purpose = null,
+        public ?bool $readonly = null,
+        #[MapName('remote_id')]
+        public ?string $remoteId = null,
+        #[MapName('team_id')]
+        public ?string $teamId = null,
+        #[MapName('update_at')]
+        public ?int $updateAt = null,
+    ) {}
 }

--- a/src/Client/Dto/SidebarCategory.php
+++ b/src/Client/Dto/SidebarCategory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -10,15 +12,14 @@ use Spatie\LaravelData\Data as SpatieData;
  */
 class SidebarCategory extends SpatieData
 {
-	public function __construct(
-		#[MapName('display_name')]
-		public ?string $displayName = null,
-		public ?string $id = null,
-		#[MapName('team_id')]
-		public ?string $teamId = null,
-		public ?string $type = null,
-		#[MapName('user_id')]
-		public ?string $userId = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('display_name')]
+        public ?string $displayName = null,
+        public ?string $id = null,
+        #[MapName('team_id')]
+        public ?string $teamId = null,
+        public ?string $type = null,
+        #[MapName('user_id')]
+        public ?string $userId = null,
+    ) {}
 }

--- a/src/Client/Dto/SidebarCategoryWithChannels.php
+++ b/src/Client/Dto/SidebarCategoryWithChannels.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -10,17 +12,16 @@ use Spatie\LaravelData\Data as SpatieData;
  */
 class SidebarCategoryWithChannels extends SpatieData
 {
-	public function __construct(
-		#[MapName('channel_ids')]
-		public ?array $channelIds = null,
-		#[MapName('display_name')]
-		public ?string $displayName = null,
-		public ?string $id = null,
-		#[MapName('team_id')]
-		public ?string $teamId = null,
-		public ?string $type = null,
-		#[MapName('user_id')]
-		public ?string $userId = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('channel_ids')]
+        public ?array $channelIds = null,
+        #[MapName('display_name')]
+        public ?string $displayName = null,
+        public ?string $id = null,
+        #[MapName('team_id')]
+        public ?string $teamId = null,
+        public ?string $type = null,
+        #[MapName('user_id')]
+        public ?string $userId = null,
+    ) {}
 }

--- a/src/Client/Dto/SlackAttachment.php
+++ b/src/Client/Dto/SlackAttachment.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,39 +9,38 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class SlackAttachment extends SpatieData
 {
-	public function __construct(
-		#[MapName('AuthorIcon')]
-		public ?string $authorIcon = null,
-		#[MapName('AuthorLink')]
-		public ?string $authorLink = null,
-		#[MapName('AuthorName')]
-		public ?string $authorName = null,
-		#[MapName('Color')]
-		public ?string $color = null,
-		#[MapName('Fallback')]
-		public ?string $fallback = null,
-		#[MapName('Fields')]
-		public ?array $fields = null,
-		#[MapName('Footer')]
-		public ?string $footer = null,
-		#[MapName('FooterIcon')]
-		public ?string $footerIcon = null,
-		#[MapName('Id')]
-		public ?string $id = null,
-		#[MapName('ImageURL')]
-		public ?string $imageUrl = null,
-		#[MapName('Pretext')]
-		public ?string $pretext = null,
-		#[MapName('Text')]
-		public ?string $text = null,
-		#[MapName('ThumbURL')]
-		public ?string $thumbUrl = null,
-		#[MapName('Timestamp')]
-		public ?string $timestamp = null,
-		#[MapName('Title')]
-		public ?string $title = null,
-		#[MapName('TitleLink')]
-		public ?string $titleLink = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('AuthorIcon')]
+        public ?string $authorIcon = null,
+        #[MapName('AuthorLink')]
+        public ?string $authorLink = null,
+        #[MapName('AuthorName')]
+        public ?string $authorName = null,
+        #[MapName('Color')]
+        public ?string $color = null,
+        #[MapName('Fallback')]
+        public ?string $fallback = null,
+        #[MapName('Fields')]
+        public ?array $fields = null,
+        #[MapName('Footer')]
+        public ?string $footer = null,
+        #[MapName('FooterIcon')]
+        public ?string $footerIcon = null,
+        #[MapName('Id')]
+        public ?string $id = null,
+        #[MapName('ImageURL')]
+        public ?string $imageUrl = null,
+        #[MapName('Pretext')]
+        public ?string $pretext = null,
+        #[MapName('Text')]
+        public ?string $text = null,
+        #[MapName('ThumbURL')]
+        public ?string $thumbUrl = null,
+        #[MapName('Timestamp')]
+        public ?string $timestamp = null,
+        #[MapName('Title')]
+        public ?string $title = null,
+        #[MapName('TitleLink')]
+        public ?string $titleLink = null,
+    ) {}
 }

--- a/src/Client/Dto/SlackAttachmentField.php
+++ b/src/Client/Dto/SlackAttachmentField.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,13 +9,12 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class SlackAttachmentField extends SpatieData
 {
-	public function __construct(
-		#[MapName('Short')]
-		public ?bool $short = null,
-		#[MapName('Title')]
-		public ?string $title = null,
-		#[MapName('Value')]
-		public ?string $value = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('Short')]
+        public ?bool $short = null,
+        #[MapName('Title')]
+        public ?string $title = null,
+        #[MapName('Value')]
+        public ?string $value = null,
+    ) {}
 }

--- a/src/Client/Dto/Status.php
+++ b/src/Client/Dto/Status.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,13 +9,12 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class Status extends SpatieData
 {
-	public function __construct(
-		#[MapName('last_activity_at')]
-		public ?int $lastActivityAt = null,
-		public ?bool $manual = null,
-		public ?string $status = null,
-		#[MapName('user_id')]
-		public ?string $userId = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('last_activity_at')]
+        public ?int $lastActivityAt = null,
+        public ?bool $manual = null,
+        public ?string $status = null,
+        #[MapName('user_id')]
+        public ?string $userId = null,
+    ) {}
 }

--- a/src/Client/Dto/StatusOk.php
+++ b/src/Client/Dto/StatusOk.php
@@ -1,13 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Data as SpatieData;
 
 class StatusOk extends SpatieData
 {
-	public function __construct(
-		public ?string $status = null,
-	) {
-	}
+    public function __construct(
+        public ?string $status = null,
+    ) {}
 }

--- a/src/Client/Dto/StorageUsage.php
+++ b/src/Client/Dto/StorageUsage.php
@@ -1,13 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Data as SpatieData;
 
 class StorageUsage extends SpatieData
 {
-	public function __construct(
-		public int|float|null $bytes = null,
-	) {
-	}
+    public function __construct(
+        public int|float|null $bytes = null,
+    ) {}
 }

--- a/src/Client/Dto/Subscription.php
+++ b/src/Client/Dto/Subscription.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,22 +9,21 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class Subscription extends SpatieData
 {
-	public function __construct(
-		#[MapName('add_ons')]
-		public ?array $addOns = null,
-		#[MapName('create_at')]
-		public ?int $createAt = null,
-		#[MapName('customer_id')]
-		public ?string $customerId = null,
-		public ?string $dns = null,
-		#[MapName('end_at')]
-		public ?int $endAt = null,
-		public ?string $id = null,
-		#[MapName('product_id')]
-		public ?string $productId = null,
-		public ?int $seats = null,
-		#[MapName('start_at')]
-		public ?int $startAt = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('add_ons')]
+        public ?array $addOns = null,
+        #[MapName('create_at')]
+        public ?int $createAt = null,
+        #[MapName('customer_id')]
+        public ?string $customerId = null,
+        public ?string $dns = null,
+        #[MapName('end_at')]
+        public ?int $endAt = null,
+        public ?string $id = null,
+        #[MapName('product_id')]
+        public ?string $productId = null,
+        public ?int $seats = null,
+        #[MapName('start_at')]
+        public ?int $startAt = null,
+    ) {}
 }

--- a/src/Client/Dto/SubscriptionStats.php
+++ b/src/Client/Dto/SubscriptionStats.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,11 +9,10 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class SubscriptionStats extends SpatieData
 {
-	public function __construct(
-		#[MapName('is_paid_tier')]
-		public ?string $isPaidTier = null,
-		#[MapName('remaining_seats')]
-		public ?int $remainingSeats = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('is_paid_tier')]
+        public ?string $isPaidTier = null,
+        #[MapName('remaining_seats')]
+        public ?int $remainingSeats = null,
+    ) {}
 }

--- a/src/Client/Dto/System.php
+++ b/src/Client/Dto/System.php
@@ -1,14 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Data as SpatieData;
 
 class System extends SpatieData
 {
-	public function __construct(
-		public ?string $name = null,
-		public ?string $value = null,
-	) {
-	}
+    public function __construct(
+        public ?string $name = null,
+        public ?string $value = null,
+    ) {}
 }

--- a/src/Client/Dto/SystemStatusResponse.php
+++ b/src/Client/Dto/SystemStatusResponse.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,26 +9,25 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class SystemStatusResponse extends SpatieData
 {
-	public function __construct(
-		#[MapName('AndroidLatestVersion')]
-		public ?string $androidLatestVersion = null,
-		#[MapName('AndroidMinVersion')]
-		public ?string $androidMinVersion = null,
-		#[MapName('CanReceiveNotifications')]
-		public ?string $canReceiveNotifications = null,
-		#[MapName('DesktopLatestVersion')]
-		public ?string $desktopLatestVersion = null,
-		#[MapName('DesktopMinVersion')]
-		public ?string $desktopMinVersion = null,
-		#[MapName('IosLatestVersion')]
-		public ?string $iosLatestVersion = null,
-		#[MapName('IosMinVersion')]
-		public ?string $iosMinVersion = null,
-		#[MapName('database_status')]
-		public ?string $databaseStatus = null,
-		#[MapName('filestore_status')]
-		public ?string $filestoreStatus = null,
-		public ?string $status = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('AndroidLatestVersion')]
+        public ?string $androidLatestVersion = null,
+        #[MapName('AndroidMinVersion')]
+        public ?string $androidMinVersion = null,
+        #[MapName('CanReceiveNotifications')]
+        public ?string $canReceiveNotifications = null,
+        #[MapName('DesktopLatestVersion')]
+        public ?string $desktopLatestVersion = null,
+        #[MapName('DesktopMinVersion')]
+        public ?string $desktopMinVersion = null,
+        #[MapName('IosLatestVersion')]
+        public ?string $iosLatestVersion = null,
+        #[MapName('IosMinVersion')]
+        public ?string $iosMinVersion = null,
+        #[MapName('database_status')]
+        public ?string $databaseStatus = null,
+        #[MapName('filestore_status')]
+        public ?string $filestoreStatus = null,
+        public ?string $status = null,
+    ) {}
 }

--- a/src/Client/Dto/Team.php
+++ b/src/Client/Dto/Team.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,28 +9,27 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class Team extends SpatieData
 {
-	public function __construct(
-		#[MapName('allow_open_invite')]
-		public ?bool $allowOpenInvite = null,
-		#[MapName('allowed_domains')]
-		public ?string $allowedDomains = null,
-		#[MapName('create_at')]
-		public ?int $createAt = null,
-		#[MapName('delete_at')]
-		public ?int $deleteAt = null,
-		public ?string $description = null,
-		#[MapName('display_name')]
-		public ?string $displayName = null,
-		public ?string $email = null,
-		public ?string $id = null,
-		#[MapName('invite_id')]
-		public ?string $inviteId = null,
-		public ?string $name = null,
-		#[MapName('policy_id')]
-		public ?string $policyId = null,
-		public ?string $type = null,
-		#[MapName('update_at')]
-		public ?int $updateAt = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('allow_open_invite')]
+        public ?bool $allowOpenInvite = null,
+        #[MapName('allowed_domains')]
+        public ?string $allowedDomains = null,
+        #[MapName('create_at')]
+        public ?int $createAt = null,
+        #[MapName('delete_at')]
+        public ?int $deleteAt = null,
+        public ?string $description = null,
+        #[MapName('display_name')]
+        public ?string $displayName = null,
+        public ?string $email = null,
+        public ?string $id = null,
+        #[MapName('invite_id')]
+        public ?string $inviteId = null,
+        public ?string $name = null,
+        #[MapName('policy_id')]
+        public ?string $policyId = null,
+        public ?string $type = null,
+        #[MapName('update_at')]
+        public ?int $updateAt = null,
+    ) {}
 }

--- a/src/Client/Dto/TeamExists.php
+++ b/src/Client/Dto/TeamExists.php
@@ -1,13 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Data as SpatieData;
 
 class TeamExists extends SpatieData
 {
-	public function __construct(
-		public ?bool $exists = null,
-	) {
-	}
+    public function __construct(
+        public ?bool $exists = null,
+    ) {}
 }

--- a/src/Client/Dto/TeamMap.php
+++ b/src/Client/Dto/TeamMap.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -10,9 +12,8 @@ use Spatie\LaravelData\Data as SpatieData;
  */
 class TeamMap extends SpatieData
 {
-	public function __construct(
-		#[MapName('team_id')]
-		public ?Team $teamId = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('team_id')]
+        public ?Team $teamId = null,
+    ) {}
 }

--- a/src/Client/Dto/TeamMember.php
+++ b/src/Client/Dto/TeamMember.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,20 +9,19 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class TeamMember extends SpatieData
 {
-	public function __construct(
-		#[MapName('delete_at')]
-		public ?int $deleteAt = null,
-		#[MapName('explicit_roles')]
-		public ?string $explicitRoles = null,
-		public ?string $roles = null,
-		#[MapName('scheme_admin')]
-		public ?bool $schemeAdmin = null,
-		#[MapName('scheme_user')]
-		public ?bool $schemeUser = null,
-		#[MapName('team_id')]
-		public ?string $teamId = null,
-		#[MapName('user_id')]
-		public ?string $userId = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('delete_at')]
+        public ?int $deleteAt = null,
+        #[MapName('explicit_roles')]
+        public ?string $explicitRoles = null,
+        public ?string $roles = null,
+        #[MapName('scheme_admin')]
+        public ?bool $schemeAdmin = null,
+        #[MapName('scheme_user')]
+        public ?bool $schemeUser = null,
+        #[MapName('team_id')]
+        public ?string $teamId = null,
+        #[MapName('user_id')]
+        public ?string $userId = null,
+    ) {}
 }

--- a/src/Client/Dto/TeamStats.php
+++ b/src/Client/Dto/TeamStats.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,13 +9,12 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class TeamStats extends SpatieData
 {
-	public function __construct(
-		#[MapName('active_member_count')]
-		public ?int $activeMemberCount = null,
-		#[MapName('team_id')]
-		public ?string $teamId = null,
-		#[MapName('total_member_count')]
-		public ?int $totalMemberCount = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('active_member_count')]
+        public ?int $activeMemberCount = null,
+        #[MapName('team_id')]
+        public ?string $teamId = null,
+        #[MapName('total_member_count')]
+        public ?int $totalMemberCount = null,
+    ) {}
 }

--- a/src/Client/Dto/TeamUnread.php
+++ b/src/Client/Dto/TeamUnread.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,13 +9,12 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class TeamUnread extends SpatieData
 {
-	public function __construct(
-		#[MapName('mention_count')]
-		public ?int $mentionCount = null,
-		#[MapName('msg_count')]
-		public ?int $msgCount = null,
-		#[MapName('team_id')]
-		public ?string $teamId = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('mention_count')]
+        public ?int $mentionCount = null,
+        #[MapName('msg_count')]
+        public ?int $msgCount = null,
+        #[MapName('team_id')]
+        public ?string $teamId = null,
+    ) {}
 }

--- a/src/Client/Dto/TeamsLimits.php
+++ b/src/Client/Dto/TeamsLimits.php
@@ -1,13 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Data as SpatieData;
 
 class TeamsLimits extends SpatieData
 {
-	public function __construct(
-		public ?int $active = null,
-	) {
-	}
+    public function __construct(
+        public ?int $active = null,
+    ) {}
 }

--- a/src/Client/Dto/TermsOfService.php
+++ b/src/Client/Dto/TermsOfService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,13 +9,12 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class TermsOfService extends SpatieData
 {
-	public function __construct(
-		#[MapName('create_at')]
-		public ?int $createAt = null,
-		public ?string $id = null,
-		public ?string $text = null,
-		#[MapName('user_id')]
-		public ?string $userId = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('create_at')]
+        public ?int $createAt = null,
+        public ?string $id = null,
+        public ?string $text = null,
+        #[MapName('user_id')]
+        public ?string $userId = null,
+    ) {}
 }

--- a/src/Client/Dto/Timezone.php
+++ b/src/Client/Dto/Timezone.php
@@ -1,15 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Data as SpatieData;
 
 class Timezone extends SpatieData
 {
-	public function __construct(
-		public ?string $automaticTimezone = null,
-		public ?string $manualTimezone = null,
-		public ?bool $useAutomaticTimezone = null,
-	) {
-	}
+    public function __construct(
+        public ?string $automaticTimezone = null,
+        public ?string $manualTimezone = null,
+        public ?bool $useAutomaticTimezone = null,
+    ) {}
 }

--- a/src/Client/Dto/TopChannel.php
+++ b/src/Client/Dto/TopChannel.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,16 +9,15 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class TopChannel extends SpatieData
 {
-	public function __construct(
-		#[MapName('display_name')]
-		public ?string $displayName = null,
-		public ?string $id = null,
-		#[MapName('message_count')]
-		public ?string $messageCount = null,
-		public ?string $name = null,
-		#[MapName('team_id')]
-		public ?string $teamId = null,
-		public ?string $type = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('display_name')]
+        public ?string $displayName = null,
+        public ?string $id = null,
+        #[MapName('message_count')]
+        public ?string $messageCount = null,
+        public ?string $name = null,
+        #[MapName('team_id')]
+        public ?string $teamId = null,
+        public ?string $type = null,
+    ) {}
 }

--- a/src/Client/Dto/TopChannelList.php
+++ b/src/Client/Dto/TopChannelList.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,10 +9,9 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class TopChannelList extends SpatieData
 {
-	public function __construct(
-		#[MapName('has_next')]
-		public ?bool $hasNext = null,
-		public ?array $items = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('has_next')]
+        public ?bool $hasNext = null,
+        public ?array $items = null,
+    ) {}
 }

--- a/src/Client/Dto/TopDm.php
+++ b/src/Client/Dto/TopDm.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,13 +9,12 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class TopDm extends SpatieData
 {
-	public function __construct(
-		#[MapName('outgoing_message_count')]
-		public ?int $outgoingMessageCount = null,
-		#[MapName('post_count')]
-		public ?int $postCount = null,
-		#[MapName('second_participant')]
-		public ?TopDminsightUserInformation $secondParticipant = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('outgoing_message_count')]
+        public ?int $outgoingMessageCount = null,
+        #[MapName('post_count')]
+        public ?int $postCount = null,
+        #[MapName('second_participant')]
+        public ?TopDminsightUserInformation $secondParticipant = null,
+    ) {}
 }

--- a/src/Client/Dto/TopDminsightUserInformation.php
+++ b/src/Client/Dto/TopDminsightUserInformation.php
@@ -1,12 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Data as SpatieData;
 
-class TopDminsightUserInformation extends SpatieData
-{
-	public function __construct()
-	{
-	}
-}
+class TopDminsightUserInformation extends SpatieData {}

--- a/src/Client/Dto/TopDmlist.php
+++ b/src/Client/Dto/TopDmlist.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,10 +9,9 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class TopDmlist extends SpatieData
 {
-	public function __construct(
-		#[MapName('has_next')]
-		public ?bool $hasNext = null,
-		public ?array $items = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('has_next')]
+        public ?bool $hasNext = null,
+        public ?array $items = null,
+    ) {}
 }

--- a/src/Client/Dto/TopReaction.php
+++ b/src/Client/Dto/TopReaction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,10 +9,9 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class TopReaction extends SpatieData
 {
-	public function __construct(
-		public ?int $count = null,
-		#[MapName('emoji_name')]
-		public ?string $emojiName = null,
-	) {
-	}
+    public function __construct(
+        public ?int $count = null,
+        #[MapName('emoji_name')]
+        public ?string $emojiName = null,
+    ) {}
 }

--- a/src/Client/Dto/TopReactionList.php
+++ b/src/Client/Dto/TopReactionList.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,10 +9,9 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class TopReactionList extends SpatieData
 {
-	public function __construct(
-		#[MapName('has_next')]
-		public ?bool $hasNext = null,
-		public ?array $items = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('has_next')]
+        public ?bool $hasNext = null,
+        public ?array $items = null,
+    ) {}
 }

--- a/src/Client/Dto/TopThread.php
+++ b/src/Client/Dto/TopThread.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,18 +9,17 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class TopThread extends SpatieData
 {
-	public function __construct(
-		#[MapName('Participants')]
-		public ?array $participants = null,
-		#[MapName('channel_display_name')]
-		public ?string $channelDisplayName = null,
-		#[MapName('channel_id')]
-		public ?string $channelId = null,
-		#[MapName('channel_name')]
-		public ?string $channelName = null,
-		public ?Post $post = null,
-		#[MapName('user_information')]
-		public ?InsightUserInformation $userInformation = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('Participants')]
+        public ?array $participants = null,
+        #[MapName('channel_display_name')]
+        public ?string $channelDisplayName = null,
+        #[MapName('channel_id')]
+        public ?string $channelId = null,
+        #[MapName('channel_name')]
+        public ?string $channelName = null,
+        public ?Post $post = null,
+        #[MapName('user_information')]
+        public ?InsightUserInformation $userInformation = null,
+    ) {}
 }

--- a/src/Client/Dto/TopThreadList.php
+++ b/src/Client/Dto/TopThreadList.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,10 +9,9 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class TopThreadList extends SpatieData
 {
-	public function __construct(
-		#[MapName('has_next')]
-		public ?bool $hasNext = null,
-		public ?array $items = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('has_next')]
+        public ?bool $hasNext = null,
+        public ?array $items = null,
+    ) {}
 }

--- a/src/Client/Dto/TriggerIdReturn.php
+++ b/src/Client/Dto/TriggerIdReturn.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,9 +9,8 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class TriggerIdReturn extends SpatieData
 {
-	public function __construct(
-		#[MapName('trigger_id')]
-		public ?string $triggerId = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('trigger_id')]
+        public ?string $triggerId = null,
+    ) {}
 }

--- a/src/Client/Dto/UploadSession.php
+++ b/src/Client/Dto/UploadSession.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -10,20 +12,19 @@ use Spatie\LaravelData\Data as SpatieData;
  */
 class UploadSession extends SpatieData
 {
-	public function __construct(
-		#[MapName('channel_id')]
-		public ?string $channelId = null,
-		#[MapName('create_at')]
-		public ?int $createAt = null,
-		#[MapName('file_offset')]
-		public ?int $fileOffset = null,
-		#[MapName('file_size')]
-		public ?int $fileSize = null,
-		public ?string $filename = null,
-		public ?string $id = null,
-		public ?string $type = null,
-		#[MapName('user_id')]
-		public ?string $userId = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('channel_id')]
+        public ?string $channelId = null,
+        #[MapName('create_at')]
+        public ?int $createAt = null,
+        #[MapName('file_offset')]
+        public ?int $fileOffset = null,
+        #[MapName('file_size')]
+        public ?int $fileSize = null,
+        public ?string $filename = null,
+        public ?string $id = null,
+        public ?string $type = null,
+        #[MapName('user_id')]
+        public ?string $userId = null,
+    ) {}
 }

--- a/src/Client/Dto/User.php
+++ b/src/Client/Dto/User.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,43 +9,42 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class User extends SpatieData
 {
-	public function __construct(
-		#[MapName('auth_service')]
-		public ?string $authService = null,
-		#[MapName('create_at')]
-		public ?int $createAt = null,
-		#[MapName('delete_at')]
-		public ?int $deleteAt = null,
-		public ?string $email = null,
-		#[MapName('email_verified')]
-		public ?bool $emailVerified = null,
-		#[MapName('failed_attempts')]
-		public ?int $failedAttempts = null,
-		#[MapName('first_name')]
-		public ?string $firstName = null,
-		public ?string $id = null,
-		#[MapName('last_name')]
-		public ?string $lastName = null,
-		#[MapName('last_password_update')]
-		public ?int $lastPasswordUpdate = null,
-		#[MapName('last_picture_update')]
-		public ?int $lastPictureUpdate = null,
-		public ?string $locale = null,
-		#[MapName('mfa_active')]
-		public ?bool $mfaActive = null,
-		public ?string $nickname = null,
-		#[MapName('notify_props')]
-		public ?UserNotifyProps $notifyProps = null,
-		public ?object $props = null,
-		public ?string $roles = null,
-		#[MapName('terms_of_service_create_at')]
-		public ?int $termsOfServiceCreateAt = null,
-		#[MapName('terms_of_service_id')]
-		public ?string $termsOfServiceId = null,
-		public ?Timezone $timezone = null,
-		#[MapName('update_at')]
-		public ?int $updateAt = null,
-		public ?string $username = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('auth_service')]
+        public ?string $authService = null,
+        #[MapName('create_at')]
+        public ?int $createAt = null,
+        #[MapName('delete_at')]
+        public ?int $deleteAt = null,
+        public ?string $email = null,
+        #[MapName('email_verified')]
+        public ?bool $emailVerified = null,
+        #[MapName('failed_attempts')]
+        public ?int $failedAttempts = null,
+        #[MapName('first_name')]
+        public ?string $firstName = null,
+        public ?string $id = null,
+        #[MapName('last_name')]
+        public ?string $lastName = null,
+        #[MapName('last_password_update')]
+        public ?int $lastPasswordUpdate = null,
+        #[MapName('last_picture_update')]
+        public ?int $lastPictureUpdate = null,
+        public ?string $locale = null,
+        #[MapName('mfa_active')]
+        public ?bool $mfaActive = null,
+        public ?string $nickname = null,
+        #[MapName('notify_props')]
+        public ?UserNotifyProps $notifyProps = null,
+        public ?object $props = null,
+        public ?string $roles = null,
+        #[MapName('terms_of_service_create_at')]
+        public ?int $termsOfServiceCreateAt = null,
+        #[MapName('terms_of_service_id')]
+        public ?string $termsOfServiceId = null,
+        public ?Timezone $timezone = null,
+        #[MapName('update_at')]
+        public ?int $updateAt = null,
+        public ?string $username = null,
+    ) {}
 }

--- a/src/Client/Dto/UserAccessToken.php
+++ b/src/Client/Dto/UserAccessToken.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,12 +9,11 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class UserAccessToken extends SpatieData
 {
-	public function __construct(
-		public ?string $description = null,
-		public ?string $id = null,
-		public ?string $token = null,
-		#[MapName('user_id')]
-		public ?string $userId = null,
-	) {
-	}
+    public function __construct(
+        public ?string $description = null,
+        public ?string $id = null,
+        public ?string $token = null,
+        #[MapName('user_id')]
+        public ?string $userId = null,
+    ) {}
 }

--- a/src/Client/Dto/UserAccessTokenSanitized.php
+++ b/src/Client/Dto/UserAccessTokenSanitized.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,13 +9,12 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class UserAccessTokenSanitized extends SpatieData
 {
-	public function __construct(
-		public ?string $description = null,
-		public ?string $id = null,
-		#[MapName('is_active')]
-		public ?bool $isActive = null,
-		#[MapName('user_id')]
-		public ?string $userId = null,
-	) {
-	}
+    public function __construct(
+        public ?string $description = null,
+        public ?string $id = null,
+        #[MapName('is_active')]
+        public ?bool $isActive = null,
+        #[MapName('user_id')]
+        public ?string $userId = null,
+    ) {}
 }

--- a/src/Client/Dto/UserAuthData.php
+++ b/src/Client/Dto/UserAuthData.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,11 +9,10 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class UserAuthData extends SpatieData
 {
-	public function __construct(
-		#[MapName('auth_data')]
-		public ?string $authData = null,
-		#[MapName('auth_service')]
-		public ?string $authService = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('auth_data')]
+        public ?string $authData = null,
+        #[MapName('auth_service')]
+        public ?string $authService = null,
+    ) {}
 }

--- a/src/Client/Dto/UserAutocomplete.php
+++ b/src/Client/Dto/UserAutocomplete.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,10 +9,9 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class UserAutocomplete extends SpatieData
 {
-	public function __construct(
-		#[MapName('out_of_channel')]
-		public ?array $outOfChannel = null,
-		public ?array $users = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('out_of_channel')]
+        public ?array $outOfChannel = null,
+        public ?array $users = null,
+    ) {}
 }

--- a/src/Client/Dto/UserAutocompleteInChannel.php
+++ b/src/Client/Dto/UserAutocompleteInChannel.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,11 +9,10 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class UserAutocompleteInChannel extends SpatieData
 {
-	public function __construct(
-		#[MapName('in_channel')]
-		public ?array $inChannel = null,
-		#[MapName('out_of_channel')]
-		public ?array $outOfChannel = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('in_channel')]
+        public ?array $inChannel = null,
+        #[MapName('out_of_channel')]
+        public ?array $outOfChannel = null,
+    ) {}
 }

--- a/src/Client/Dto/UserAutocompleteInTeam.php
+++ b/src/Client/Dto/UserAutocompleteInTeam.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,9 +9,8 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class UserAutocompleteInTeam extends SpatieData
 {
-	public function __construct(
-		#[MapName('in_team')]
-		public ?array $inTeam = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('in_team')]
+        public ?array $inTeam = null,
+    ) {}
 }

--- a/src/Client/Dto/UserNotifyProps.php
+++ b/src/Client/Dto/UserNotifyProps.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,17 +9,16 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class UserNotifyProps extends SpatieData
 {
-	public function __construct(
-		public ?string $channel = null,
-		public ?string $desktop = null,
-		#[MapName('desktop_sound')]
-		public ?string $desktopSound = null,
-		public ?string $email = null,
-		#[MapName('first_name')]
-		public ?string $firstName = null,
-		#[MapName('mention_keys')]
-		public ?string $mentionKeys = null,
-		public ?string $push = null,
-	) {
-	}
+    public function __construct(
+        public ?string $channel = null,
+        public ?string $desktop = null,
+        #[MapName('desktop_sound')]
+        public ?string $desktopSound = null,
+        public ?string $email = null,
+        #[MapName('first_name')]
+        public ?string $firstName = null,
+        #[MapName('mention_keys')]
+        public ?string $mentionKeys = null,
+        public ?string $push = null,
+    ) {}
 }

--- a/src/Client/Dto/UserTermsOfService.php
+++ b/src/Client/Dto/UserTermsOfService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,13 +9,12 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class UserTermsOfService extends SpatieData
 {
-	public function __construct(
-		#[MapName('create_at')]
-		public ?int $createAt = null,
-		#[MapName('terms_of_service_id')]
-		public ?string $termsOfServiceId = null,
-		#[MapName('user_id')]
-		public ?string $userId = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('create_at')]
+        public ?int $createAt = null,
+        #[MapName('terms_of_service_id')]
+        public ?string $termsOfServiceId = null,
+        #[MapName('user_id')]
+        public ?string $userId = null,
+    ) {}
 }

--- a/src/Client/Dto/UserThread.php
+++ b/src/Client/Dto/UserThread.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -10,16 +12,15 @@ use Spatie\LaravelData\Data as SpatieData;
  */
 class UserThread extends SpatieData
 {
-	public function __construct(
-		public ?string $id = null,
-		#[MapName('last_reply_at')]
-		public ?int $lastReplyAt = null,
-		#[MapName('last_viewed_at')]
-		public ?int $lastViewedAt = null,
-		public ?array $participants = null,
-		public ?Post $post = null,
-		#[MapName('reply_count')]
-		public ?int $replyCount = null,
-	) {
-	}
+    public function __construct(
+        public ?string $id = null,
+        #[MapName('last_reply_at')]
+        public ?int $lastReplyAt = null,
+        #[MapName('last_viewed_at')]
+        public ?int $lastViewedAt = null,
+        public ?array $participants = null,
+        public ?Post $post = null,
+        #[MapName('reply_count')]
+        public ?int $replyCount = null,
+    ) {}
 }

--- a/src/Client/Dto/UserThreads.php
+++ b/src/Client/Dto/UserThreads.php
@@ -1,14 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Data as SpatieData;
 
 class UserThreads extends SpatieData
 {
-	public function __construct(
-		public ?array $threads = null,
-		public ?int $total = null,
-	) {
-	}
+    /**
+     * @param  array<int, mixed>  $threads
+     */
+    public function __construct(
+        public ?array $threads = null,
+        public ?int $total = null,
+    ) {}
 }

--- a/src/Client/Dto/UsersStats.php
+++ b/src/Client/Dto/UsersStats.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Attributes\MapName;
@@ -7,9 +9,8 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class UsersStats extends SpatieData
 {
-	public function __construct(
-		#[MapName('total_users_count')]
-		public ?int $totalUsersCount = null,
-	) {
-	}
+    public function __construct(
+        #[MapName('total_users_count')]
+        public ?int $totalUsersCount = null,
+    ) {}
 }

--- a/src/Client/Dto/WebhookOnCreationPayload.php
+++ b/src/Client/Dto/WebhookOnCreationPayload.php
@@ -1,12 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Data as SpatieData;
 
-class WebhookOnCreationPayload extends SpatieData
-{
-	public function __construct()
-	{
-	}
-}
+class WebhookOnCreationPayload extends SpatieData {}

--- a/src/Client/Dto/WebhookOnStatusUpdatePayload.php
+++ b/src/Client/Dto/WebhookOnStatusUpdatePayload.php
@@ -1,12 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Dto;
 
 use Spatie\LaravelData\Data as SpatieData;
 
-class WebhookOnStatusUpdatePayload extends SpatieData
-{
-	public function __construct()
-	{
-	}
-}
+class WebhookOnStatusUpdatePayload extends SpatieData {}

--- a/src/Client/Mattermost.php
+++ b/src/Client/Mattermost.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client;
 
 use ConduitUI\Mattermost\Client\Resource\Bots;
@@ -21,7 +23,6 @@ use ConduitUI\Mattermost\Client\Resource\Threads;
 use ConduitUI\Mattermost\Client\Resource\Users;
 use ConduitUI\Mattermost\Client\Resource\Webhooks;
 use Saloon\Contracts\Authenticator;
-use Saloon\Http\Auth\MultiAuthenticator;
 use Saloon\Http\Auth\TokenAuthenticator;
 use Saloon\Http\Connector;
 
@@ -32,135 +33,108 @@ use Saloon\Http\Connector;
  */
 class Mattermost extends Connector
 {
-	/**
-	 * @param string $bearerToken
-	 * @param string $bearerToken
-	 */
-	public function __construct(
-		protected string $bearerToken,
-	) {
-	}
+    public function __construct(
+        protected string $baseUrl,
+        protected string $token,
+    ) {}
 
+    public function resolveBaseUrl(): string
+    {
+        return $this->baseUrl;
+    }
 
-	public function resolveBaseUrl(): string
-	{
-		return "http://your-mattermost-url.com";
-	}
+    public function defaultAuth(): ?Authenticator
+    {
+        return new TokenAuthenticator($this->token);
+    }
 
+    public function bots(): Bots
+    {
+        return new Bots($this);
+    }
 
-	public function defaultAuth(): ?Authenticator
-	{
-		return new MultiAuthenticator(
-			new TokenAuthenticator($this->bearerToken, "Bearer"),
-			new TokenAuthenticator($this->bearerToken, "Bearer")
-		);
-	}
+    public function channels(): Channels
+    {
+        return new Channels($this);
+    }
 
+    public function commands(): Commands
+    {
+        return new Commands($this);
+    }
 
-	public function bots(): Bots
-	{
-		return new Bots($this);
-	}
+    public function dataRetention(): DataRetention
+    {
+        return new DataRetention($this);
+    }
 
+    public function emoji(): Emoji
+    {
+        return new Emoji($this);
+    }
 
-	public function channels(): Channels
-	{
-		return new Channels($this);
-	}
+    public function files(): Files
+    {
+        return new Files($this);
+    }
 
+    public function groups(): Groups
+    {
+        return new Groups($this);
+    }
 
-	public function commands(): Commands
-	{
-		return new Commands($this);
-	}
+    public function insights(): Insights
+    {
+        return new Insights($this);
+    }
 
+    public function oauth(): Oauth
+    {
+        return new Oauth($this);
+    }
 
-	public function dataRetention(): DataRetention
-	{
-		return new DataRetention($this);
-	}
+    public function posts(): Posts
+    {
+        return new Posts($this);
+    }
 
+    public function preferences(): Preferences
+    {
+        return new Preferences($this);
+    }
 
-	public function emoji(): Emoji
-	{
-		return new Emoji($this);
-	}
+    public function reactions(): Reactions
+    {
+        return new Reactions($this);
+    }
 
+    public function status(): Status
+    {
+        return new Status($this);
+    }
 
-	public function files(): Files
-	{
-		return new Files($this);
-	}
+    public function system(): System
+    {
+        return new System($this);
+    }
 
+    public function teams(): Teams
+    {
+        return new Teams($this);
+    }
 
-	public function groups(): Groups
-	{
-		return new Groups($this);
-	}
+    public function threads(): Threads
+    {
+        return new Threads($this);
+    }
 
+    public function users(): Users
+    {
+        return new Users($this);
+    }
 
-	public function insights(): Insights
-	{
-		return new Insights($this);
-	}
-
-
-	public function oauth(): Oauth
-	{
-		return new Oauth($this);
-	}
-
-
-	public function posts(): Posts
-	{
-		return new Posts($this);
-	}
-
-
-	public function preferences(): Preferences
-	{
-		return new Preferences($this);
-	}
-
-
-	public function reactions(): Reactions
-	{
-		return new Reactions($this);
-	}
-
-
-	public function status(): Status
-	{
-		return new Status($this);
-	}
-
-
-	public function system(): System
-	{
-		return new System($this);
-	}
-
-
-	public function teams(): Teams
-	{
-		return new Teams($this);
-	}
-
-
-	public function threads(): Threads
-	{
-		return new Threads($this);
-	}
-
-
-	public function users(): Users
-	{
-		return new Users($this);
-	}
-
-
-	public function webhooks(): Webhooks
-	{
-		return new Webhooks($this);
-	}
+    public function webhooks(): Webhooks
+    {
+        return new Webhooks($this);
+    }
 }

--- a/src/Client/Requests/Bots/AssignBot.php
+++ b/src/Client/Requests/Bots/AssignBot.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Bots;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -19,24 +20,21 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class AssignBot extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/bots/{$this->botUserId}/assign/{$this->userId}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/bots/{$this->botUserId}/assign/{$this->userId}";
-	}
-
-
-	/**
-	 * @param string $botUserId Bot user ID
-	 * @param string $userId The user ID to assign the bot to.
-	 */
-	public function __construct(
-		protected string $botUserId,
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $botUserId  Bot user ID
+     * @param  string  $userId  The user ID to assign the bot to.
+     */
+    public function __construct(
+        protected string $botUserId,
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Bots/ConvertBotToUser.php
+++ b/src/Client/Requests/Bots/ConvertBotToUser.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Bots;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -21,30 +22,26 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class ConvertBotToUser extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/bots/{$this->botUserId}/convert_to_user";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/bots/{$this->botUserId}/convert_to_user";
-	}
+    /**
+     * @param  string  $botUserId  Bot user ID
+     * @param  null|bool  $setSystemAdmin  Whether to give the user the system admin role.
+     */
+    public function __construct(
+        protected string $botUserId,
+        protected ?bool $setSystemAdmin = null,
+    ) {}
 
-
-	/**
-	 * @param string $botUserId Bot user ID
-	 * @param null|bool $setSystemAdmin Whether to give the user the system admin role.
-	 */
-	public function __construct(
-		protected string $botUserId,
-		protected ?bool $setSystemAdmin = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['set_system_admin' => $this->setSystemAdmin]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['set_system_admin' => $this->setSystemAdmin]);
+    }
 }

--- a/src/Client/Requests/Bots/ConvertUserToBot.php
+++ b/src/Client/Requests/Bots/ConvertUserToBot.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Bots;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -21,22 +22,19 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class ConvertUserToBot extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/convert_to_bot";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/convert_to_bot";
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function __construct(
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function __construct(
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Bots/CreateBot.php
+++ b/src/Client/Requests/Bots/CreateBot.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Bots;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -19,18 +20,14 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class CreateBot extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/bots';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/bots";
-	}
-
-
-	public function __construct()
-	{
-	}
+    public function __construct() {}
 }

--- a/src/Client/Requests/Bots/DisableBot.php
+++ b/src/Client/Requests/Bots/DisableBot.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Bots;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -19,22 +20,19 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class DisableBot extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/bots/{$this->botUserId}/disable";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/bots/{$this->botUserId}/disable";
-	}
-
-
-	/**
-	 * @param string $botUserId Bot user ID
-	 */
-	public function __construct(
-		protected string $botUserId,
-	) {
-	}
+    /**
+     * @param  string  $botUserId  Bot user ID
+     */
+    public function __construct(
+        protected string $botUserId,
+    ) {}
 }

--- a/src/Client/Requests/Bots/EnableBot.php
+++ b/src/Client/Requests/Bots/EnableBot.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Bots;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -19,22 +20,19 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class EnableBot extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/bots/{$this->botUserId}/enable";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/bots/{$this->botUserId}/enable";
-	}
-
-
-	/**
-	 * @param string $botUserId Bot user ID
-	 */
-	public function __construct(
-		protected string $botUserId,
-	) {
-	}
+    /**
+     * @param  string  $botUserId  Bot user ID
+     */
+    public function __construct(
+        protected string $botUserId,
+    ) {}
 }

--- a/src/Client/Requests/Bots/GetBot.php
+++ b/src/Client/Requests/Bots/GetBot.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Bots;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -18,28 +19,24 @@ use Saloon\Http\Request;
  */
 class GetBot extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/bots/{$this->botUserId}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/bots/{$this->botUserId}";
-	}
+    /**
+     * @param  string  $botUserId  Bot user ID
+     * @param  null|bool  $includeDeleted  If deleted bots should be returned.
+     */
+    public function __construct(
+        protected string $botUserId,
+        protected ?bool $includeDeleted = null,
+    ) {}
 
-
-	/**
-	 * @param string $botUserId Bot user ID
-	 * @param null|bool $includeDeleted If deleted bots should be returned.
-	 */
-	public function __construct(
-		protected string $botUserId,
-		protected ?bool $includeDeleted = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['include_deleted' => $this->includeDeleted]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['include_deleted' => $this->includeDeleted]);
+    }
 }

--- a/src/Client/Requests/Bots/GetBots.php
+++ b/src/Client/Requests/Bots/GetBots.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Bots;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -18,30 +19,26 @@ use Saloon\Http\Request;
  */
 class GetBots extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/bots';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/bots";
-	}
+    /**
+     * @param  null|int  $page  The page to select.
+     * @param  null|bool  $includeDeleted  If deleted bots should be returned.
+     * @param  null|bool  $onlyOrphaned  When true, only orphaned bots will be returned. A bot is consitered orphaned if it's owner has been deactivated.
+     */
+    public function __construct(
+        protected ?int $page = null,
+        protected ?bool $includeDeleted = null,
+        protected ?bool $onlyOrphaned = null,
+    ) {}
 
-
-	/**
-	 * @param null|int $page The page to select.
-	 * @param null|bool $includeDeleted If deleted bots should be returned.
-	 * @param null|bool $onlyOrphaned When true, only orphaned bots will be returned. A bot is consitered orphaned if it's owner has been deactivated.
-	 */
-	public function __construct(
-		protected ?int $page = null,
-		protected ?bool $includeDeleted = null,
-		protected ?bool $onlyOrphaned = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['page' => $this->page, 'include_deleted' => $this->includeDeleted, 'only_orphaned' => $this->onlyOrphaned]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['page' => $this->page, 'include_deleted' => $this->includeDeleted, 'only_orphaned' => $this->onlyOrphaned]);
+    }
 }

--- a/src/Client/Requests/Bots/PatchBot.php
+++ b/src/Client/Requests/Bots/PatchBot.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Bots;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -19,20 +20,17 @@ use Saloon\Http\Request;
  */
 class PatchBot extends Request
 {
-	protected Method $method = Method::PUT;
+    protected Method $method = Method::PUT;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/bots/{$this->botUserId}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/bots/{$this->botUserId}";
-	}
-
-
-	/**
-	 * @param string $botUserId Bot user ID
-	 */
-	public function __construct(
-		protected string $botUserId,
-	) {
-	}
+    /**
+     * @param  string  $botUserId  Bot user ID
+     */
+    public function __construct(
+        protected string $botUserId,
+    ) {}
 }

--- a/src/Client/Requests/Channels/AddChannelMember.php
+++ b/src/Client/Requests/Channels/AddChannelMember.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -15,22 +16,19 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class AddChannelMember extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/channels/{$this->channelId}/members";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/channels/{$this->channelId}/members";
-	}
-
-
-	/**
-	 * @param string $channelId The channel ID
-	 */
-	public function __construct(
-		protected string $channelId,
-	) {
-	}
+    /**
+     * @param  string  $channelId  The channel ID
+     */
+    public function __construct(
+        protected string $channelId,
+    ) {}
 }

--- a/src/Client/Requests/Channels/AutocompleteChannelsForTeam.php
+++ b/src/Client/Requests/Channels/AutocompleteChannelsForTeam.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -20,28 +21,24 @@ use Saloon\Http\Request;
  */
 class AutocompleteChannelsForTeam extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/teams/{$this->teamId}/channels/autocomplete";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/{$this->teamId}/channels/autocomplete";
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  string  $name  Name or display name
+     */
+    public function __construct(
+        protected string $teamId,
+        protected string $name,
+    ) {}
 
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param string $name Name or display name
-	 */
-	public function __construct(
-		protected string $teamId,
-		protected string $name,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['name' => $this->name]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['name' => $this->name]);
+    }
 }

--- a/src/Client/Requests/Channels/AutocompleteChannelsForTeamForSearch.php
+++ b/src/Client/Requests/Channels/AutocompleteChannelsForTeamForSearch.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -20,28 +21,24 @@ use Saloon\Http\Request;
  */
 class AutocompleteChannelsForTeamForSearch extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/teams/{$this->teamId}/channels/search_autocomplete";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/{$this->teamId}/channels/search_autocomplete";
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  string  $name  Name or display name
+     */
+    public function __construct(
+        protected string $teamId,
+        protected string $name,
+    ) {}
 
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param string $name Name or display name
-	 */
-	public function __construct(
-		protected string $teamId,
-		protected string $name,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['name' => $this->name]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['name' => $this->name]);
+    }
 }

--- a/src/Client/Requests/Channels/ChannelMembersMinusGroupMembers.php
+++ b/src/Client/Requests/Channels/ChannelMembersMinusGroupMembers.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -24,30 +25,26 @@ use Saloon\Http\Request;
  */
 class ChannelMembersMinusGroupMembers extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/channels/{$this->channelId}/members_minus_group_members";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/channels/{$this->channelId}/members_minus_group_members";
-	}
+    /**
+     * @param  string  $channelId  Channel GUID
+     * @param  string  $groupIds  A comma-separated list of group ids.
+     * @param  null|int  $page  The page to select.
+     */
+    public function __construct(
+        protected string $channelId,
+        protected string $groupIds,
+        protected ?int $page = null,
+    ) {}
 
-
-	/**
-	 * @param string $channelId Channel GUID
-	 * @param string $groupIds A comma-separated list of group ids.
-	 * @param null|int $page The page to select.
-	 */
-	public function __construct(
-		protected string $channelId,
-		protected string $groupIds,
-		protected ?int $page = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['group_ids' => $this->groupIds, 'page' => $this->page]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['group_ids' => $this->groupIds, 'page' => $this->page]);
+    }
 }

--- a/src/Client/Requests/Channels/CreateChannel.php
+++ b/src/Client/Requests/Channels/CreateChannel.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -19,18 +20,14 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class CreateChannel extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/channels';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/channels";
-	}
-
-
-	public function __construct()
-	{
-	}
+    public function __construct() {}
 }

--- a/src/Client/Requests/Channels/CreateDirectChannel.php
+++ b/src/Client/Requests/Channels/CreateDirectChannel.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -19,18 +20,14 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class CreateDirectChannel extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/channels/direct';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/channels/direct";
-	}
-
-
-	public function __construct()
-	{
-	}
+    public function __construct() {}
 }

--- a/src/Client/Requests/Channels/CreateGroupChannel.php
+++ b/src/Client/Requests/Channels/CreateGroupChannel.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -19,18 +20,14 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class CreateGroupChannel extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/channels/group';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/channels/group";
-	}
-
-
-	public function __construct()
-	{
-	}
+    public function __construct() {}
 }

--- a/src/Client/Requests/Channels/CreateSidebarCategoryForTeamForUser.php
+++ b/src/Client/Requests/Channels/CreateSidebarCategoryForTeamForUser.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -19,24 +20,21 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class CreateSidebarCategoryForTeamForUser extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/channels/categories";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/channels/categories";
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param string $userId User GUID
-	 */
-	public function __construct(
-		protected string $teamId,
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  string  $userId  User GUID
+     */
+    public function __construct(
+        protected string $teamId,
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Channels/DeleteChannel.php
+++ b/src/Client/Requests/Channels/DeleteChannel.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -28,20 +29,17 @@ use Saloon\Http\Request;
  */
 class DeleteChannel extends Request
 {
-	protected Method $method = Method::DELETE;
+    protected Method $method = Method::DELETE;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/channels/{$this->channelId}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/channels/{$this->channelId}";
-	}
-
-
-	/**
-	 * @param string $channelId Channel GUID
-	 */
-	public function __construct(
-		protected string $channelId,
-	) {
-	}
+    /**
+     * @param  string  $channelId  Channel GUID
+     */
+    public function __construct(
+        protected string $channelId,
+    ) {}
 }

--- a/src/Client/Requests/Channels/GetAllChannels.php
+++ b/src/Client/Requests/Channels/GetAllChannels.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -14,44 +15,40 @@ use Saloon\Http\Request;
  */
 class GetAllChannels extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/channels';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/channels";
-	}
+    /**
+     * @param  null|string  $notAssociatedToGroup  A group id to exclude channels that are associated with that group via GroupChannel records. This can also be left blank with `not_associated_to_group=`.
+     * @param  null|int  $page  The page to select.
+     * @param  null|bool  $excludeDefaultChannels  Whether to exclude default channels (ex Town Square, Off-Topic) from the results.
+     * @param  null|bool  $includeDeleted  Include channels that have been archived. This correlates to the `DeleteAt` flag being set in the database.
+     * @param  null|bool  $includeTotalCount  Appends a total count of returned channels inside the response object - ex: `{ "channels": [], "total_count" : 0 }`.
+     * @param  null|bool  $excludePolicyConstrained  If set to true, channels which are part of a data retention policy will be excluded. The `sysconsole_read_compliance` permission is required to use this parameter.
+     *                                               __Minimum server version__: 5.35
+     */
+    public function __construct(
+        protected ?string $notAssociatedToGroup = null,
+        protected ?int $page = null,
+        protected ?bool $excludeDefaultChannels = null,
+        protected ?bool $includeDeleted = null,
+        protected ?bool $includeTotalCount = null,
+        protected ?bool $excludePolicyConstrained = null,
+    ) {}
 
-
-	/**
-	 * @param null|string $notAssociatedToGroup A group id to exclude channels that are associated with that group via GroupChannel records. This can also be left blank with `not_associated_to_group=`.
-	 * @param null|int $page The page to select.
-	 * @param null|bool $excludeDefaultChannels Whether to exclude default channels (ex Town Square, Off-Topic) from the results.
-	 * @param null|bool $includeDeleted Include channels that have been archived. This correlates to the `DeleteAt` flag being set in the database.
-	 * @param null|bool $includeTotalCount Appends a total count of returned channels inside the response object - ex: `{ "channels": [], "total_count" : 0 }`.
-	 * @param null|bool $excludePolicyConstrained If set to true, channels which are part of a data retention policy will be excluded. The `sysconsole_read_compliance` permission is required to use this parameter.
-	 * __Minimum server version__: 5.35
-	 */
-	public function __construct(
-		protected ?string $notAssociatedToGroup = null,
-		protected ?int $page = null,
-		protected ?bool $excludeDefaultChannels = null,
-		protected ?bool $includeDeleted = null,
-		protected ?bool $includeTotalCount = null,
-		protected ?bool $excludePolicyConstrained = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter([
-			'not_associated_to_group' => $this->notAssociatedToGroup,
-			'page' => $this->page,
-			'exclude_default_channels' => $this->excludeDefaultChannels,
-			'include_deleted' => $this->includeDeleted,
-			'include_total_count' => $this->includeTotalCount,
-			'exclude_policy_constrained' => $this->excludePolicyConstrained,
-		]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter([
+            'not_associated_to_group' => $this->notAssociatedToGroup,
+            'page' => $this->page,
+            'exclude_default_channels' => $this->excludeDefaultChannels,
+            'include_deleted' => $this->includeDeleted,
+            'include_total_count' => $this->includeTotalCount,
+            'exclude_policy_constrained' => $this->excludePolicyConstrained,
+        ]);
+    }
 }

--- a/src/Client/Requests/Channels/GetChannel.php
+++ b/src/Client/Requests/Channels/GetChannel.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,20 +17,17 @@ use Saloon\Http\Request;
  */
 class GetChannel extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/channels/{$this->channelId}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/channels/{$this->channelId}";
-	}
-
-
-	/**
-	 * @param string $channelId Channel GUID
-	 */
-	public function __construct(
-		protected string $channelId,
-	) {
-	}
+    /**
+     * @param  string  $channelId  Channel GUID
+     */
+    public function __construct(
+        protected string $channelId,
+    ) {}
 }

--- a/src/Client/Requests/Channels/GetChannelByName.php
+++ b/src/Client/Requests/Channels/GetChannelByName.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,30 +17,26 @@ use Saloon\Http\Request;
  */
 class GetChannelByName extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/teams/{$this->teamId}/channels/name/{$this->channelName}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/{$this->teamId}/channels/name/{$this->channelName}";
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  string  $channelName  Channel Name
+     * @param  null|bool  $includeDeleted  Defines if deleted channels should be returned or not (Mattermost Server 5.26.0+)
+     */
+    public function __construct(
+        protected string $teamId,
+        protected string $channelName,
+        protected ?bool $includeDeleted = null,
+    ) {}
 
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param string $channelName Channel Name
-	 * @param null|bool $includeDeleted Defines if deleted channels should be returned or not (Mattermost Server 5.26.0+)
-	 */
-	public function __construct(
-		protected string $teamId,
-		protected string $channelName,
-		protected ?bool $includeDeleted = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['include_deleted' => $this->includeDeleted]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['include_deleted' => $this->includeDeleted]);
+    }
 }

--- a/src/Client/Requests/Channels/GetChannelByNameForTeamName.php
+++ b/src/Client/Requests/Channels/GetChannelByNameForTeamName.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,30 +17,26 @@ use Saloon\Http\Request;
  */
 class GetChannelByNameForTeamName extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/teams/name/{$this->teamName}/channels/name/{$this->channelName}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/name/{$this->teamName}/channels/name/{$this->channelName}";
-	}
+    /**
+     * @param  string  $teamName  Team Name
+     * @param  string  $channelName  Channel Name
+     * @param  null|bool  $includeDeleted  Defines if deleted channels should be returned or not (Mattermost Server 5.26.0+)
+     */
+    public function __construct(
+        protected string $teamName,
+        protected string $channelName,
+        protected ?bool $includeDeleted = null,
+    ) {}
 
-
-	/**
-	 * @param string $teamName Team Name
-	 * @param string $channelName Channel Name
-	 * @param null|bool $includeDeleted Defines if deleted channels should be returned or not (Mattermost Server 5.26.0+)
-	 */
-	public function __construct(
-		protected string $teamName,
-		protected string $channelName,
-		protected ?bool $includeDeleted = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['include_deleted' => $this->includeDeleted]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['include_deleted' => $this->includeDeleted]);
+    }
 }

--- a/src/Client/Requests/Channels/GetChannelMember.php
+++ b/src/Client/Requests/Channels/GetChannelMember.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -15,22 +16,19 @@ use Saloon\Http\Request;
  */
 class GetChannelMember extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/channels/{$this->channelId}/members/{$this->userId}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/channels/{$this->channelId}/members/{$this->userId}";
-	}
-
-
-	/**
-	 * @param string $channelId Channel GUID
-	 * @param string $userId User GUID
-	 */
-	public function __construct(
-		protected string $channelId,
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $channelId  Channel GUID
+     * @param  string  $userId  User GUID
+     */
+    public function __construct(
+        protected string $channelId,
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Channels/GetChannelMemberCountsByGroup.php
+++ b/src/Client/Requests/Channels/GetChannelMemberCountsByGroup.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -18,28 +19,24 @@ use Saloon\Http\Request;
  */
 class GetChannelMemberCountsByGroup extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/channels/{$this->channelId}/member_counts_by_group";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/channels/{$this->channelId}/member_counts_by_group";
-	}
+    /**
+     * @param  string  $channelId  Channel GUID
+     * @param  null|bool  $includeTimezones  Defines if member timezone counts should be returned or not
+     */
+    public function __construct(
+        protected string $channelId,
+        protected ?bool $includeTimezones = null,
+    ) {}
 
-
-	/**
-	 * @param string $channelId Channel GUID
-	 * @param null|bool $includeTimezones Defines if member timezone counts should be returned or not
-	 */
-	public function __construct(
-		protected string $channelId,
-		protected ?bool $includeTimezones = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['include_timezones' => $this->includeTimezones]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['include_timezones' => $this->includeTimezones]);
+    }
 }

--- a/src/Client/Requests/Channels/GetChannelMembers.php
+++ b/src/Client/Requests/Channels/GetChannelMembers.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -15,28 +16,24 @@ use Saloon\Http\Request;
  */
 class GetChannelMembers extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/channels/{$this->channelId}/members";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/channels/{$this->channelId}/members";
-	}
+    /**
+     * @param  string  $channelId  Channel GUID
+     * @param  null|int  $page  The page to select.
+     */
+    public function __construct(
+        protected string $channelId,
+        protected ?int $page = null,
+    ) {}
 
-
-	/**
-	 * @param string $channelId Channel GUID
-	 * @param null|int $page The page to select.
-	 */
-	public function __construct(
-		protected string $channelId,
-		protected ?int $page = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['page' => $this->page]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['page' => $this->page]);
+    }
 }

--- a/src/Client/Requests/Channels/GetChannelMembersByIds.php
+++ b/src/Client/Requests/Channels/GetChannelMembersByIds.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -18,22 +19,19 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class GetChannelMembersByIds extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/channels/{$this->channelId}/members/ids";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/channels/{$this->channelId}/members/ids";
-	}
-
-
-	/**
-	 * @param string $channelId Channel GUID
-	 */
-	public function __construct(
-		protected string $channelId,
-	) {
-	}
+    /**
+     * @param  string  $channelId  Channel GUID
+     */
+    public function __construct(
+        protected string $channelId,
+    ) {}
 }

--- a/src/Client/Requests/Channels/GetChannelMembersForUser.php
+++ b/src/Client/Requests/Channels/GetChannelMembersForUser.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -17,22 +18,19 @@ use Saloon\Http\Request;
  */
 class GetChannelMembersForUser extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/channels/members";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/channels/members";
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 * @param string $teamId Team GUID
-	 */
-	public function __construct(
-		protected string $userId,
-		protected string $teamId,
-	) {
-	}
+    /**
+     * @param  string  $userId  User GUID
+     * @param  string  $teamId  Team GUID
+     */
+    public function __construct(
+        protected string $userId,
+        protected string $teamId,
+    ) {}
 }

--- a/src/Client/Requests/Channels/GetChannelMembersTimezones.php
+++ b/src/Client/Requests/Channels/GetChannelMembersTimezones.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -19,20 +20,17 @@ use Saloon\Http\Request;
  */
 class GetChannelMembersTimezones extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/channels/{$this->channelId}/timezones";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/channels/{$this->channelId}/timezones";
-	}
-
-
-	/**
-	 * @param string $channelId Channel GUID
-	 */
-	public function __construct(
-		protected string $channelId,
-	) {
-	}
+    /**
+     * @param  string  $channelId  Channel GUID
+     */
+    public function __construct(
+        protected string $channelId,
+    ) {}
 }

--- a/src/Client/Requests/Channels/GetChannelModerations.php
+++ b/src/Client/Requests/Channels/GetChannelModerations.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,20 +17,17 @@ use Saloon\Http\Request;
  */
 class GetChannelModerations extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/channels/{$this->channelId}/moderations";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/channels/{$this->channelId}/moderations";
-	}
-
-
-	/**
-	 * @param string $channelId Channel GUID
-	 */
-	public function __construct(
-		protected string $channelId,
-	) {
-	}
+    /**
+     * @param  string  $channelId  Channel GUID
+     */
+    public function __construct(
+        protected string $channelId,
+    ) {}
 }

--- a/src/Client/Requests/Channels/GetChannelStats.php
+++ b/src/Client/Requests/Channels/GetChannelStats.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -15,20 +16,17 @@ use Saloon\Http\Request;
  */
 class GetChannelStats extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/channels/{$this->channelId}/stats";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/channels/{$this->channelId}/stats";
-	}
-
-
-	/**
-	 * @param string $channelId Channel GUID
-	 */
-	public function __construct(
-		protected string $channelId,
-	) {
-	}
+    /**
+     * @param  string  $channelId  Channel GUID
+     */
+    public function __construct(
+        protected string $channelId,
+    ) {}
 }

--- a/src/Client/Requests/Channels/GetChannelUnread.php
+++ b/src/Client/Requests/Channels/GetChannelUnread.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,22 +17,19 @@ use Saloon\Http\Request;
  */
 class GetChannelUnread extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/channels/{$this->channelId}/unread";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/channels/{$this->channelId}/unread";
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 * @param string $channelId Channel GUID
-	 */
-	public function __construct(
-		protected string $userId,
-		protected string $channelId,
-	) {
-	}
+    /**
+     * @param  string  $userId  User GUID
+     * @param  string  $channelId  Channel GUID
+     */
+    public function __construct(
+        protected string $userId,
+        protected string $channelId,
+    ) {}
 }

--- a/src/Client/Requests/Channels/GetChannelsForTeamForUser.php
+++ b/src/Client/Requests/Channels/GetChannelsForTeamForUser.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,32 +17,28 @@ use Saloon\Http\Request;
  */
 class GetChannelsForTeamForUser extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/channels";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/channels";
-	}
+    /**
+     * @param  string  $userId  User GUID
+     * @param  string  $teamId  Team GUID
+     * @param  null|bool  $includeDeleted  Defines if deleted channels should be returned or not
+     * @param  null|int  $lastDeleteAt  Filters the deleted channels by this time in epoch format. Does not have any effect if include_deleted is set to false.
+     */
+    public function __construct(
+        protected string $userId,
+        protected string $teamId,
+        protected ?bool $includeDeleted = null,
+        protected ?int $lastDeleteAt = null,
+    ) {}
 
-
-	/**
-	 * @param string $userId User GUID
-	 * @param string $teamId Team GUID
-	 * @param null|bool $includeDeleted Defines if deleted channels should be returned or not
-	 * @param null|int $lastDeleteAt Filters the deleted channels by this time in epoch format. Does not have any effect if include_deleted is set to false.
-	 */
-	public function __construct(
-		protected string $userId,
-		protected string $teamId,
-		protected ?bool $includeDeleted = null,
-		protected ?int $lastDeleteAt = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['include_deleted' => $this->includeDeleted, 'last_delete_at' => $this->lastDeleteAt]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['include_deleted' => $this->includeDeleted, 'last_delete_at' => $this->lastDeleteAt]);
+    }
 }

--- a/src/Client/Requests/Channels/GetChannelsForUser.php
+++ b/src/Client/Requests/Channels/GetChannelsForUser.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -20,30 +21,26 @@ use Saloon\Http\Request;
  */
 class GetChannelsForUser extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/channels";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/channels";
-	}
+    /**
+     * @param  string  $userId  The ID of the user. This can also be "me" which will point to the current user.
+     * @param  null|int  $lastDeleteAt  Filters the deleted channels by this time in epoch format. Does not have any effect if include_deleted is set to false.
+     * @param  null|bool  $includeDeleted  Defines if deleted channels should be returned or not
+     */
+    public function __construct(
+        protected string $userId,
+        protected ?int $lastDeleteAt = null,
+        protected ?bool $includeDeleted = null,
+    ) {}
 
-
-	/**
-	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
-	 * @param null|int $lastDeleteAt Filters the deleted channels by this time in epoch format. Does not have any effect if include_deleted is set to false.
-	 * @param null|bool $includeDeleted Defines if deleted channels should be returned or not
-	 */
-	public function __construct(
-		protected string $userId,
-		protected ?int $lastDeleteAt = null,
-		protected ?bool $includeDeleted = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['last_delete_at' => $this->lastDeleteAt, 'include_deleted' => $this->includeDeleted]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['last_delete_at' => $this->lastDeleteAt, 'include_deleted' => $this->includeDeleted]);
+    }
 }

--- a/src/Client/Requests/Channels/GetDeletedChannelsForTeam.php
+++ b/src/Client/Requests/Channels/GetDeletedChannelsForTeam.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,28 +17,24 @@ use Saloon\Http\Request;
  */
 class GetDeletedChannelsForTeam extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/teams/{$this->teamId}/channels/deleted";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/{$this->teamId}/channels/deleted";
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  null|int  $page  The page to select.
+     */
+    public function __construct(
+        protected string $teamId,
+        protected ?int $page = null,
+    ) {}
 
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param null|int $page The page to select.
-	 */
-	public function __construct(
-		protected string $teamId,
-		protected ?int $page = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['page' => $this->page]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['page' => $this->page]);
+    }
 }

--- a/src/Client/Requests/Channels/GetPinnedPosts.php
+++ b/src/Client/Requests/Channels/GetPinnedPosts.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -13,20 +14,17 @@ use Saloon\Http\Request;
  */
 class GetPinnedPosts extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/channels/{$this->channelId}/pinned";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/channels/{$this->channelId}/pinned";
-	}
-
-
-	/**
-	 * @param string $channelId Channel GUID
-	 */
-	public function __construct(
-		protected string $channelId,
-	) {
-	}
+    /**
+     * @param  string  $channelId  Channel GUID
+     */
+    public function __construct(
+        protected string $channelId,
+    ) {}
 }

--- a/src/Client/Requests/Channels/GetPrivateChannelsForTeam.php
+++ b/src/Client/Requests/Channels/GetPrivateChannelsForTeam.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -21,28 +22,24 @@ use Saloon\Http\Request;
  */
 class GetPrivateChannelsForTeam extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/teams/{$this->teamId}/channels/private";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/{$this->teamId}/channels/private";
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  null|int  $page  The page to select.
+     */
+    public function __construct(
+        protected string $teamId,
+        protected ?int $page = null,
+    ) {}
 
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param null|int $page The page to select.
-	 */
-	public function __construct(
-		protected string $teamId,
-		protected ?int $page = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['page' => $this->page]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['page' => $this->page]);
+    }
 }

--- a/src/Client/Requests/Channels/GetPublicChannelsByIdsForTeam.php
+++ b/src/Client/Requests/Channels/GetPublicChannelsByIdsForTeam.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -18,22 +19,19 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class GetPublicChannelsByIdsForTeam extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/teams/{$this->teamId}/channels/ids";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/{$this->teamId}/channels/ids";
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 */
-	public function __construct(
-		protected string $teamId,
-	) {
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     */
+    public function __construct(
+        protected string $teamId,
+    ) {}
 }

--- a/src/Client/Requests/Channels/GetPublicChannelsForTeam.php
+++ b/src/Client/Requests/Channels/GetPublicChannelsForTeam.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,28 +17,24 @@ use Saloon\Http\Request;
  */
 class GetPublicChannelsForTeam extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/teams/{$this->teamId}/channels";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/{$this->teamId}/channels";
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  null|int  $page  The page to select.
+     */
+    public function __construct(
+        protected string $teamId,
+        protected ?int $page = null,
+    ) {}
 
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param null|int $page The page to select.
-	 */
-	public function __construct(
-		protected string $teamId,
-		protected ?int $page = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['page' => $this->page]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['page' => $this->page]);
+    }
 }

--- a/src/Client/Requests/Channels/GetSidebarCategoriesForTeamForUser.php
+++ b/src/Client/Requests/Channels/GetSidebarCategoriesForTeamForUser.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -18,22 +19,19 @@ use Saloon\Http\Request;
  */
 class GetSidebarCategoriesForTeamForUser extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/channels/categories";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/channels/categories";
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param string $userId User GUID
-	 */
-	public function __construct(
-		protected string $teamId,
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  string  $userId  User GUID
+     */
+    public function __construct(
+        protected string $teamId,
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Channels/GetSidebarCategoryForTeamForUser.php
+++ b/src/Client/Requests/Channels/GetSidebarCategoryForTeamForUser.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -17,24 +18,21 @@ use Saloon\Http\Request;
  */
 class GetSidebarCategoryForTeamForUser extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/channels/categories/{$this->categoryId}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/channels/categories/{$this->categoryId}";
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param string $userId User GUID
-	 * @param string $categoryId Category GUID
-	 */
-	public function __construct(
-		protected string $teamId,
-		protected string $userId,
-		protected string $categoryId,
-	) {
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  string  $userId  User GUID
+     * @param  string  $categoryId  Category GUID
+     */
+    public function __construct(
+        protected string $teamId,
+        protected string $userId,
+        protected string $categoryId,
+    ) {}
 }

--- a/src/Client/Requests/Channels/GetSidebarCategoryOrderForTeamForUser.php
+++ b/src/Client/Requests/Channels/GetSidebarCategoryOrderForTeamForUser.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -18,22 +19,19 @@ use Saloon\Http\Request;
  */
 class GetSidebarCategoryOrderForTeamForUser extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/channels/categories/order";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/channels/categories/order";
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param string $userId User GUID
-	 */
-	public function __construct(
-		protected string $teamId,
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  string  $userId  User GUID
+     */
+    public function __construct(
+        protected string $teamId,
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Channels/MoveChannel.php
+++ b/src/Client/Requests/Channels/MoveChannel.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -22,22 +23,19 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class MoveChannel extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/channels/{$this->channelId}/move";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/channels/{$this->channelId}/move";
-	}
-
-
-	/**
-	 * @param string $channelId Channel GUID
-	 */
-	public function __construct(
-		protected string $channelId,
-	) {
-	}
+    /**
+     * @param  string  $channelId  Channel GUID
+     */
+    public function __construct(
+        protected string $channelId,
+    ) {}
 }

--- a/src/Client/Requests/Channels/PatchChannel.php
+++ b/src/Client/Requests/Channels/PatchChannel.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -19,20 +20,17 @@ use Saloon\Http\Request;
  */
 class PatchChannel extends Request
 {
-	protected Method $method = Method::PUT;
+    protected Method $method = Method::PUT;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/channels/{$this->channelId}/patch";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/channels/{$this->channelId}/patch";
-	}
-
-
-	/**
-	 * @param string $channelId Channel GUID
-	 */
-	public function __construct(
-		protected string $channelId,
-	) {
-	}
+    /**
+     * @param  string  $channelId  Channel GUID
+     */
+    public function __construct(
+        protected string $channelId,
+    ) {}
 }

--- a/src/Client/Requests/Channels/PatchChannelModerations.php
+++ b/src/Client/Requests/Channels/PatchChannelModerations.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,20 +17,17 @@ use Saloon\Http\Request;
  */
 class PatchChannelModerations extends Request
 {
-	protected Method $method = Method::PUT;
+    protected Method $method = Method::PUT;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/channels/{$this->channelId}/moderations/patch";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/channels/{$this->channelId}/moderations/patch";
-	}
-
-
-	/**
-	 * @param string $channelId Channel GUID
-	 */
-	public function __construct(
-		protected string $channelId,
-	) {
-	}
+    /**
+     * @param  string  $channelId  Channel GUID
+     */
+    public function __construct(
+        protected string $channelId,
+    ) {}
 }

--- a/src/Client/Requests/Channels/RemoveSidebarCategoryForTeamForUser.php
+++ b/src/Client/Requests/Channels/RemoveSidebarCategoryForTeamForUser.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -18,24 +19,21 @@ use Saloon\Http\Request;
  */
 class RemoveSidebarCategoryForTeamForUser extends Request
 {
-	protected Method $method = Method::DELETE;
+    protected Method $method = Method::DELETE;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/channels/categories/{$this->categoryId}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/channels/categories/{$this->categoryId}";
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param string $userId User GUID
-	 * @param string $categoryId Category GUID
-	 */
-	public function __construct(
-		protected string $teamId,
-		protected string $userId,
-		protected string $categoryId,
-	) {
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  string  $userId  User GUID
+     * @param  string  $categoryId  Category GUID
+     */
+    public function __construct(
+        protected string $teamId,
+        protected string $userId,
+        protected string $categoryId,
+    ) {}
 }

--- a/src/Client/Requests/Channels/RemoveUserFromChannel.php
+++ b/src/Client/Requests/Channels/RemoveUserFromChannel.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -21,22 +22,19 @@ use Saloon\Http\Request;
  */
 class RemoveUserFromChannel extends Request
 {
-	protected Method $method = Method::DELETE;
+    protected Method $method = Method::DELETE;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/channels/{$this->channelId}/members/{$this->userId}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/channels/{$this->channelId}/members/{$this->userId}";
-	}
-
-
-	/**
-	 * @param string $channelId Channel GUID
-	 * @param string $userId User GUID
-	 */
-	public function __construct(
-		protected string $channelId,
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $channelId  Channel GUID
+     * @param  string  $userId  User GUID
+     */
+    public function __construct(
+        protected string $channelId,
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Channels/RestoreChannel.php
+++ b/src/Client/Requests/Channels/RestoreChannel.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -21,22 +22,19 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class RestoreChannel extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/channels/{$this->channelId}/restore";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/channels/{$this->channelId}/restore";
-	}
-
-
-	/**
-	 * @param string $channelId Channel GUID
-	 */
-	public function __construct(
-		protected string $channelId,
-	) {
-	}
+    /**
+     * @param  string  $channelId  Channel GUID
+     */
+    public function __construct(
+        protected string $channelId,
+    ) {}
 }

--- a/src/Client/Requests/Channels/SearchAllChannels.php
+++ b/src/Client/Requests/Channels/SearchAllChannels.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -26,28 +27,24 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class SearchAllChannels extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/channels/search';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/channels/search";
-	}
+    /**
+     * @param  null|bool  $systemConsole  Is the request from system_console. If this is set to true, it filters channels by the logged in user.
+     */
+    public function __construct(
+        protected ?bool $systemConsole = null,
+    ) {}
 
-
-	/**
-	 * @param null|bool $systemConsole Is the request from system_console. If this is set to true, it filters channels by the logged in user.
-	 */
-	public function __construct(
-		protected ?bool $systemConsole = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['system_console' => $this->systemConsole]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['system_console' => $this->systemConsole]);
+    }
 }

--- a/src/Client/Requests/Channels/SearchArchivedChannels.php
+++ b/src/Client/Requests/Channels/SearchArchivedChannels.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -25,22 +26,19 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class SearchArchivedChannels extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/teams/{$this->teamId}/channels/search_archived";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/{$this->teamId}/channels/search_archived";
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 */
-	public function __construct(
-		protected string $teamId,
-	) {
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     */
+    public function __construct(
+        protected string $teamId,
+    ) {}
 }

--- a/src/Client/Requests/Channels/SearchChannels.php
+++ b/src/Client/Requests/Channels/SearchChannels.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -22,22 +23,19 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class SearchChannels extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/teams/{$this->teamId}/channels/search";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/{$this->teamId}/channels/search";
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 */
-	public function __construct(
-		protected string $teamId,
-	) {
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     */
+    public function __construct(
+        protected string $teamId,
+    ) {}
 }

--- a/src/Client/Requests/Channels/SearchGroupChannels.php
+++ b/src/Client/Requests/Channels/SearchGroupChannels.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -18,18 +19,14 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class SearchGroupChannels extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/channels/group/search';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/channels/group/search";
-	}
-
-
-	public function __construct()
-	{
-	}
+    public function __construct() {}
 }

--- a/src/Client/Requests/Channels/UpdateChannel.php
+++ b/src/Client/Requests/Channels/UpdateChannel.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -18,20 +19,17 @@ use Saloon\Http\Request;
  */
 class UpdateChannel extends Request
 {
-	protected Method $method = Method::PUT;
+    protected Method $method = Method::PUT;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/channels/{$this->channelId}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/channels/{$this->channelId}";
-	}
-
-
-	/**
-	 * @param string $channelId Channel GUID
-	 */
-	public function __construct(
-		protected string $channelId,
-	) {
-	}
+    /**
+     * @param  string  $channelId  Channel GUID
+     */
+    public function __construct(
+        protected string $channelId,
+    ) {}
 }

--- a/src/Client/Requests/Channels/UpdateChannelMemberSchemeRoles.php
+++ b/src/Client/Requests/Channels/UpdateChannelMemberSchemeRoles.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -19,22 +20,19 @@ use Saloon\Http\Request;
  */
 class UpdateChannelMemberSchemeRoles extends Request
 {
-	protected Method $method = Method::PUT;
+    protected Method $method = Method::PUT;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/channels/{$this->channelId}/members/{$this->userId}/schemeRoles";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/channels/{$this->channelId}/members/{$this->userId}/schemeRoles";
-	}
-
-
-	/**
-	 * @param string $channelId Channel GUID
-	 * @param string $userId User GUID
-	 */
-	public function __construct(
-		protected string $channelId,
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $channelId  Channel GUID
+     * @param  string  $userId  User GUID
+     */
+    public function __construct(
+        protected string $channelId,
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Channels/UpdateChannelNotifyProps.php
+++ b/src/Client/Requests/Channels/UpdateChannelNotifyProps.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,22 +17,19 @@ use Saloon\Http\Request;
  */
 class UpdateChannelNotifyProps extends Request
 {
-	protected Method $method = Method::PUT;
+    protected Method $method = Method::PUT;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/channels/{$this->channelId}/members/{$this->userId}/notify_props";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/channels/{$this->channelId}/members/{$this->userId}/notify_props";
-	}
-
-
-	/**
-	 * @param string $channelId Channel GUID
-	 * @param string $userId User GUID
-	 */
-	public function __construct(
-		protected string $channelId,
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $channelId  Channel GUID
+     * @param  string  $userId  User GUID
+     */
+    public function __construct(
+        protected string $channelId,
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Channels/UpdateChannelPrivacy.php
+++ b/src/Client/Requests/Channels/UpdateChannelPrivacy.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -22,20 +23,17 @@ use Saloon\Http\Request;
  */
 class UpdateChannelPrivacy extends Request
 {
-	protected Method $method = Method::PUT;
+    protected Method $method = Method::PUT;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/channels/{$this->channelId}/privacy";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/channels/{$this->channelId}/privacy";
-	}
-
-
-	/**
-	 * @param string $channelId Channel GUID
-	 */
-	public function __construct(
-		protected string $channelId,
-	) {
-	}
+    /**
+     * @param  string  $channelId  Channel GUID
+     */
+    public function __construct(
+        protected string $channelId,
+    ) {}
 }

--- a/src/Client/Requests/Channels/UpdateChannelRoles.php
+++ b/src/Client/Requests/Channels/UpdateChannelRoles.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,22 +17,19 @@ use Saloon\Http\Request;
  */
 class UpdateChannelRoles extends Request
 {
-	protected Method $method = Method::PUT;
+    protected Method $method = Method::PUT;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/channels/{$this->channelId}/members/{$this->userId}/roles";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/channels/{$this->channelId}/members/{$this->userId}/roles";
-	}
-
-
-	/**
-	 * @param string $channelId Channel GUID
-	 * @param string $userId User GUID
-	 */
-	public function __construct(
-		protected string $channelId,
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $channelId  Channel GUID
+     * @param  string  $userId  User GUID
+     */
+    public function __construct(
+        protected string $channelId,
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Channels/UpdateChannelScheme.php
+++ b/src/Client/Requests/Channels/UpdateChannelScheme.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -19,20 +20,17 @@ use Saloon\Http\Request;
  */
 class UpdateChannelScheme extends Request
 {
-	protected Method $method = Method::PUT;
+    protected Method $method = Method::PUT;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/channels/{$this->channelId}/scheme";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/channels/{$this->channelId}/scheme";
-	}
-
-
-	/**
-	 * @param string $channelId Channel GUID
-	 */
-	public function __construct(
-		protected string $channelId,
-	) {
-	}
+    /**
+     * @param  string  $channelId  Channel GUID
+     */
+    public function __construct(
+        protected string $channelId,
+    ) {}
 }

--- a/src/Client/Requests/Channels/UpdateSidebarCategoriesForTeamForUser.php
+++ b/src/Client/Requests/Channels/UpdateSidebarCategoriesForTeamForUser.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -18,22 +19,19 @@ use Saloon\Http\Request;
  */
 class UpdateSidebarCategoriesForTeamForUser extends Request
 {
-	protected Method $method = Method::PUT;
+    protected Method $method = Method::PUT;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/channels/categories";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/channels/categories";
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param string $userId User GUID
-	 */
-	public function __construct(
-		protected string $teamId,
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  string  $userId  User GUID
+     */
+    public function __construct(
+        protected string $teamId,
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Channels/UpdateSidebarCategoryForTeamForUser.php
+++ b/src/Client/Requests/Channels/UpdateSidebarCategoryForTeamForUser.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -17,24 +18,21 @@ use Saloon\Http\Request;
  */
 class UpdateSidebarCategoryForTeamForUser extends Request
 {
-	protected Method $method = Method::PUT;
+    protected Method $method = Method::PUT;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/channels/categories/{$this->categoryId}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/channels/categories/{$this->categoryId}";
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param string $userId User GUID
-	 * @param string $categoryId Category GUID
-	 */
-	public function __construct(
-		protected string $teamId,
-		protected string $userId,
-		protected string $categoryId,
-	) {
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  string  $userId  User GUID
+     * @param  string  $categoryId  Category GUID
+     */
+    public function __construct(
+        protected string $teamId,
+        protected string $userId,
+        protected string $categoryId,
+    ) {}
 }

--- a/src/Client/Requests/Channels/UpdateSidebarCategoryOrderForTeamForUser.php
+++ b/src/Client/Requests/Channels/UpdateSidebarCategoryOrderForTeamForUser.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -18,22 +19,19 @@ use Saloon\Http\Request;
  */
 class UpdateSidebarCategoryOrderForTeamForUser extends Request
 {
-	protected Method $method = Method::PUT;
+    protected Method $method = Method::PUT;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/channels/categories/order";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/channels/categories/order";
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param string $userId User GUID
-	 */
-	public function __construct(
-		protected string $teamId,
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  string  $userId  User GUID
+     */
+    public function __construct(
+        protected string $teamId,
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Channels/ViewChannel.php
+++ b/src/Client/Requests/Channels/ViewChannel.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Channels;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -22,22 +23,19 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class ViewChannel extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/channels/members/{$this->userId}/view";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/channels/members/{$this->userId}/view";
-	}
-
-
-	/**
-	 * @param string $userId User ID to perform the view action for
-	 */
-	public function __construct(
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $userId  User ID to perform the view action for
+     */
+    public function __construct(
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Commands/CreateCommand.php
+++ b/src/Client/Requests/Commands/CreateCommand.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Commands;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -18,18 +19,14 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class CreateCommand extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/commands';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/commands";
-	}
-
-
-	public function __construct()
-	{
-	}
+    public function __construct() {}
 }

--- a/src/Client/Requests/Commands/DeleteCommand.php
+++ b/src/Client/Requests/Commands/DeleteCommand.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Commands;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,20 +17,17 @@ use Saloon\Http\Request;
  */
 class DeleteCommand extends Request
 {
-	protected Method $method = Method::DELETE;
+    protected Method $method = Method::DELETE;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/commands/{$this->commandId}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/commands/{$this->commandId}";
-	}
-
-
-	/**
-	 * @param string $commandId ID of the command to delete
-	 */
-	public function __construct(
-		protected string $commandId,
-	) {
-	}
+    /**
+     * @param  string  $commandId  ID of the command to delete
+     */
+    public function __construct(
+        protected string $commandId,
+    ) {}
 }

--- a/src/Client/Requests/Commands/ExecuteCommand.php
+++ b/src/Client/Requests/Commands/ExecuteCommand.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Commands;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -18,18 +19,14 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class ExecuteCommand extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/commands/execute';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/commands/execute";
-	}
-
-
-	public function __construct()
-	{
-	}
+    public function __construct() {}
 }

--- a/src/Client/Requests/Commands/GetCommandById.php
+++ b/src/Client/Requests/Commands/GetCommandById.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Commands;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -19,20 +20,17 @@ use Saloon\Http\Request;
  */
 class GetCommandById extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/commands/{$this->commandId}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/commands/{$this->commandId}";
-	}
-
-
-	/**
-	 * @param string $commandId ID of the command to get
-	 */
-	public function __construct(
-		protected string $commandId,
-	) {
-	}
+    /**
+     * @param  string  $commandId  ID of the command to get
+     */
+    public function __construct(
+        protected string $commandId,
+    ) {}
 }

--- a/src/Client/Requests/Commands/ListAutocompleteCommands.php
+++ b/src/Client/Requests/Commands/ListAutocompleteCommands.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Commands;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -15,20 +16,17 @@ use Saloon\Http\Request;
  */
 class ListAutocompleteCommands extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/teams/{$this->teamId}/commands/autocomplete";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/{$this->teamId}/commands/autocomplete";
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 */
-	public function __construct(
-		protected string $teamId,
-	) {
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     */
+    public function __construct(
+        protected string $teamId,
+    ) {}
 }

--- a/src/Client/Requests/Commands/ListCommands.php
+++ b/src/Client/Requests/Commands/ListCommands.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Commands;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -15,29 +16,25 @@ use Saloon\Http\Request;
  */
 class ListCommands extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/commands';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/commands";
-	}
+    /**
+     * @param  null|string  $teamId  The team id.
+     * @param  null|bool  $customOnly  To get only the custom commands. If set to false will get the custom
+     *                                 if the user have access plus the system commands, otherwise just the system commands.
+     */
+    public function __construct(
+        protected ?string $teamId = null,
+        protected ?bool $customOnly = null,
+    ) {}
 
-
-	/**
-	 * @param null|string $teamId The team id.
-	 * @param null|bool $customOnly To get only the custom commands. If set to false will get the custom
-	 * if the user have access plus the system commands, otherwise just the system commands.
-	 */
-	public function __construct(
-		protected ?string $teamId = null,
-		protected ?bool $customOnly = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['team_id' => $this->teamId, 'custom_only' => $this->customOnly]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['team_id' => $this->teamId, 'custom_only' => $this->customOnly]);
+    }
 }

--- a/src/Client/Requests/Commands/MoveCommand.php
+++ b/src/Client/Requests/Commands/MoveCommand.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Commands;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -19,20 +20,17 @@ use Saloon\Http\Request;
  */
 class MoveCommand extends Request
 {
-	protected Method $method = Method::PUT;
+    protected Method $method = Method::PUT;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/commands/{$this->commandId}/move";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/commands/{$this->commandId}/move";
-	}
-
-
-	/**
-	 * @param string $commandId ID of the command to move
-	 */
-	public function __construct(
-		protected string $commandId,
-	) {
-	}
+    /**
+     * @param  string  $commandId  ID of the command to move
+     */
+    public function __construct(
+        protected string $commandId,
+    ) {}
 }

--- a/src/Client/Requests/Commands/RegenCommandToken.php
+++ b/src/Client/Requests/Commands/RegenCommandToken.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Commands;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,20 +17,17 @@ use Saloon\Http\Request;
  */
 class RegenCommandToken extends Request
 {
-	protected Method $method = Method::PUT;
+    protected Method $method = Method::PUT;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/commands/{$this->commandId}/regen_token";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/commands/{$this->commandId}/regen_token";
-	}
-
-
-	/**
-	 * @param string $commandId ID of the command to generate the new token
-	 */
-	public function __construct(
-		protected string $commandId,
-	) {
-	}
+    /**
+     * @param  string  $commandId  ID of the command to generate the new token
+     */
+    public function __construct(
+        protected string $commandId,
+    ) {}
 }

--- a/src/Client/Requests/Commands/UpdateCommand.php
+++ b/src/Client/Requests/Commands/UpdateCommand.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Commands;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,20 +17,17 @@ use Saloon\Http\Request;
  */
 class UpdateCommand extends Request
 {
-	protected Method $method = Method::PUT;
+    protected Method $method = Method::PUT;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/commands/{$this->commandId}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/commands/{$this->commandId}";
-	}
-
-
-	/**
-	 * @param string $commandId ID of the command to update
-	 */
-	public function __construct(
-		protected string $commandId,
-	) {
-	}
+    /**
+     * @param  string  $commandId  ID of the command to update
+     */
+    public function __construct(
+        protected string $commandId,
+    ) {}
 }

--- a/src/Client/Requests/DataRetention/GetChannelPoliciesForUser.php
+++ b/src/Client/Requests/DataRetention/GetChannelPoliciesForUser.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\DataRetention;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -23,28 +24,24 @@ use Saloon\Http\Request;
  */
 class GetChannelPoliciesForUser extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/data_retention/channel_policies";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/data_retention/channel_policies";
-	}
+    /**
+     * @param  string  $userId  The ID of the user. This can also be "me" which will point to the current user.
+     * @param  null|int  $page  The page to select.
+     */
+    public function __construct(
+        protected string $userId,
+        protected ?int $page = null,
+    ) {}
 
-
-	/**
-	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
-	 * @param null|int $page The page to select.
-	 */
-	public function __construct(
-		protected string $userId,
-		protected ?int $page = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['page' => $this->page]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['page' => $this->page]);
+    }
 }

--- a/src/Client/Requests/DataRetention/GetTeamPoliciesForUser.php
+++ b/src/Client/Requests/DataRetention/GetTeamPoliciesForUser.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\DataRetention;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -23,28 +24,24 @@ use Saloon\Http\Request;
  */
 class GetTeamPoliciesForUser extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/data_retention/team_policies";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/data_retention/team_policies";
-	}
+    /**
+     * @param  string  $userId  The ID of the user. This can also be "me" which will point to the current user.
+     * @param  null|int  $page  The page to select.
+     */
+    public function __construct(
+        protected string $userId,
+        protected ?int $page = null,
+    ) {}
 
-
-	/**
-	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
-	 * @param null|int $page The page to select.
-	 */
-	public function __construct(
-		protected string $userId,
-		protected ?int $page = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['page' => $this->page]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['page' => $this->page]);
+    }
 }

--- a/src/Client/Requests/Emoji/AutocompleteEmoji.php
+++ b/src/Client/Requests/Emoji/AutocompleteEmoji.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Emoji;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -18,26 +19,22 @@ use Saloon\Http\Request;
  */
 class AutocompleteEmoji extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/emoji/autocomplete';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/emoji/autocomplete";
-	}
+    /**
+     * @param  string  $name  The emoji name to search.
+     */
+    public function __construct(
+        protected string $name,
+    ) {}
 
-
-	/**
-	 * @param string $name The emoji name to search.
-	 */
-	public function __construct(
-		protected string $name,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['name' => $this->name]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['name' => $this->name]);
+    }
 }

--- a/src/Client/Requests/Emoji/CreateEmoji.php
+++ b/src/Client/Requests/Emoji/CreateEmoji.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Emoji;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -17,18 +18,14 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class CreateEmoji extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/emoji';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/emoji";
-	}
-
-
-	public function __construct()
-	{
-	}
+    public function __construct() {}
 }

--- a/src/Client/Requests/Emoji/DeleteEmoji.php
+++ b/src/Client/Requests/Emoji/DeleteEmoji.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Emoji;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,20 +17,17 @@ use Saloon\Http\Request;
  */
 class DeleteEmoji extends Request
 {
-	protected Method $method = Method::DELETE;
+    protected Method $method = Method::DELETE;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/emoji/{$this->emojiId}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/emoji/{$this->emojiId}";
-	}
-
-
-	/**
-	 * @param string $emojiId Emoji GUID
-	 */
-	public function __construct(
-		protected string $emojiId,
-	) {
-	}
+    /**
+     * @param  string  $emojiId  Emoji GUID
+     */
+    public function __construct(
+        protected string $emojiId,
+    ) {}
 }

--- a/src/Client/Requests/Emoji/GetEmoji.php
+++ b/src/Client/Requests/Emoji/GetEmoji.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Emoji;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -15,20 +16,17 @@ use Saloon\Http\Request;
  */
 class GetEmoji extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/emoji/{$this->emojiId}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/emoji/{$this->emojiId}";
-	}
-
-
-	/**
-	 * @param string $emojiId Emoji GUID
-	 */
-	public function __construct(
-		protected string $emojiId,
-	) {
-	}
+    /**
+     * @param  string  $emojiId  Emoji GUID
+     */
+    public function __construct(
+        protected string $emojiId,
+    ) {}
 }

--- a/src/Client/Requests/Emoji/GetEmojiByName.php
+++ b/src/Client/Requests/Emoji/GetEmojiByName.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Emoji;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -18,20 +19,17 @@ use Saloon\Http\Request;
  */
 class GetEmojiByName extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/emoji/name/{$this->emojiName}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/emoji/name/{$this->emojiName}";
-	}
-
-
-	/**
-	 * @param string $emojiName Emoji name
-	 */
-	public function __construct(
-		protected string $emojiName,
-	) {
-	}
+    /**
+     * @param  string  $emojiName  Emoji name
+     */
+    public function __construct(
+        protected string $emojiName,
+    ) {}
 }

--- a/src/Client/Requests/Emoji/GetEmojiImage.php
+++ b/src/Client/Requests/Emoji/GetEmojiImage.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Emoji;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -15,20 +16,17 @@ use Saloon\Http\Request;
  */
 class GetEmojiImage extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/emoji/{$this->emojiId}/image";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/emoji/{$this->emojiId}/image";
-	}
-
-
-	/**
-	 * @param string $emojiId Emoji GUID
-	 */
-	public function __construct(
-		protected string $emojiId,
-	) {
-	}
+    /**
+     * @param  string  $emojiId  Emoji GUID
+     */
+    public function __construct(
+        protected string $emojiId,
+    ) {}
 }

--- a/src/Client/Requests/Emoji/GetEmojiList.php
+++ b/src/Client/Requests/Emoji/GetEmojiList.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Emoji;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,28 +17,24 @@ use Saloon\Http\Request;
  */
 class GetEmojiList extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/emoji';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/emoji";
-	}
+    /**
+     * @param  null|int  $page  The page to select.
+     * @param  null|string  $sort  Either blank for no sorting or "name" to sort by emoji names. Minimum server version for sorting is 4.7.
+     */
+    public function __construct(
+        protected ?int $page = null,
+        protected ?string $sort = null,
+    ) {}
 
-
-	/**
-	 * @param null|int $page The page to select.
-	 * @param null|string $sort Either blank for no sorting or "name" to sort by emoji names. Minimum server version for sorting is 4.7.
-	 */
-	public function __construct(
-		protected ?int $page = null,
-		protected ?string $sort = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['page' => $this->page, 'sort' => $this->sort]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['page' => $this->page, 'sort' => $this->sort]);
+    }
 }

--- a/src/Client/Requests/Emoji/SearchEmoji.php
+++ b/src/Client/Requests/Emoji/SearchEmoji.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Emoji;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -20,18 +21,14 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class SearchEmoji extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/emoji/search';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/emoji/search";
-	}
-
-
-	public function __construct()
-	{
-	}
+    public function __construct() {}
 }

--- a/src/Client/Requests/Files/GetFile.php
+++ b/src/Client/Requests/Files/GetFile.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Files;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,20 +17,17 @@ use Saloon\Http\Request;
  */
 class GetFile extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/files/{$this->fileId}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/files/{$this->fileId}";
-	}
-
-
-	/**
-	 * @param string $fileId The ID of the file to get
-	 */
-	public function __construct(
-		protected string $fileId,
-	) {
-	}
+    /**
+     * @param  string  $fileId  The ID of the file to get
+     */
+    public function __construct(
+        protected string $fileId,
+    ) {}
 }

--- a/src/Client/Requests/Files/GetFileInfo.php
+++ b/src/Client/Requests/Files/GetFileInfo.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Files;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,20 +17,17 @@ use Saloon\Http\Request;
  */
 class GetFileInfo extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/files/{$this->fileId}/info";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/files/{$this->fileId}/info";
-	}
-
-
-	/**
-	 * @param string $fileId The ID of the file info to get
-	 */
-	public function __construct(
-		protected string $fileId,
-	) {
-	}
+    /**
+     * @param  string  $fileId  The ID of the file info to get
+     */
+    public function __construct(
+        protected string $fileId,
+    ) {}
 }

--- a/src/Client/Requests/Files/GetFileLink.php
+++ b/src/Client/Requests/Files/GetFileLink.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Files;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,20 +17,17 @@ use Saloon\Http\Request;
  */
 class GetFileLink extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/files/{$this->fileId}/link";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/files/{$this->fileId}/link";
-	}
-
-
-	/**
-	 * @param string $fileId The ID of the file to get a link for
-	 */
-	public function __construct(
-		protected string $fileId,
-	) {
-	}
+    /**
+     * @param  string  $fileId  The ID of the file to get a link for
+     */
+    public function __construct(
+        protected string $fileId,
+    ) {}
 }

--- a/src/Client/Requests/Files/GetFilePreview.php
+++ b/src/Client/Requests/Files/GetFilePreview.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Files;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,20 +17,17 @@ use Saloon\Http\Request;
  */
 class GetFilePreview extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/files/{$this->fileId}/preview";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/files/{$this->fileId}/preview";
-	}
-
-
-	/**
-	 * @param string $fileId The ID of the file to get
-	 */
-	public function __construct(
-		protected string $fileId,
-	) {
-	}
+    /**
+     * @param  string  $fileId  The ID of the file to get
+     */
+    public function __construct(
+        protected string $fileId,
+    ) {}
 }

--- a/src/Client/Requests/Files/GetFilePublic.php
+++ b/src/Client/Requests/Files/GetFilePublic.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Files;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -14,28 +15,24 @@ use Saloon\Http\Request;
  */
 class GetFilePublic extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/files/{$this->fileId}/public";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/files/{$this->fileId}/public";
-	}
+    /**
+     * @param  string  $fileId  The ID of the file to get
+     * @param  string  $h  File hash
+     */
+    public function __construct(
+        protected string $fileId,
+        protected string $h,
+    ) {}
 
-
-	/**
-	 * @param string $fileId The ID of the file to get
-	 * @param string $h File hash
-	 */
-	public function __construct(
-		protected string $fileId,
-		protected string $h,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['h' => $this->h]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['h' => $this->h]);
+    }
 }

--- a/src/Client/Requests/Files/GetFileThumbnail.php
+++ b/src/Client/Requests/Files/GetFileThumbnail.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Files;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,20 +17,17 @@ use Saloon\Http\Request;
  */
 class GetFileThumbnail extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/files/{$this->fileId}/thumbnail";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/files/{$this->fileId}/thumbnail";
-	}
-
-
-	/**
-	 * @param string $fileId The ID of the file to get
-	 */
-	public function __construct(
-		protected string $fileId,
-	) {
-	}
+    /**
+     * @param  string  $fileId  The ID of the file to get
+     */
+    public function __construct(
+        protected string $fileId,
+    ) {}
 }

--- a/src/Client/Requests/Files/UploadFile.php
+++ b/src/Client/Requests/Files/UploadFile.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Files;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -30,30 +31,26 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class UploadFile extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/files';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/files";
-	}
+    /**
+     * @param  null|string  $channelId  The ID of the channel that this file will be uploaded to
+     * @param  null|string  $filename  The name of the file to be uploaded
+     */
+    public function __construct(
+        protected ?string $channelId = null,
+        protected ?string $filename = null,
+    ) {}
 
-
-	/**
-	 * @param null|string $channelId The ID of the channel that this file will be uploaded to
-	 * @param null|string $filename The name of the file to be uploaded
-	 */
-	public function __construct(
-		protected ?string $channelId = null,
-		protected ?string $filename = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['channel_id' => $this->channelId, 'filename' => $this->filename]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['channel_id' => $this->channelId, 'filename' => $this->filename]);
+    }
 }

--- a/src/Client/Requests/Groups/GetGroupsAssociatedToChannelsByTeam.php
+++ b/src/Client/Requests/Groups/GetGroupsAssociatedToChannelsByTeam.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Groups;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -20,32 +21,28 @@ use Saloon\Http\Request;
  */
 class GetGroupsAssociatedToChannelsByTeam extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/teams/{$this->teamId}/groups_by_channels";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/{$this->teamId}/groups_by_channels";
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  null|int  $page  The page to select.
+     * @param  null|bool  $filterAllowReference  Boolean which filters in the group entries with the `allow_reference` attribute set.
+     * @param  null|bool  $paginate  Boolean to determine whether the pagination should be applied or not
+     */
+    public function __construct(
+        protected string $teamId,
+        protected ?int $page = null,
+        protected ?bool $filterAllowReference = null,
+        protected ?bool $paginate = null,
+    ) {}
 
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param null|int $page The page to select.
-	 * @param null|bool $filterAllowReference Boolean which filters in the group entries with the `allow_reference` attribute set.
-	 * @param null|bool $paginate Boolean to determine whether the pagination should be applied or not
-	 */
-	public function __construct(
-		protected string $teamId,
-		protected ?int $page = null,
-		protected ?bool $filterAllowReference = null,
-		protected ?bool $paginate = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['page' => $this->page, 'filter_allow_reference' => $this->filterAllowReference, 'paginate' => $this->paginate]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['page' => $this->page, 'filter_allow_reference' => $this->filterAllowReference, 'paginate' => $this->paginate]);
+    }
 }

--- a/src/Client/Requests/Groups/GetGroupsByChannel.php
+++ b/src/Client/Requests/Groups/GetGroupsByChannel.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Groups;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -19,30 +20,26 @@ use Saloon\Http\Request;
  */
 class GetGroupsByChannel extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/channels/{$this->channelId}/groups";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/channels/{$this->channelId}/groups";
-	}
+    /**
+     * @param  string  $channelId  Channel GUID
+     * @param  null|int  $page  The page to select.
+     * @param  null|bool  $filterAllowReference  Boolean which filters the group entries with the `allow_reference` attribute set.
+     */
+    public function __construct(
+        protected string $channelId,
+        protected ?int $page = null,
+        protected ?bool $filterAllowReference = null,
+    ) {}
 
-
-	/**
-	 * @param string $channelId Channel GUID
-	 * @param null|int $page The page to select.
-	 * @param null|bool $filterAllowReference Boolean which filters the group entries with the `allow_reference` attribute set.
-	 */
-	public function __construct(
-		protected string $channelId,
-		protected ?int $page = null,
-		protected ?bool $filterAllowReference = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['page' => $this->page, 'filter_allow_reference' => $this->filterAllowReference]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['page' => $this->page, 'filter_allow_reference' => $this->filterAllowReference]);
+    }
 }

--- a/src/Client/Requests/Groups/GetGroupsByTeam.php
+++ b/src/Client/Requests/Groups/GetGroupsByTeam.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Groups;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -15,30 +16,26 @@ use Saloon\Http\Request;
  */
 class GetGroupsByTeam extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/teams/{$this->teamId}/groups";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/{$this->teamId}/groups";
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  null|int  $page  The page to select.
+     * @param  null|bool  $filterAllowReference  Boolean which filters in the group entries with the `allow_reference` attribute set.
+     */
+    public function __construct(
+        protected string $teamId,
+        protected ?int $page = null,
+        protected ?bool $filterAllowReference = null,
+    ) {}
 
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param null|int $page The page to select.
-	 * @param null|bool $filterAllowReference Boolean which filters in the group entries with the `allow_reference` attribute set.
-	 */
-	public function __construct(
-		protected string $teamId,
-		protected ?int $page = null,
-		protected ?bool $filterAllowReference = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['page' => $this->page, 'filter_allow_reference' => $this->filterAllowReference]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['page' => $this->page, 'filter_allow_reference' => $this->filterAllowReference]);
+    }
 }

--- a/src/Client/Requests/Groups/GetGroupsByUserId.php
+++ b/src/Client/Requests/Groups/GetGroupsByUserId.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Groups;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -15,20 +16,17 @@ use Saloon\Http\Request;
  */
 class GetGroupsByUserId extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/groups";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/groups";
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function __construct(
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function __construct(
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Insights/GetNewTeamMembers.php
+++ b/src/Client/Requests/Insights/GetNewTeamMembers.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Insights;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,33 +17,29 @@ use Saloon\Http\Request;
  */
 class GetNewTeamMembers extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/teams/{$this->teamId}/top/team_members";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/{$this->teamId}/top/team_members";
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  string  $timeRange  Time range can be "today", "7_day", or "28_day".
+     *                             - `today`: team members who joined during the current day.
+     *                             - `7_day`: team members who joined in the last 7 days.
+     *                             - `28_day`: team members who joined in the last 28 days.
+     * @param  null|int  $page  The page to select.
+     */
+    public function __construct(
+        protected string $teamId,
+        protected string $timeRange,
+        protected ?int $page = null,
+    ) {}
 
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param string $timeRange Time range can be "today", "7_day", or "28_day".
-	 * - `today`: team members who joined during the current day.
-	 * - `7_day`: team members who joined in the last 7 days.
-	 * - `28_day`: team members who joined in the last 28 days.
-	 * @param null|int $page The page to select.
-	 */
-	public function __construct(
-		protected string $teamId,
-		protected string $timeRange,
-		protected ?int $page = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['time_range' => $this->timeRange, 'page' => $this->page]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['time_range' => $this->timeRange, 'page' => $this->page]);
+    }
 }

--- a/src/Client/Requests/Insights/GetTopChannelsForTeam.php
+++ b/src/Client/Requests/Insights/GetTopChannelsForTeam.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Insights;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,33 +17,29 @@ use Saloon\Http\Request;
  */
 class GetTopChannelsForTeam extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/teams/{$this->teamId}/top/channels";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/{$this->teamId}/top/channels";
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  string  $timeRange  Time range can be "today", "7_day", or "28_day".
+     *                             - `today`: channels with posts on the current day.
+     *                             - `7_day`: channels with posts in the last 7 days.
+     *                             - `28_day`: channels with posts in the last 28 days.
+     * @param  null|int  $page  The page to select.
+     */
+    public function __construct(
+        protected string $teamId,
+        protected string $timeRange,
+        protected ?int $page = null,
+    ) {}
 
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param string $timeRange Time range can be "today", "7_day", or "28_day".
-	 * - `today`: channels with posts on the current day.
-	 * - `7_day`: channels with posts in the last 7 days.
-	 * - `28_day`: channels with posts in the last 28 days.
-	 * @param null|int $page The page to select.
-	 */
-	public function __construct(
-		protected string $teamId,
-		protected string $timeRange,
-		protected ?int $page = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['time_range' => $this->timeRange, 'page' => $this->page]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['time_range' => $this->timeRange, 'page' => $this->page]);
+    }
 }

--- a/src/Client/Requests/Insights/GetTopChannelsForUser.php
+++ b/src/Client/Requests/Insights/GetTopChannelsForUser.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Insights;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,35 +17,31 @@ use Saloon\Http\Request;
  */
 class GetTopChannelsForUser extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/users/me/top/channels';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/me/top/channels";
-	}
+    /**
+     * @param  string  $timeRange  Time range can be "today", "7_day", or "28_day".
+     *                             - `today`: channels with posts on the current day.
+     *                             - `7_day`: channels with posts in the last 7 days.
+     *                             - `28_day`: channels with posts in the last 28 days.
+     * @param  null|int  $page  The page to select.
+     * @param  null|string  $teamId  Team ID will scope the response to a given team.
+     *                               ##### Permissions
+     *                               Must have `view_team` permission for the team.
+     */
+    public function __construct(
+        protected string $timeRange,
+        protected ?int $page = null,
+        protected ?string $teamId = null,
+    ) {}
 
-
-	/**
-	 * @param string $timeRange Time range can be "today", "7_day", or "28_day".
-	 * - `today`: channels with posts on the current day.
-	 * - `7_day`: channels with posts in the last 7 days.
-	 * - `28_day`: channels with posts in the last 28 days.
-	 * @param null|int $page The page to select.
-	 * @param null|string $teamId Team ID will scope the response to a given team.
-	 * ##### Permissions
-	 * Must have `view_team` permission for the team.
-	 */
-	public function __construct(
-		protected string $timeRange,
-		protected ?int $page = null,
-		protected ?string $teamId = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['time_range' => $this->timeRange, 'page' => $this->page, 'team_id' => $this->teamId]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['time_range' => $this->timeRange, 'page' => $this->page, 'team_id' => $this->teamId]);
+    }
 }

--- a/src/Client/Requests/Insights/GetTopDmsForUser.php
+++ b/src/Client/Requests/Insights/GetTopDmsForUser.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Insights;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -15,31 +16,27 @@ use Saloon\Http\Request;
  */
 class GetTopDmsForUser extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/users/me/top/dms';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/me/top/dms";
-	}
+    /**
+     * @param  string  $timeRange  Time range can be "today", "7_day", or "28_day".
+     *                             - `today`: threads with activity on the current day.
+     *                             - `7_day`: threads with activity in the last 7 days.
+     *                             - `28_day`: threads with activity in the last 28 days.
+     * @param  null|int  $page  The page to select.
+     */
+    public function __construct(
+        protected string $timeRange,
+        protected ?int $page = null,
+    ) {}
 
-
-	/**
-	 * @param string $timeRange Time range can be "today", "7_day", or "28_day".
-	 * - `today`: threads with activity on the current day.
-	 * - `7_day`: threads with activity in the last 7 days.
-	 * - `28_day`: threads with activity in the last 28 days.
-	 * @param null|int $page The page to select.
-	 */
-	public function __construct(
-		protected string $timeRange,
-		protected ?int $page = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['time_range' => $this->timeRange, 'page' => $this->page]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['time_range' => $this->timeRange, 'page' => $this->page]);
+    }
 }

--- a/src/Client/Requests/Insights/GetTopReactionsForTeam.php
+++ b/src/Client/Requests/Insights/GetTopReactionsForTeam.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Insights;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,33 +17,29 @@ use Saloon\Http\Request;
  */
 class GetTopReactionsForTeam extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/teams/{$this->teamId}/top/reactions";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/{$this->teamId}/top/reactions";
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  string  $timeRange  Time range can be "today", "7_day", or "28_day".
+     *                             - `today`: reactions posted on the current day.
+     *                             - `7_day`: reactions posted in the last 7 days.
+     *                             - `28_day`: reactions posted in the last 28 days.
+     * @param  null|int  $page  The page to select.
+     */
+    public function __construct(
+        protected string $teamId,
+        protected string $timeRange,
+        protected ?int $page = null,
+    ) {}
 
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param string $timeRange Time range can be "today", "7_day", or "28_day".
-	 * - `today`: reactions posted on the current day.
-	 * - `7_day`: reactions posted in the last 7 days.
-	 * - `28_day`: reactions posted in the last 28 days.
-	 * @param null|int $page The page to select.
-	 */
-	public function __construct(
-		protected string $teamId,
-		protected string $timeRange,
-		protected ?int $page = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['time_range' => $this->timeRange, 'page' => $this->page]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['time_range' => $this->timeRange, 'page' => $this->page]);
+    }
 }

--- a/src/Client/Requests/Insights/GetTopReactionsForUser.php
+++ b/src/Client/Requests/Insights/GetTopReactionsForUser.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Insights;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -18,35 +19,31 @@ use Saloon\Http\Request;
  */
 class GetTopReactionsForUser extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/users/me/top/reactions';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/me/top/reactions";
-	}
+    /**
+     * @param  string  $timeRange  Time range can be "today", "7_day", or "28_day".
+     *                             - `today`: reactions posted on the current day.
+     *                             - `7_day`: reactions posted in the last 7 days.
+     *                             - `28_day`: reactions posted in the last 28 days.
+     * @param  null|int  $page  The page to select.
+     * @param  null|string  $teamId  Team ID will scope the response to a given team and exclude direct and group messages.
+     *                               ##### Permissions
+     *                               Must have `view_team` permission for the team.
+     */
+    public function __construct(
+        protected string $timeRange,
+        protected ?int $page = null,
+        protected ?string $teamId = null,
+    ) {}
 
-
-	/**
-	 * @param string $timeRange Time range can be "today", "7_day", or "28_day".
-	 * - `today`: reactions posted on the current day.
-	 * - `7_day`: reactions posted in the last 7 days.
-	 * - `28_day`: reactions posted in the last 28 days.
-	 * @param null|int $page The page to select.
-	 * @param null|string $teamId Team ID will scope the response to a given team and exclude direct and group messages.
-	 * ##### Permissions
-	 * Must have `view_team` permission for the team.
-	 */
-	public function __construct(
-		protected string $timeRange,
-		protected ?int $page = null,
-		protected ?string $teamId = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['time_range' => $this->timeRange, 'page' => $this->page, 'team_id' => $this->teamId]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['time_range' => $this->timeRange, 'page' => $this->page, 'team_id' => $this->teamId]);
+    }
 }

--- a/src/Client/Requests/Insights/GetTopThreadsForTeam.php
+++ b/src/Client/Requests/Insights/GetTopThreadsForTeam.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Insights;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,33 +17,29 @@ use Saloon\Http\Request;
  */
 class GetTopThreadsForTeam extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/teams/{$this->teamId}/top/threads";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/{$this->teamId}/top/threads";
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  string  $timeRange  Time range can be "today", "7_day", or "28_day".
+     *                             - `today`: threads with activity on the current day.
+     *                             - `7_day`: threads with activity in the last 7 days.
+     *                             - `28_day`: threads with activity in the last 28 days.
+     * @param  null|int  $page  The page to select.
+     */
+    public function __construct(
+        protected string $teamId,
+        protected string $timeRange,
+        protected ?int $page = null,
+    ) {}
 
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param string $timeRange Time range can be "today", "7_day", or "28_day".
-	 * - `today`: threads with activity on the current day.
-	 * - `7_day`: threads with activity in the last 7 days.
-	 * - `28_day`: threads with activity in the last 28 days.
-	 * @param null|int $page The page to select.
-	 */
-	public function __construct(
-		protected string $teamId,
-		protected string $timeRange,
-		protected ?int $page = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['time_range' => $this->timeRange, 'page' => $this->page]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['time_range' => $this->timeRange, 'page' => $this->page]);
+    }
 }

--- a/src/Client/Requests/Insights/GetTopThreadsForUser.php
+++ b/src/Client/Requests/Insights/GetTopThreadsForUser.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Insights;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,35 +17,31 @@ use Saloon\Http\Request;
  */
 class GetTopThreadsForUser extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/users/me/top/threads';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/me/top/threads";
-	}
+    /**
+     * @param  string  $timeRange  Time range can be "today", "7_day", or "28_day".
+     *                             - `today`: threads with activity on the current day.
+     *                             - `7_day`: threads with activity in the last 7 days.
+     *                             - `28_day`: threads with activity in the last 28 days.
+     * @param  null|int  $page  The page to select.
+     * @param  null|string  $teamId  Team ID will scope the response to a given team.
+     *                               ##### Permissions
+     *                               Must have `view_team` permission for the team.
+     */
+    public function __construct(
+        protected string $timeRange,
+        protected ?int $page = null,
+        protected ?string $teamId = null,
+    ) {}
 
-
-	/**
-	 * @param string $timeRange Time range can be "today", "7_day", or "28_day".
-	 * - `today`: threads with activity on the current day.
-	 * - `7_day`: threads with activity in the last 7 days.
-	 * - `28_day`: threads with activity in the last 28 days.
-	 * @param null|int $page The page to select.
-	 * @param null|string $teamId Team ID will scope the response to a given team.
-	 * ##### Permissions
-	 * Must have `view_team` permission for the team.
-	 */
-	public function __construct(
-		protected string $timeRange,
-		protected ?int $page = null,
-		protected ?string $teamId = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['time_range' => $this->timeRange, 'page' => $this->page, 'team_id' => $this->teamId]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['time_range' => $this->timeRange, 'page' => $this->page, 'team_id' => $this->teamId]);
+    }
 }

--- a/src/Client/Requests/Oauth/GetAuthorizedOauthAppsForUser.php
+++ b/src/Client/Requests/Oauth/GetAuthorizedOauthAppsForUser.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Oauth;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,28 +17,24 @@ use Saloon\Http\Request;
  */
 class GetAuthorizedOauthAppsForUser extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/oauth/apps/authorized";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/oauth/apps/authorized";
-	}
+    /**
+     * @param  string  $userId  User GUID
+     * @param  null|int  $page  The page to select.
+     */
+    public function __construct(
+        protected string $userId,
+        protected ?int $page = null,
+    ) {}
 
-
-	/**
-	 * @param string $userId User GUID
-	 * @param null|int $page The page to select.
-	 */
-	public function __construct(
-		protected string $userId,
-		protected ?int $page = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['page' => $this->page]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['page' => $this->page]);
+    }
 }

--- a/src/Client/Requests/Posts/CreatePost.php
+++ b/src/Client/Requests/Posts/CreatePost.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Posts;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -19,28 +20,24 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class CreatePost extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/posts';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/posts";
-	}
+    /**
+     * @param  null|bool  $setOnline  Whether to set the user status as online or not.
+     */
+    public function __construct(
+        protected ?bool $setOnline = null,
+    ) {}
 
-
-	/**
-	 * @param null|bool $setOnline Whether to set the user status as online or not.
-	 */
-	public function __construct(
-		protected ?bool $setOnline = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['set_online' => $this->setOnline]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['set_online' => $this->setOnline]);
+    }
 }

--- a/src/Client/Requests/Posts/CreatePostEphemeral.php
+++ b/src/Client/Requests/Posts/CreatePostEphemeral.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Posts;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -18,18 +19,14 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class CreatePostEphemeral extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/posts/ephemeral';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/posts/ephemeral";
-	}
-
-
-	public function __construct()
-	{
-	}
+    public function __construct() {}
 }

--- a/src/Client/Requests/Posts/DeletePost.php
+++ b/src/Client/Requests/Posts/DeletePost.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Posts;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -17,20 +18,17 @@ use Saloon\Http\Request;
  */
 class DeletePost extends Request
 {
-	protected Method $method = Method::DELETE;
+    protected Method $method = Method::DELETE;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/posts/{$this->postId}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/posts/{$this->postId}";
-	}
-
-
-	/**
-	 * @param string $postId ID of the post to delete
-	 */
-	public function __construct(
-		protected string $postId,
-	) {
-	}
+    /**
+     * @param  string  $postId  ID of the post to delete
+     */
+    public function __construct(
+        protected string $postId,
+    ) {}
 }

--- a/src/Client/Requests/Posts/DoPostAction.php
+++ b/src/Client/Requests/Posts/DoPostAction.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Posts;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -19,24 +20,21 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class DoPostAction extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/posts/{$this->postId}/actions/{$this->actionId}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/posts/{$this->postId}/actions/{$this->actionId}";
-	}
-
-
-	/**
-	 * @param string $postId Post GUID
-	 * @param string $actionId Action GUID
-	 */
-	public function __construct(
-		protected string $postId,
-		protected string $actionId,
-	) {
-	}
+    /**
+     * @param  string  $postId  Post GUID
+     * @param  string  $actionId  Action GUID
+     */
+    public function __construct(
+        protected string $postId,
+        protected string $actionId,
+    ) {}
 }

--- a/src/Client/Requests/Posts/GetFileInfosForPost.php
+++ b/src/Client/Requests/Posts/GetFileInfosForPost.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Posts;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,28 +17,24 @@ use Saloon\Http\Request;
  */
 class GetFileInfosForPost extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/posts/{$this->postId}/files/info";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/posts/{$this->postId}/files/info";
-	}
+    /**
+     * @param  string  $postId  ID of the post
+     * @param  null|bool  $includeDeleted  Defines if result should include deleted posts, must have 'manage_system' (admin) permission.
+     */
+    public function __construct(
+        protected string $postId,
+        protected ?bool $includeDeleted = null,
+    ) {}
 
-
-	/**
-	 * @param string $postId ID of the post
-	 * @param null|bool $includeDeleted Defines if result should include deleted posts, must have 'manage_system' (admin) permission.
-	 */
-	public function __construct(
-		protected string $postId,
-		protected ?bool $includeDeleted = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['include_deleted' => $this->includeDeleted]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['include_deleted' => $this->includeDeleted]);
+    }
 }

--- a/src/Client/Requests/Posts/GetFlaggedPostsForUser.php
+++ b/src/Client/Requests/Posts/GetFlaggedPostsForUser.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Posts;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -17,32 +18,28 @@ use Saloon\Http\Request;
  */
 class GetFlaggedPostsForUser extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/posts/flagged";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/posts/flagged";
-	}
+    /**
+     * @param  string  $userId  ID of the user
+     * @param  null|string  $teamId  Team ID
+     * @param  null|string  $channelId  Channel ID
+     * @param  null|int  $page  The page to select
+     */
+    public function __construct(
+        protected string $userId,
+        protected ?string $teamId = null,
+        protected ?string $channelId = null,
+        protected ?int $page = null,
+    ) {}
 
-
-	/**
-	 * @param string $userId ID of the user
-	 * @param null|string $teamId Team ID
-	 * @param null|string $channelId Channel ID
-	 * @param null|int $page The page to select
-	 */
-	public function __construct(
-		protected string $userId,
-		protected ?string $teamId = null,
-		protected ?string $channelId = null,
-		protected ?int $page = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['team_id' => $this->teamId, 'channel_id' => $this->channelId, 'page' => $this->page]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['team_id' => $this->teamId, 'channel_id' => $this->channelId, 'page' => $this->page]);
+    }
 }

--- a/src/Client/Requests/Posts/GetPost.php
+++ b/src/Client/Requests/Posts/GetPost.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Posts;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,28 +17,24 @@ use Saloon\Http\Request;
  */
 class GetPost extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/posts/{$this->postId}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/posts/{$this->postId}";
-	}
+    /**
+     * @param  string  $postId  ID of the post to get
+     * @param  null|bool  $includeDeleted  Defines if result should include deleted posts, must have 'manage_system' (admin) permission.
+     */
+    public function __construct(
+        protected string $postId,
+        protected ?bool $includeDeleted = null,
+    ) {}
 
-
-	/**
-	 * @param string $postId ID of the post to get
-	 * @param null|bool $includeDeleted Defines if result should include deleted posts, must have 'manage_system' (admin) permission.
-	 */
-	public function __construct(
-		protected string $postId,
-		protected ?bool $includeDeleted = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['include_deleted' => $this->includeDeleted]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['include_deleted' => $this->includeDeleted]);
+    }
 }

--- a/src/Client/Requests/Posts/GetPostThread.php
+++ b/src/Client/Requests/Posts/GetPostThread.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Posts;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -17,48 +18,44 @@ use Saloon\Http\Request;
  */
 class GetPostThread extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/posts/{$this->postId}/thread";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/posts/{$this->postId}/thread";
-	}
+    /**
+     * @param  string  $postId  ID of a post in the thread
+     * @param  null|int  $perPage  The number of posts per page
+     * @param  null|string  $fromPost  The post_id to return the next page of posts from
+     * @param  null|int  $fromCreateAt  The create_at timestamp to return the next page of posts from
+     * @param  null|string  $direction  The direction to return the posts. Either up or down.
+     * @param  null|bool  $skipFetchThreads  Whether to skip fetching threads or not
+     * @param  null|bool  $collapsedThreads  Whether the client uses CRT or not
+     * @param  null|bool  $collapsedThreadsExtended  Whether to return the associated users as part of the response or not
+     */
+    public function __construct(
+        protected string $postId,
+        protected ?int $perPage = null,
+        protected ?string $fromPost = null,
+        protected ?int $fromCreateAt = null,
+        protected ?string $direction = null,
+        protected ?bool $skipFetchThreads = null,
+        protected ?bool $collapsedThreads = null,
+        protected ?bool $collapsedThreadsExtended = null,
+    ) {}
 
-
-	/**
-	 * @param string $postId ID of a post in the thread
-	 * @param null|int $perPage The number of posts per page
-	 * @param null|string $fromPost The post_id to return the next page of posts from
-	 * @param null|int $fromCreateAt The create_at timestamp to return the next page of posts from
-	 * @param null|string $direction The direction to return the posts. Either up or down.
-	 * @param null|bool $skipFetchThreads Whether to skip fetching threads or not
-	 * @param null|bool $collapsedThreads Whether the client uses CRT or not
-	 * @param null|bool $collapsedThreadsExtended Whether to return the associated users as part of the response or not
-	 */
-	public function __construct(
-		protected string $postId,
-		protected ?int $perPage = null,
-		protected ?string $fromPost = null,
-		protected ?int $fromCreateAt = null,
-		protected ?string $direction = null,
-		protected ?bool $skipFetchThreads = null,
-		protected ?bool $collapsedThreads = null,
-		protected ?bool $collapsedThreadsExtended = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter([
-			'perPage' => $this->perPage,
-			'fromPost' => $this->fromPost,
-			'fromCreateAt' => $this->fromCreateAt,
-			'direction' => $this->direction,
-			'skipFetchThreads' => $this->skipFetchThreads,
-			'collapsedThreads' => $this->collapsedThreads,
-			'collapsedThreadsExtended' => $this->collapsedThreadsExtended,
-		]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter([
+            'perPage' => $this->perPage,
+            'fromPost' => $this->fromPost,
+            'fromCreateAt' => $this->fromCreateAt,
+            'direction' => $this->direction,
+            'skipFetchThreads' => $this->skipFetchThreads,
+            'collapsedThreads' => $this->collapsedThreads,
+            'collapsedThreadsExtended' => $this->collapsedThreadsExtended,
+        ]);
+    }
 }

--- a/src/Client/Requests/Posts/GetPostsAroundLastUnread.php
+++ b/src/Client/Requests/Posts/GetPostsAroundLastUnread.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Posts;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -19,44 +20,40 @@ use Saloon\Http\Request;
  */
 class GetPostsAroundLastUnread extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/channels/{$this->channelId}/posts/unread";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/channels/{$this->channelId}/posts/unread";
-	}
+    /**
+     * @param  string  $userId  ID of the user
+     * @param  string  $channelId  The channel ID to get the posts for
+     * @param  null|int  $limitBefore  Number of posts before the oldest unread posts. Maximum is 200 posts if limit is set greater than that.
+     * @param  null|int  $limitAfter  Number of posts after and including the oldest unread post. Maximum is 200 posts if limit is set greater than that.
+     * @param  null|bool  $skipFetchThreads  Whether to skip fetching threads or not
+     * @param  null|bool  $collapsedThreads  Whether the client uses CRT or not
+     * @param  null|bool  $collapsedThreadsExtended  Whether to return the associated users as part of the response or not
+     */
+    public function __construct(
+        protected string $userId,
+        protected string $channelId,
+        protected ?int $limitBefore = null,
+        protected ?int $limitAfter = null,
+        protected ?bool $skipFetchThreads = null,
+        protected ?bool $collapsedThreads = null,
+        protected ?bool $collapsedThreadsExtended = null,
+    ) {}
 
-
-	/**
-	 * @param string $userId ID of the user
-	 * @param string $channelId The channel ID to get the posts for
-	 * @param null|int $limitBefore Number of posts before the oldest unread posts. Maximum is 200 posts if limit is set greater than that.
-	 * @param null|int $limitAfter Number of posts after and including the oldest unread post. Maximum is 200 posts if limit is set greater than that.
-	 * @param null|bool $skipFetchThreads Whether to skip fetching threads or not
-	 * @param null|bool $collapsedThreads Whether the client uses CRT or not
-	 * @param null|bool $collapsedThreadsExtended Whether to return the associated users as part of the response or not
-	 */
-	public function __construct(
-		protected string $userId,
-		protected string $channelId,
-		protected ?int $limitBefore = null,
-		protected ?int $limitAfter = null,
-		protected ?bool $skipFetchThreads = null,
-		protected ?bool $collapsedThreads = null,
-		protected ?bool $collapsedThreadsExtended = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter([
-			'limit_before' => $this->limitBefore,
-			'limit_after' => $this->limitAfter,
-			'skipFetchThreads' => $this->skipFetchThreads,
-			'collapsedThreads' => $this->collapsedThreads,
-			'collapsedThreadsExtended' => $this->collapsedThreadsExtended,
-		]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter([
+            'limit_before' => $this->limitBefore,
+            'limit_after' => $this->limitAfter,
+            'skipFetchThreads' => $this->skipFetchThreads,
+            'collapsedThreads' => $this->collapsedThreads,
+            'collapsedThreadsExtended' => $this->collapsedThreadsExtended,
+        ]);
+    }
 }

--- a/src/Client/Requests/Posts/GetPostsByIds.php
+++ b/src/Client/Requests/Posts/GetPostsByIds.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Posts;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -19,18 +20,14 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class GetPostsByIds extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/posts/ids';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/posts/ids";
-	}
-
-
-	public function __construct()
-	{
-	}
+    public function __construct() {}
 }

--- a/src/Client/Requests/Posts/GetPostsForChannel.php
+++ b/src/Client/Requests/Posts/GetPostsForChannel.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Posts;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -22,34 +23,30 @@ use Saloon\Http\Request;
  */
 class GetPostsForChannel extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/channels/{$this->channelId}/posts";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/channels/{$this->channelId}/posts";
-	}
+    /**
+     * @param  string  $channelId  The channel ID to get the posts for
+     * @param  null|int  $page  The page to select
+     * @param  null|int  $since  Provide a non-zero value in Unix time milliseconds to select posts modified after that time
+     * @param  null|string  $before  A post id to select the posts that came before this one
+     * @param  null|bool  $includeDeleted  Whether to include deleted posts or not. Must have system admin permissions.
+     */
+    public function __construct(
+        protected string $channelId,
+        protected ?int $page = null,
+        protected ?int $since = null,
+        protected ?string $before = null,
+        protected ?bool $includeDeleted = null,
+    ) {}
 
-
-	/**
-	 * @param string $channelId The channel ID to get the posts for
-	 * @param null|int $page The page to select
-	 * @param null|int $since Provide a non-zero value in Unix time milliseconds to select posts modified after that time
-	 * @param null|string $before A post id to select the posts that came before this one
-	 * @param null|bool $includeDeleted Whether to include deleted posts or not. Must have system admin permissions.
-	 */
-	public function __construct(
-		protected string $channelId,
-		protected ?int $page = null,
-		protected ?int $since = null,
-		protected ?string $before = null,
-		protected ?bool $includeDeleted = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['page' => $this->page, 'since' => $this->since, 'before' => $this->before, 'include_deleted' => $this->includeDeleted]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['page' => $this->page, 'since' => $this->since, 'before' => $this->before, 'include_deleted' => $this->includeDeleted]);
+    }
 }

--- a/src/Client/Requests/Posts/PatchPost.php
+++ b/src/Client/Requests/Posts/PatchPost.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Posts;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -17,20 +18,17 @@ use Saloon\Http\Request;
  */
 class PatchPost extends Request
 {
-	protected Method $method = Method::PUT;
+    protected Method $method = Method::PUT;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/posts/{$this->postId}/patch";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/posts/{$this->postId}/patch";
-	}
-
-
-	/**
-	 * @param string $postId Post GUID
-	 */
-	public function __construct(
-		protected string $postId,
-	) {
-	}
+    /**
+     * @param  string  $postId  Post GUID
+     */
+    public function __construct(
+        protected string $postId,
+    ) {}
 }

--- a/src/Client/Requests/Posts/PinPost.php
+++ b/src/Client/Requests/Posts/PinPost.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Posts;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -18,22 +19,19 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class PinPost extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/posts/{$this->postId}/pin";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/posts/{$this->postId}/pin";
-	}
-
-
-	/**
-	 * @param string $postId Post GUID
-	 */
-	public function __construct(
-		protected string $postId,
-	) {
-	}
+    /**
+     * @param  string  $postId  Post GUID
+     */
+    public function __construct(
+        protected string $postId,
+    ) {}
 }

--- a/src/Client/Requests/Posts/SaveAcknowledgementForPost.php
+++ b/src/Client/Requests/Posts/SaveAcknowledgementForPost.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Posts;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -20,22 +21,19 @@ use Saloon\Http\Request;
  */
 class SaveAcknowledgementForPost extends Request
 {
-	protected Method $method = Method::DELETE;
+    protected Method $method = Method::DELETE;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/posts/{$this->postId}/ack";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/posts/{$this->postId}/ack";
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 * @param string $postId Post GUID
-	 */
-	public function __construct(
-		protected string $userId,
-		protected string $postId,
-	) {
-	}
+    /**
+     * @param  string  $userId  User GUID
+     * @param  string  $postId  Post GUID
+     */
+    public function __construct(
+        protected string $userId,
+        protected string $postId,
+    ) {}
 }

--- a/src/Client/Requests/Posts/SearchPosts.php
+++ b/src/Client/Requests/Posts/SearchPosts.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Posts;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -18,22 +19,19 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class SearchPosts extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/teams/{$this->teamId}/posts/search";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/{$this->teamId}/posts/search";
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 */
-	public function __construct(
-		protected string $teamId,
-	) {
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     */
+    public function __construct(
+        protected string $teamId,
+    ) {}
 }

--- a/src/Client/Requests/Posts/SetPostReminder.php
+++ b/src/Client/Requests/Posts/SetPostReminder.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Posts;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -20,24 +21,21 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class SetPostReminder extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/posts/{$this->postId}/reminder";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/posts/{$this->postId}/reminder";
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 * @param string $postId Post GUID
-	 */
-	public function __construct(
-		protected string $userId,
-		protected string $postId,
-	) {
-	}
+    /**
+     * @param  string  $userId  User GUID
+     * @param  string  $postId  Post GUID
+     */
+    public function __construct(
+        protected string $userId,
+        protected string $postId,
+    ) {}
 }

--- a/src/Client/Requests/Posts/SetPostUnread.php
+++ b/src/Client/Requests/Posts/SetPostUnread.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Posts;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -23,24 +24,21 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class SetPostUnread extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/posts/{$this->postId}/set_unread";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/posts/{$this->postId}/set_unread";
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 * @param string $postId Post GUID
-	 */
-	public function __construct(
-		protected string $userId,
-		protected string $postId,
-	) {
-	}
+    /**
+     * @param  string  $userId  User GUID
+     * @param  string  $postId  Post GUID
+     */
+    public function __construct(
+        protected string $userId,
+        protected string $postId,
+    ) {}
 }

--- a/src/Client/Requests/Posts/UnpinPost.php
+++ b/src/Client/Requests/Posts/UnpinPost.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Posts;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -18,22 +19,19 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class UnpinPost extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/posts/{$this->postId}/unpin";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/posts/{$this->postId}/unpin";
-	}
-
-
-	/**
-	 * @param string $postId Post GUID
-	 */
-	public function __construct(
-		protected string $postId,
-	) {
-	}
+    /**
+     * @param  string  $postId  Post GUID
+     */
+    public function __construct(
+        protected string $postId,
+    ) {}
 }

--- a/src/Client/Requests/Posts/UpdatePost.php
+++ b/src/Client/Requests/Posts/UpdatePost.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Posts;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,20 +17,17 @@ use Saloon\Http\Request;
  */
 class UpdatePost extends Request
 {
-	protected Method $method = Method::PUT;
+    protected Method $method = Method::PUT;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/posts/{$this->postId}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/posts/{$this->postId}";
-	}
-
-
-	/**
-	 * @param string $postId ID of the post to update
-	 */
-	public function __construct(
-		protected string $postId,
-	) {
-	}
+    /**
+     * @param  string  $postId  ID of the post to update
+     */
+    public function __construct(
+        protected string $postId,
+    ) {}
 }

--- a/src/Client/Requests/Preferences/DeletePreferences.php
+++ b/src/Client/Requests/Preferences/DeletePreferences.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Preferences;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -18,22 +19,19 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class DeletePreferences extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/preferences/delete";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/preferences/delete";
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function __construct(
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function __construct(
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Preferences/GetPreferences.php
+++ b/src/Client/Requests/Preferences/GetPreferences.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Preferences;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,20 +17,17 @@ use Saloon\Http\Request;
  */
 class GetPreferences extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/preferences";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/preferences";
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function __construct(
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function __construct(
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Preferences/GetPreferencesByCategory.php
+++ b/src/Client/Requests/Preferences/GetPreferencesByCategory.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Preferences;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,22 +17,19 @@ use Saloon\Http\Request;
  */
 class GetPreferencesByCategory extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/preferences/{$this->category}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/preferences/{$this->category}";
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 * @param string $category The category of a group of preferences
-	 */
-	public function __construct(
-		protected string $userId,
-		protected string $category,
-	) {
-	}
+    /**
+     * @param  string  $userId  User GUID
+     * @param  string  $category  The category of a group of preferences
+     */
+    public function __construct(
+        protected string $userId,
+        protected string $category,
+    ) {}
 }

--- a/src/Client/Requests/Preferences/GetPreferencesByCategoryByName.php
+++ b/src/Client/Requests/Preferences/GetPreferencesByCategoryByName.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Preferences;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,24 +17,21 @@ use Saloon\Http\Request;
  */
 class GetPreferencesByCategoryByName extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/preferences/{$this->category}/name/{$this->preferenceName}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/preferences/{$this->category}/name/{$this->preferenceName}";
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 * @param string $category The category of a group of preferences
-	 * @param string $preferenceName The name of the preference
-	 */
-	public function __construct(
-		protected string $userId,
-		protected string $category,
-		protected string $preferenceName,
-	) {
-	}
+    /**
+     * @param  string  $userId  User GUID
+     * @param  string  $category  The category of a group of preferences
+     * @param  string  $preferenceName  The name of the preference
+     */
+    public function __construct(
+        protected string $userId,
+        protected string $category,
+        protected string $preferenceName,
+    ) {}
 }

--- a/src/Client/Requests/Preferences/UpdatePreferences.php
+++ b/src/Client/Requests/Preferences/UpdatePreferences.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Preferences;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,20 +17,17 @@ use Saloon\Http\Request;
  */
 class UpdatePreferences extends Request
 {
-	protected Method $method = Method::PUT;
+    protected Method $method = Method::PUT;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/preferences";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/preferences";
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function __construct(
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function __construct(
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Reactions/DeleteReaction.php
+++ b/src/Client/Requests/Reactions/DeleteReaction.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Reactions;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,24 +17,21 @@ use Saloon\Http\Request;
  */
 class DeleteReaction extends Request
 {
-	protected Method $method = Method::DELETE;
+    protected Method $method = Method::DELETE;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/posts/{$this->postId}/reactions/{$this->emojiName}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/posts/{$this->postId}/reactions/{$this->emojiName}";
-	}
-
-
-	/**
-	 * @param string $userId ID of the user
-	 * @param string $postId ID of the post
-	 * @param string $emojiName emoji name
-	 */
-	public function __construct(
-		protected string $userId,
-		protected string $postId,
-		protected string $emojiName,
-	) {
-	}
+    /**
+     * @param  string  $userId  ID of the user
+     * @param  string  $postId  ID of the post
+     * @param  string  $emojiName  emoji name
+     */
+    public function __construct(
+        protected string $userId,
+        protected string $postId,
+        protected string $emojiName,
+    ) {}
 }

--- a/src/Client/Requests/Reactions/GetBulkReactions.php
+++ b/src/Client/Requests/Reactions/GetBulkReactions.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Reactions;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -20,18 +21,14 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class GetBulkReactions extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/posts/ids/reactions';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/posts/ids/reactions";
-	}
-
-
-	public function __construct()
-	{
-	}
+    public function __construct() {}
 }

--- a/src/Client/Requests/Reactions/GetReactions.php
+++ b/src/Client/Requests/Reactions/GetReactions.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Reactions;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,20 +17,17 @@ use Saloon\Http\Request;
  */
 class GetReactions extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/posts/{$this->postId}/reactions";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/posts/{$this->postId}/reactions";
-	}
-
-
-	/**
-	 * @param string $postId ID of a post
-	 */
-	public function __construct(
-		protected string $postId,
-	) {
-	}
+    /**
+     * @param  string  $postId  ID of a post
+     */
+    public function __construct(
+        protected string $postId,
+    ) {}
 }

--- a/src/Client/Requests/Reactions/SaveReaction.php
+++ b/src/Client/Requests/Reactions/SaveReaction.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Reactions;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -18,18 +19,14 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class SaveReaction extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/reactions';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/reactions";
-	}
-
-
-	public function __construct()
-	{
-	}
+    public function __construct() {}
 }

--- a/src/Client/Requests/Status/GetUserStatus.php
+++ b/src/Client/Requests/Status/GetUserStatus.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Status;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -15,20 +16,17 @@ use Saloon\Http\Request;
  */
 class GetUserStatus extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/status";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/status";
-	}
-
-
-	/**
-	 * @param string $userId User ID
-	 */
-	public function __construct(
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $userId  User ID
+     */
+    public function __construct(
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Status/GetUsersStatusesByIds.php
+++ b/src/Client/Requests/Status/GetUsersStatusesByIds.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Status;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -17,18 +18,14 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class GetUsersStatusesByIds extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/users/status/ids';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/status/ids";
-	}
-
-
-	public function __construct()
-	{
-	}
+    public function __construct() {}
 }

--- a/src/Client/Requests/Status/PostUserRecentCustomStatusDelete.php
+++ b/src/Client/Requests/Status/PostUserRecentCustomStatusDelete.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Status;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -19,22 +20,19 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class PostUserRecentCustomStatusDelete extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/status/custom/recent/delete";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/status/custom/recent/delete";
-	}
-
-
-	/**
-	 * @param string $userId User ID
-	 */
-	public function __construct(
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $userId  User ID
+     */
+    public function __construct(
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Status/RemoveRecentCustomStatus.php
+++ b/src/Client/Requests/Status/RemoveRecentCustomStatus.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Status;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -17,20 +18,17 @@ use Saloon\Http\Request;
  */
 class RemoveRecentCustomStatus extends Request
 {
-	protected Method $method = Method::DELETE;
+    protected Method $method = Method::DELETE;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/status/custom/recent";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/status/custom/recent";
-	}
-
-
-	/**
-	 * @param string $userId User ID
-	 */
-	public function __construct(
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $userId  User ID
+     */
+    public function __construct(
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Status/UnsetUserCustomStatus.php
+++ b/src/Client/Requests/Status/UnsetUserCustomStatus.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Status;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,20 +17,17 @@ use Saloon\Http\Request;
  */
 class UnsetUserCustomStatus extends Request
 {
-	protected Method $method = Method::DELETE;
+    protected Method $method = Method::DELETE;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/status/custom";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/status/custom";
-	}
-
-
-	/**
-	 * @param string $userId User ID
-	 */
-	public function __construct(
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $userId  User ID
+     */
+    public function __construct(
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Status/UpdateUserCustomStatus.php
+++ b/src/Client/Requests/Status/UpdateUserCustomStatus.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Status;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -17,20 +18,17 @@ use Saloon\Http\Request;
  */
 class UpdateUserCustomStatus extends Request
 {
-	protected Method $method = Method::PUT;
+    protected Method $method = Method::PUT;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/status/custom";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/status/custom";
-	}
-
-
-	/**
-	 * @param string $userId User ID
-	 */
-	public function __construct(
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $userId  User ID
+     */
+    public function __construct(
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Status/UpdateUserStatus.php
+++ b/src/Client/Requests/Status/UpdateUserStatus.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Status;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -17,20 +18,17 @@ use Saloon\Http\Request;
  */
 class UpdateUserStatus extends Request
 {
-	protected Method $method = Method::PUT;
+    protected Method $method = Method::PUT;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/status";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/status";
-	}
-
-
-	/**
-	 * @param string $userId User ID
-	 */
-	public function __construct(
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $userId  User ID
+     */
+    public function __construct(
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/System/GenerateSupportPacket.php
+++ b/src/Client/Requests/System/GenerateSupportPacket.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\System;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -20,16 +21,12 @@ use Saloon\Http\Request;
  */
 class GenerateSupportPacket extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/system/support_packet';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/system/support_packet";
-	}
-
-
-	public function __construct()
-	{
-	}
+    public function __construct() {}
 }

--- a/src/Client/Requests/System/GetNotices.php
+++ b/src/Client/Requests/System/GetNotices.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\System;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -17,32 +18,28 @@ use Saloon\Http\Request;
  */
 class GetNotices extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/system/notices/{$this->teamId}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/system/notices/{$this->teamId}";
-	}
+    /**
+     * @param  string  $teamId  ID of the team
+     * @param  string  $clientVersion  Version of the client (desktop/mobile/web) that issues the request
+     * @param  null|string  $locale  Client locale
+     * @param  string  $client  Client type (web/mobile-ios/mobile-android/desktop)
+     */
+    public function __construct(
+        protected string $teamId,
+        protected string $clientVersion,
+        protected ?string $locale,
+        protected string $client,
+    ) {}
 
-
-	/**
-	 * @param string $teamId ID of the team
-	 * @param string $clientVersion Version of the client (desktop/mobile/web) that issues the request
-	 * @param null|string $locale Client locale
-	 * @param string $client Client type (web/mobile-ios/mobile-android/desktop)
-	 */
-	public function __construct(
-		protected string $teamId,
-		protected string $clientVersion,
-		protected ?string $locale = null,
-		protected string $client,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['clientVersion' => $this->clientVersion, 'locale' => $this->locale, 'client' => $this->client]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['clientVersion' => $this->clientVersion, 'locale' => $this->locale, 'client' => $this->client]);
+    }
 }

--- a/src/Client/Requests/System/GetPing.php
+++ b/src/Client/Requests/System/GetPing.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\System;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -29,28 +30,24 @@ use Saloon\Http\Request;
  */
 class GetPing extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/system/ping';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/system/ping";
-	}
+    /**
+     * @param  null|bool  $getServerStatus  Check the status of the database and file storage as well
+     * @param  null|string  $deviceId  Check whether this device id can receive push notifications
+     */
+    public function __construct(
+        protected ?bool $getServerStatus = null,
+        protected ?string $deviceId = null,
+    ) {}
 
-
-	/**
-	 * @param null|bool $getServerStatus Check the status of the database and file storage as well
-	 * @param null|string $deviceId Check whether this device id can receive push notifications
-	 */
-	public function __construct(
-		protected ?bool $getServerStatus = null,
-		protected ?string $deviceId = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['get_server_status' => $this->getServerStatus, 'device_id' => $this->deviceId]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['get_server_status' => $this->getServerStatus, 'device_id' => $this->deviceId]);
+    }
 }

--- a/src/Client/Requests/System/GetSupportedTimezone.php
+++ b/src/Client/Requests/System/GetSupportedTimezone.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\System;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -15,16 +16,12 @@ use Saloon\Http\Request;
  */
 class GetSupportedTimezone extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/system/timezones';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/system/timezones";
-	}
-
-
-	public function __construct()
-	{
-	}
+    public function __construct() {}
 }

--- a/src/Client/Requests/System/MarkNoticesViewed.php
+++ b/src/Client/Requests/System/MarkNoticesViewed.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\System;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -17,16 +18,12 @@ use Saloon\Http\Request;
  */
 class MarkNoticesViewed extends Request
 {
-	protected Method $method = Method::PUT;
+    protected Method $method = Method::PUT;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/system/notices/view';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/system/notices/view";
-	}
-
-
-	public function __construct()
-	{
-	}
+    public function __construct() {}
 }

--- a/src/Client/Requests/Teams/AddTeamMember.php
+++ b/src/Client/Requests/Teams/AddTeamMember.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Teams;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -18,22 +19,19 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class AddTeamMember extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/teams/{$this->teamId}/members";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/{$this->teamId}/members";
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 */
-	public function __construct(
-		protected string $teamId,
-	) {
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     */
+    public function __construct(
+        protected string $teamId,
+    ) {}
 }

--- a/src/Client/Requests/Teams/AddTeamMemberFromInvite.php
+++ b/src/Client/Requests/Teams/AddTeamMemberFromInvite.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Teams;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -18,28 +19,24 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class AddTeamMemberFromInvite extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/teams/members/invite';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/members/invite";
-	}
+    /**
+     * @param  string  $token  Token id from the invitation
+     */
+    public function __construct(
+        protected string $token,
+    ) {}
 
-
-	/**
-	 * @param string $token Token id from the invitation
-	 */
-	public function __construct(
-		protected string $token,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['token' => $this->token]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['token' => $this->token]);
+    }
 }

--- a/src/Client/Requests/Teams/AddTeamMembers.php
+++ b/src/Client/Requests/Teams/AddTeamMembers.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Teams;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -18,30 +19,26 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class AddTeamMembers extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/teams/{$this->teamId}/members/batch";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/{$this->teamId}/members/batch";
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  null|bool  $graceful  Instead of aborting the operation if a user cannot be added, return an arrray that will contain both the success and added members and the ones with error, in form of `[{"member": {...}, "user_id", "...", "error": {...}}]`
+     */
+    public function __construct(
+        protected string $teamId,
+        protected ?bool $graceful = null,
+    ) {}
 
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param null|bool $graceful Instead of aborting the operation if a user cannot be added, return an arrray that will contain both the success and added members and the ones with error, in form of `[{"member": {...}, "user_id", "...", "error": {...}}]`
-	 */
-	public function __construct(
-		protected string $teamId,
-		protected ?bool $graceful = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['graceful' => $this->graceful]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['graceful' => $this->graceful]);
+    }
 }

--- a/src/Client/Requests/Teams/CreateTeam.php
+++ b/src/Client/Requests/Teams/CreateTeam.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Teams;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -18,18 +19,14 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class CreateTeam extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/teams';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams";
-	}
-
-
-	public function __construct()
-	{
-	}
+    public function __construct() {}
 }

--- a/src/Client/Requests/Teams/GetAllTeams.php
+++ b/src/Client/Requests/Teams/GetAllTeams.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Teams;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -17,35 +18,31 @@ use Saloon\Http\Request;
  */
 class GetAllTeams extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/teams';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams";
-	}
+    /**
+     * @param  null|int  $page  The page to select.
+     * @param  null|bool  $includeTotalCount  Appends a total count of returned teams inside the response object - ex: `{ "teams": [], "total_count" : 0 }`.
+     * @param  null|bool  $excludePolicyConstrained  If set to true, teams which are part of a data retention policy will be excluded. The `sysconsole_read_compliance` permission is required to use this parameter.
+     *                                               __Minimum server version__: 5.35
+     */
+    public function __construct(
+        protected ?int $page = null,
+        protected ?bool $includeTotalCount = null,
+        protected ?bool $excludePolicyConstrained = null,
+    ) {}
 
-
-	/**
-	 * @param null|int $page The page to select.
-	 * @param null|bool $includeTotalCount Appends a total count of returned teams inside the response object - ex: `{ "teams": [], "total_count" : 0 }`.
-	 * @param null|bool $excludePolicyConstrained If set to true, teams which are part of a data retention policy will be excluded. The `sysconsole_read_compliance` permission is required to use this parameter.
-	 * __Minimum server version__: 5.35
-	 */
-	public function __construct(
-		protected ?int $page = null,
-		protected ?bool $includeTotalCount = null,
-		protected ?bool $excludePolicyConstrained = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter([
-			'page' => $this->page,
-			'include_total_count' => $this->includeTotalCount,
-			'exclude_policy_constrained' => $this->excludePolicyConstrained,
-		]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter([
+            'page' => $this->page,
+            'include_total_count' => $this->includeTotalCount,
+            'exclude_policy_constrained' => $this->excludePolicyConstrained,
+        ]);
+    }
 }

--- a/src/Client/Requests/Teams/GetTeam.php
+++ b/src/Client/Requests/Teams/GetTeam.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Teams;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,20 +17,17 @@ use Saloon\Http\Request;
  */
 class GetTeam extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/teams/{$this->teamId}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/{$this->teamId}";
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 */
-	public function __construct(
-		protected string $teamId,
-	) {
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     */
+    public function __construct(
+        protected string $teamId,
+    ) {}
 }

--- a/src/Client/Requests/Teams/GetTeamByName.php
+++ b/src/Client/Requests/Teams/GetTeamByName.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Teams;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,20 +17,17 @@ use Saloon\Http\Request;
  */
 class GetTeamByName extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/teams/name/{$this->name}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/name/{$this->name}";
-	}
-
-
-	/**
-	 * @param string $name Team Name
-	 */
-	public function __construct(
-		protected string $name,
-	) {
-	}
+    /**
+     * @param  string  $name  Team Name
+     */
+    public function __construct(
+        protected string $name,
+    ) {}
 }

--- a/src/Client/Requests/Teams/GetTeamIcon.php
+++ b/src/Client/Requests/Teams/GetTeamIcon.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Teams;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -19,20 +20,17 @@ use Saloon\Http\Request;
  */
 class GetTeamIcon extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/teams/{$this->teamId}/image";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/{$this->teamId}/image";
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 */
-	public function __construct(
-		protected string $teamId,
-	) {
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     */
+    public function __construct(
+        protected string $teamId,
+    ) {}
 }

--- a/src/Client/Requests/Teams/GetTeamInviteInfo.php
+++ b/src/Client/Requests/Teams/GetTeamInviteInfo.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Teams;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -19,20 +20,17 @@ use Saloon\Http\Request;
  */
 class GetTeamInviteInfo extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/teams/invite/{$this->inviteId}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/invite/{$this->inviteId}";
-	}
-
-
-	/**
-	 * @param string $inviteId Invite id for a team
-	 */
-	public function __construct(
-		protected string $inviteId,
-	) {
-	}
+    /**
+     * @param  string  $inviteId  Invite id for a team
+     */
+    public function __construct(
+        protected string $inviteId,
+    ) {}
 }

--- a/src/Client/Requests/Teams/GetTeamMember.php
+++ b/src/Client/Requests/Teams/GetTeamMember.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Teams;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,22 +17,19 @@ use Saloon\Http\Request;
  */
 class GetTeamMember extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/teams/{$this->teamId}/members/{$this->userId}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/{$this->teamId}/members/{$this->userId}";
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param string $userId User GUID
-	 */
-	public function __construct(
-		protected string $teamId,
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  string  $userId  User GUID
+     */
+    public function __construct(
+        protected string $teamId,
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Teams/GetTeamMembers.php
+++ b/src/Client/Requests/Teams/GetTeamMembers.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Teams;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,28 +17,24 @@ use Saloon\Http\Request;
  */
 class GetTeamMembers extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/teams/{$this->teamId}/members";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/{$this->teamId}/members";
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  null|int  $page  The page to select.
+     */
+    public function __construct(
+        protected string $teamId,
+        protected ?int $page = null,
+    ) {}
 
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param null|int $page The page to select.
-	 */
-	public function __construct(
-		protected string $teamId,
-		protected ?int $page = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['page' => $this->page]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['page' => $this->page]);
+    }
 }

--- a/src/Client/Requests/Teams/GetTeamMembersByIds.php
+++ b/src/Client/Requests/Teams/GetTeamMembersByIds.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Teams;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -18,22 +19,19 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class GetTeamMembersByIds extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/teams/{$this->teamId}/members/ids";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/{$this->teamId}/members/ids";
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 */
-	public function __construct(
-		protected string $teamId,
-	) {
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     */
+    public function __construct(
+        protected string $teamId,
+    ) {}
 }

--- a/src/Client/Requests/Teams/GetTeamMembersForUser.php
+++ b/src/Client/Requests/Teams/GetTeamMembersForUser.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Teams;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -17,20 +18,17 @@ use Saloon\Http\Request;
  */
 class GetTeamMembersForUser extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/teams/members";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/teams/members";
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function __construct(
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function __construct(
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Teams/GetTeamStats.php
+++ b/src/Client/Requests/Teams/GetTeamStats.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Teams;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,20 +17,17 @@ use Saloon\Http\Request;
  */
 class GetTeamStats extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/teams/{$this->teamId}/stats";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/{$this->teamId}/stats";
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 */
-	public function __construct(
-		protected string $teamId,
-	) {
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     */
+    public function __construct(
+        protected string $teamId,
+    ) {}
 }

--- a/src/Client/Requests/Teams/GetTeamUnread.php
+++ b/src/Client/Requests/Teams/GetTeamUnread.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Teams;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,22 +17,19 @@ use Saloon\Http\Request;
  */
 class GetTeamUnread extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/unread";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/unread";
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 * @param string $teamId Team GUID
-	 */
-	public function __construct(
-		protected string $userId,
-		protected string $teamId,
-	) {
-	}
+    /**
+     * @param  string  $userId  User GUID
+     * @param  string  $teamId  Team GUID
+     */
+    public function __construct(
+        protected string $userId,
+        protected string $teamId,
+    ) {}
 }

--- a/src/Client/Requests/Teams/GetTeamsForUser.php
+++ b/src/Client/Requests/Teams/GetTeamsForUser.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Teams;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,20 +17,17 @@ use Saloon\Http\Request;
  */
 class GetTeamsForUser extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/teams";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/teams";
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function __construct(
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function __construct(
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Teams/GetTeamsUnreadForUser.php
+++ b/src/Client/Requests/Teams/GetTeamsUnreadForUser.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Teams;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,30 +17,26 @@ use Saloon\Http\Request;
  */
 class GetTeamsUnreadForUser extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/teams/unread";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/teams/unread";
-	}
+    /**
+     * @param  string  $userId  User GUID
+     * @param  string  $excludeTeam  Optional team id to be excluded from the results
+     * @param  null|bool  $includeCollapsedThreads  Boolean to determine whether the collapsed threads should be included or not
+     */
+    public function __construct(
+        protected string $userId,
+        protected string $excludeTeam,
+        protected ?bool $includeCollapsedThreads = null,
+    ) {}
 
-
-	/**
-	 * @param string $userId User GUID
-	 * @param string $excludeTeam Optional team id to be excluded from the results
-	 * @param null|bool $includeCollapsedThreads Boolean to determine whether the collapsed threads should be included or not
-	 */
-	public function __construct(
-		protected string $userId,
-		protected string $excludeTeam,
-		protected ?bool $includeCollapsedThreads = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['exclude_team' => $this->excludeTeam, 'include_collapsed_threads' => $this->includeCollapsedThreads]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['exclude_team' => $this->excludeTeam, 'include_collapsed_threads' => $this->includeCollapsedThreads]);
+    }
 }

--- a/src/Client/Requests/Teams/ImportTeam.php
+++ b/src/Client/Requests/Teams/ImportTeam.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Teams;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -18,22 +19,19 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class ImportTeam extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/teams/{$this->teamId}/import";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/{$this->teamId}/import";
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 */
-	public function __construct(
-		protected string $teamId,
-	) {
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     */
+    public function __construct(
+        protected string $teamId,
+    ) {}
 }

--- a/src/Client/Requests/Teams/InvalidateEmailInvites.php
+++ b/src/Client/Requests/Teams/InvalidateEmailInvites.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Teams;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,16 +17,12 @@ use Saloon\Http\Request;
  */
 class InvalidateEmailInvites extends Request
 {
-	protected Method $method = Method::DELETE;
+    protected Method $method = Method::DELETE;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/teams/invites/email';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/invites/email";
-	}
-
-
-	public function __construct()
-	{
-	}
+    public function __construct() {}
 }

--- a/src/Client/Requests/Teams/InviteGuestsToTeam.php
+++ b/src/Client/Requests/Teams/InviteGuestsToTeam.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Teams;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -25,22 +26,19 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class InviteGuestsToTeam extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/teams/{$this->teamId}/invite-guests/email";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/{$this->teamId}/invite-guests/email";
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 */
-	public function __construct(
-		protected string $teamId,
-	) {
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     */
+    public function __construct(
+        protected string $teamId,
+    ) {}
 }

--- a/src/Client/Requests/Teams/InviteUsersToTeam.php
+++ b/src/Client/Requests/Teams/InviteUsersToTeam.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Teams;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -22,22 +23,19 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class InviteUsersToTeam extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/teams/{$this->teamId}/invite/email";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/{$this->teamId}/invite/email";
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 */
-	public function __construct(
-		protected string $teamId,
-	) {
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     */
+    public function __construct(
+        protected string $teamId,
+    ) {}
 }

--- a/src/Client/Requests/Teams/PatchTeam.php
+++ b/src/Client/Requests/Teams/PatchTeam.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Teams;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -17,20 +18,17 @@ use Saloon\Http\Request;
  */
 class PatchTeam extends Request
 {
-	protected Method $method = Method::PUT;
+    protected Method $method = Method::PUT;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/teams/{$this->teamId}/patch";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/{$this->teamId}/patch";
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 */
-	public function __construct(
-		protected string $teamId,
-	) {
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     */
+    public function __construct(
+        protected string $teamId,
+    ) {}
 }

--- a/src/Client/Requests/Teams/RegenerateTeamInviteId.php
+++ b/src/Client/Requests/Teams/RegenerateTeamInviteId.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Teams;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -18,22 +19,19 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class RegenerateTeamInviteId extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/teams/{$this->teamId}/regenerate_invite_id";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/{$this->teamId}/regenerate_invite_id";
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 */
-	public function __construct(
-		protected string $teamId,
-	) {
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     */
+    public function __construct(
+        protected string $teamId,
+    ) {}
 }

--- a/src/Client/Requests/Teams/RemoveTeamIcon.php
+++ b/src/Client/Requests/Teams/RemoveTeamIcon.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Teams;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -19,20 +20,17 @@ use Saloon\Http\Request;
  */
 class RemoveTeamIcon extends Request
 {
-	protected Method $method = Method::DELETE;
+    protected Method $method = Method::DELETE;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/teams/{$this->teamId}/image";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/{$this->teamId}/image";
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 */
-	public function __construct(
-		protected string $teamId,
-	) {
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     */
+    public function __construct(
+        protected string $teamId,
+    ) {}
 }

--- a/src/Client/Requests/Teams/RemoveTeamMember.php
+++ b/src/Client/Requests/Teams/RemoveTeamMember.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Teams;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,22 +17,19 @@ use Saloon\Http\Request;
  */
 class RemoveTeamMember extends Request
 {
-	protected Method $method = Method::DELETE;
+    protected Method $method = Method::DELETE;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/teams/{$this->teamId}/members/{$this->userId}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/{$this->teamId}/members/{$this->userId}";
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param string $userId User GUID
-	 */
-	public function __construct(
-		protected string $teamId,
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  string  $userId  User GUID
+     */
+    public function __construct(
+        protected string $teamId,
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Teams/RestoreTeam.php
+++ b/src/Client/Requests/Teams/RestoreTeam.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Teams;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -21,22 +22,19 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class RestoreTeam extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/teams/{$this->teamId}/restore";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/{$this->teamId}/restore";
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 */
-	public function __construct(
-		protected string $teamId,
-	) {
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     */
+    public function __construct(
+        protected string $teamId,
+    ) {}
 }

--- a/src/Client/Requests/Teams/SearchFiles.php
+++ b/src/Client/Requests/Teams/SearchFiles.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Teams;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -20,22 +21,19 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class SearchFiles extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/teams/{$this->teamId}/files/search";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/{$this->teamId}/files/search";
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 */
-	public function __construct(
-		protected string $teamId,
-	) {
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     */
+    public function __construct(
+        protected string $teamId,
+    ) {}
 }

--- a/src/Client/Requests/Teams/SearchTeams.php
+++ b/src/Client/Requests/Teams/SearchTeams.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Teams;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -21,18 +22,14 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class SearchTeams extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/teams/search';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/search";
-	}
-
-
-	public function __construct()
-	{
-	}
+    public function __construct() {}
 }

--- a/src/Client/Requests/Teams/SetTeamIcon.php
+++ b/src/Client/Requests/Teams/SetTeamIcon.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Teams;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -21,22 +22,19 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class SetTeamIcon extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/teams/{$this->teamId}/image";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/{$this->teamId}/image";
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 */
-	public function __construct(
-		protected string $teamId,
-	) {
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     */
+    public function __construct(
+        protected string $teamId,
+    ) {}
 }

--- a/src/Client/Requests/Teams/SoftDeleteTeam.php
+++ b/src/Client/Requests/Teams/SoftDeleteTeam.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Teams;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -21,28 +22,24 @@ use Saloon\Http\Request;
  */
 class SoftDeleteTeam extends Request
 {
-	protected Method $method = Method::DELETE;
+    protected Method $method = Method::DELETE;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/teams/{$this->teamId}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/{$this->teamId}";
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  null|bool  $permanent  Permanently delete the team, to be used for compliance reasons only. As of server version 5.0, `ServiceSettings.EnableAPITeamDeletion` must be set to `true` in the server's configuration.
+     */
+    public function __construct(
+        protected string $teamId,
+        protected ?bool $permanent = null,
+    ) {}
 
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param null|bool $permanent Permanently delete the team, to be used for compliance reasons only. As of server version 5.0, `ServiceSettings.EnableAPITeamDeletion` must be set to `true` in the server's configuration.
-	 */
-	public function __construct(
-		protected string $teamId,
-		protected ?bool $permanent = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['permanent' => $this->permanent]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['permanent' => $this->permanent]);
+    }
 }

--- a/src/Client/Requests/Teams/TeamExists.php
+++ b/src/Client/Requests/Teams/TeamExists.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Teams;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -15,20 +16,17 @@ use Saloon\Http\Request;
  */
 class TeamExists extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/teams/name/{$this->name}/exists";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/name/{$this->name}/exists";
-	}
-
-
-	/**
-	 * @param string $name Team Name
-	 */
-	public function __construct(
-		protected string $name,
-	) {
-	}
+    /**
+     * @param  string  $name  Team Name
+     */
+    public function __construct(
+        protected string $name,
+    ) {}
 }

--- a/src/Client/Requests/Teams/TeamMembersMinusGroupMembers.php
+++ b/src/Client/Requests/Teams/TeamMembersMinusGroupMembers.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Teams;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -24,30 +25,26 @@ use Saloon\Http\Request;
  */
 class TeamMembersMinusGroupMembers extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/teams/{$this->teamId}/members_minus_group_members";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/{$this->teamId}/members_minus_group_members";
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  string  $groupIds  A comma-separated list of group ids.
+     * @param  null|int  $page  The page to select.
+     */
+    public function __construct(
+        protected string $teamId,
+        protected string $groupIds,
+        protected ?int $page = null,
+    ) {}
 
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param string $groupIds A comma-separated list of group ids.
-	 * @param null|int $page The page to select.
-	 */
-	public function __construct(
-		protected string $teamId,
-		protected string $groupIds,
-		protected ?int $page = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['group_ids' => $this->groupIds, 'page' => $this->page]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['group_ids' => $this->groupIds, 'page' => $this->page]);
+    }
 }

--- a/src/Client/Requests/Teams/UpdateTeam.php
+++ b/src/Client/Requests/Teams/UpdateTeam.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Teams;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -17,20 +18,17 @@ use Saloon\Http\Request;
  */
 class UpdateTeam extends Request
 {
-	protected Method $method = Method::PUT;
+    protected Method $method = Method::PUT;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/teams/{$this->teamId}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/{$this->teamId}";
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 */
-	public function __construct(
-		protected string $teamId,
-	) {
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     */
+    public function __construct(
+        protected string $teamId,
+    ) {}
 }

--- a/src/Client/Requests/Teams/UpdateTeamMemberRoles.php
+++ b/src/Client/Requests/Teams/UpdateTeamMemberRoles.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Teams;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -17,22 +18,19 @@ use Saloon\Http\Request;
  */
 class UpdateTeamMemberRoles extends Request
 {
-	protected Method $method = Method::PUT;
+    protected Method $method = Method::PUT;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/teams/{$this->teamId}/members/{$this->userId}/roles";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/{$this->teamId}/members/{$this->userId}/roles";
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param string $userId User GUID
-	 */
-	public function __construct(
-		protected string $teamId,
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  string  $userId  User GUID
+     */
+    public function __construct(
+        protected string $teamId,
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Teams/UpdateTeamMemberSchemeRoles.php
+++ b/src/Client/Requests/Teams/UpdateTeamMemberSchemeRoles.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Teams;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -21,22 +22,19 @@ use Saloon\Http\Request;
  */
 class UpdateTeamMemberSchemeRoles extends Request
 {
-	protected Method $method = Method::PUT;
+    protected Method $method = Method::PUT;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/teams/{$this->teamId}/members/{$this->userId}/schemeRoles";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/{$this->teamId}/members/{$this->userId}/schemeRoles";
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param string $userId User GUID
-	 */
-	public function __construct(
-		protected string $teamId,
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  string  $userId  User GUID
+     */
+    public function __construct(
+        protected string $teamId,
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Teams/UpdateTeamPrivacy.php
+++ b/src/Client/Requests/Teams/UpdateTeamPrivacy.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Teams;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -20,20 +21,17 @@ use Saloon\Http\Request;
  */
 class UpdateTeamPrivacy extends Request
 {
-	protected Method $method = Method::PUT;
+    protected Method $method = Method::PUT;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/teams/{$this->teamId}/privacy";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/{$this->teamId}/privacy";
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 */
-	public function __construct(
-		protected string $teamId,
-	) {
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     */
+    public function __construct(
+        protected string $teamId,
+    ) {}
 }

--- a/src/Client/Requests/Teams/UpdateTeamScheme.php
+++ b/src/Client/Requests/Teams/UpdateTeamScheme.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Teams;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -19,20 +20,17 @@ use Saloon\Http\Request;
  */
 class UpdateTeamScheme extends Request
 {
-	protected Method $method = Method::PUT;
+    protected Method $method = Method::PUT;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/teams/{$this->teamId}/scheme";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/teams/{$this->teamId}/scheme";
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 */
-	public function __construct(
-		protected string $teamId,
-	) {
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     */
+    public function __construct(
+        protected string $teamId,
+    ) {}
 }

--- a/src/Client/Requests/Threads/GetThreadMentionCountsByChannel.php
+++ b/src/Client/Requests/Threads/GetThreadMentionCountsByChannel.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Threads;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -19,22 +20,19 @@ use Saloon\Http\Request;
  */
 class GetThreadMentionCountsByChannel extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/threads/mention_counts";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/threads/mention_counts";
-	}
-
-
-	/**
-	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
-	 * @param string $teamId The ID of the team in which the thread is.
-	 */
-	public function __construct(
-		protected string $userId,
-		protected string $teamId,
-	) {
-	}
+    /**
+     * @param  string  $userId  The ID of the user. This can also be "me" which will point to the current user.
+     * @param  string  $teamId  The ID of the team in which the thread is.
+     */
+    public function __construct(
+        protected string $userId,
+        protected string $teamId,
+    ) {}
 }

--- a/src/Client/Requests/Threads/GetUserThread.php
+++ b/src/Client/Requests/Threads/GetUserThread.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Threads;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -19,24 +20,21 @@ use Saloon\Http\Request;
  */
 class GetUserThread extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/threads/{$this->threadId}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/threads/{$this->threadId}";
-	}
-
-
-	/**
-	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
-	 * @param string $teamId The ID of the team in which the thread is.
-	 * @param string $threadId The ID of the thread to follow
-	 */
-	public function __construct(
-		protected string $userId,
-		protected string $teamId,
-		protected string $threadId,
-	) {
-	}
+    /**
+     * @param  string  $userId  The ID of the user. This can also be "me" which will point to the current user.
+     * @param  string  $teamId  The ID of the team in which the thread is.
+     * @param  string  $threadId  The ID of the thread to follow
+     */
+    public function __construct(
+        protected string $userId,
+        protected string $teamId,
+        protected string $threadId,
+    ) {}
 }

--- a/src/Client/Requests/Threads/GetUserThreads.php
+++ b/src/Client/Requests/Threads/GetUserThreads.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Threads;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -19,50 +20,46 @@ use Saloon\Http\Request;
  */
 class GetUserThreads extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/threads";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/threads";
-	}
+    /**
+     * @param  string  $userId  The ID of the user. This can also be "me" which will point to the current user.
+     * @param  string  $teamId  The ID of the team in which the thread is.
+     * @param  null|int  $since  Since filters the threads based on their LastUpdateAt timestamp.
+     * @param  null|bool  $deleted  Deleted will specify that even deleted threads should be returned (For mobile sync).
+     * @param  null|bool  $extended  Extended will enrich the response with participant details.
+     * @param  null|int  $page  Page specifies which part of the results to return, by PageSize.
+     * @param  null|int  $pageSize  PageSize specifies the size of the returned chunk of results.
+     * @param  null|bool  $totalsOnly  Setting this to true will only return the total counts.
+     * @param  null|bool  $threadsOnly  Setting this to true will only return threads.
+     */
+    public function __construct(
+        protected string $userId,
+        protected string $teamId,
+        protected ?int $since = null,
+        protected ?bool $deleted = null,
+        protected ?bool $extended = null,
+        protected ?int $page = null,
+        protected ?int $pageSize = null,
+        protected ?bool $totalsOnly = null,
+        protected ?bool $threadsOnly = null,
+    ) {}
 
-
-	/**
-	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
-	 * @param string $teamId The ID of the team in which the thread is.
-	 * @param null|int $since Since filters the threads based on their LastUpdateAt timestamp.
-	 * @param null|bool $deleted Deleted will specify that even deleted threads should be returned (For mobile sync).
-	 * @param null|bool $extended Extended will enrich the response with participant details.
-	 * @param null|int $page Page specifies which part of the results to return, by PageSize.
-	 * @param null|int $pageSize PageSize specifies the size of the returned chunk of results.
-	 * @param null|bool $totalsOnly Setting this to true will only return the total counts.
-	 * @param null|bool $threadsOnly Setting this to true will only return threads.
-	 */
-	public function __construct(
-		protected string $userId,
-		protected string $teamId,
-		protected ?int $since = null,
-		protected ?bool $deleted = null,
-		protected ?bool $extended = null,
-		protected ?int $page = null,
-		protected ?int $pageSize = null,
-		protected ?bool $totalsOnly = null,
-		protected ?bool $threadsOnly = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter([
-			'since' => $this->since,
-			'deleted' => $this->deleted,
-			'extended' => $this->extended,
-			'page' => $this->page,
-			'pageSize' => $this->pageSize,
-			'totalsOnly' => $this->totalsOnly,
-			'threadsOnly' => $this->threadsOnly,
-		]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter([
+            'since' => $this->since,
+            'deleted' => $this->deleted,
+            'extended' => $this->extended,
+            'page' => $this->page,
+            'pageSize' => $this->pageSize,
+            'totalsOnly' => $this->totalsOnly,
+            'threadsOnly' => $this->threadsOnly,
+        ]);
+    }
 }

--- a/src/Client/Requests/Threads/SetThreadUnreadByPostId.php
+++ b/src/Client/Requests/Threads/SetThreadUnreadByPostId.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Threads;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -23,26 +24,23 @@ use Saloon\Http\Request;
  */
 class SetThreadUnreadByPostId extends Request
 {
-	protected Method $method = Method::PUT;
+    protected Method $method = Method::PUT;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/threads/{$this->threadId}/set_unread/{$this->postId}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/threads/{$this->threadId}/set_unread/{$this->postId}";
-	}
-
-
-	/**
-	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
-	 * @param string $teamId The ID of the team in which the thread is.
-	 * @param string $threadId The ID of the thread to update
-	 * @param string $postId The ID of a post belonging to the thread to mark as unread.
-	 */
-	public function __construct(
-		protected string $userId,
-		protected string $teamId,
-		protected string $threadId,
-		protected string $postId,
-	) {
-	}
+    /**
+     * @param  string  $userId  The ID of the user. This can also be "me" which will point to the current user.
+     * @param  string  $teamId  The ID of the team in which the thread is.
+     * @param  string  $threadId  The ID of the thread to update
+     * @param  string  $postId  The ID of a post belonging to the thread to mark as unread.
+     */
+    public function __construct(
+        protected string $userId,
+        protected string $teamId,
+        protected string $threadId,
+        protected string $postId,
+    ) {}
 }

--- a/src/Client/Requests/Threads/StartFollowingThread.php
+++ b/src/Client/Requests/Threads/StartFollowingThread.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Threads;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -19,24 +20,21 @@ use Saloon\Http\Request;
  */
 class StartFollowingThread extends Request
 {
-	protected Method $method = Method::PUT;
+    protected Method $method = Method::PUT;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/threads/{$this->threadId}/following";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/threads/{$this->threadId}/following";
-	}
-
-
-	/**
-	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
-	 * @param string $teamId The ID of the team in which the thread is.
-	 * @param string $threadId The ID of the thread to follow
-	 */
-	public function __construct(
-		protected string $userId,
-		protected string $teamId,
-		protected string $threadId,
-	) {
-	}
+    /**
+     * @param  string  $userId  The ID of the user. This can also be "me" which will point to the current user.
+     * @param  string  $teamId  The ID of the team in which the thread is.
+     * @param  string  $threadId  The ID of the thread to follow
+     */
+    public function __construct(
+        protected string $userId,
+        protected string $teamId,
+        protected string $threadId,
+    ) {}
 }

--- a/src/Client/Requests/Threads/StopFollowingThread.php
+++ b/src/Client/Requests/Threads/StopFollowingThread.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Threads;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -19,24 +20,21 @@ use Saloon\Http\Request;
  */
 class StopFollowingThread extends Request
 {
-	protected Method $method = Method::DELETE;
+    protected Method $method = Method::DELETE;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/threads/{$this->threadId}/following";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/threads/{$this->threadId}/following";
-	}
-
-
-	/**
-	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
-	 * @param string $teamId The ID of the team in which the thread is.
-	 * @param string $threadId The ID of the thread to update
-	 */
-	public function __construct(
-		protected string $userId,
-		protected string $teamId,
-		protected string $threadId,
-	) {
-	}
+    /**
+     * @param  string  $userId  The ID of the user. This can also be "me" which will point to the current user.
+     * @param  string  $teamId  The ID of the team in which the thread is.
+     * @param  string  $threadId  The ID of the thread to update
+     */
+    public function __construct(
+        protected string $userId,
+        protected string $teamId,
+        protected string $threadId,
+    ) {}
 }

--- a/src/Client/Requests/Threads/UpdateThreadReadForUser.php
+++ b/src/Client/Requests/Threads/UpdateThreadReadForUser.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Threads;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -19,26 +20,23 @@ use Saloon\Http\Request;
  */
 class UpdateThreadReadForUser extends Request
 {
-	protected Method $method = Method::PUT;
+    protected Method $method = Method::PUT;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/threads/{$this->threadId}/read/{$this->timestamp}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/threads/{$this->threadId}/read/{$this->timestamp}";
-	}
-
-
-	/**
-	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
-	 * @param string $teamId The ID of the team in which the thread is.
-	 * @param string $threadId The ID of the thread to update
-	 * @param string $timestamp The timestamp to which the thread's "last read" state will be reset.
-	 */
-	public function __construct(
-		protected string $userId,
-		protected string $teamId,
-		protected string $threadId,
-		protected string $timestamp,
-	) {
-	}
+    /**
+     * @param  string  $userId  The ID of the user. This can also be "me" which will point to the current user.
+     * @param  string  $teamId  The ID of the team in which the thread is.
+     * @param  string  $threadId  The ID of the thread to update
+     * @param  string  $timestamp  The timestamp to which the thread's "last read" state will be reset.
+     */
+    public function __construct(
+        protected string $userId,
+        protected string $teamId,
+        protected string $threadId,
+        protected string $timestamp,
+    ) {}
 }

--- a/src/Client/Requests/Threads/UpdateThreadsReadForUser.php
+++ b/src/Client/Requests/Threads/UpdateThreadsReadForUser.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Threads;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -19,22 +20,19 @@ use Saloon\Http\Request;
  */
 class UpdateThreadsReadForUser extends Request
 {
-	protected Method $method = Method::PUT;
+    protected Method $method = Method::PUT;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/threads/read";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/teams/{$this->teamId}/threads/read";
-	}
-
-
-	/**
-	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
-	 * @param string $teamId The ID of the team in which the thread is.
-	 */
-	public function __construct(
-		protected string $userId,
-		protected string $teamId,
-	) {
-	}
+    /**
+     * @param  string  $userId  The ID of the user. This can also be "me" which will point to the current user.
+     * @param  string  $teamId  The ID of the team in which the thread is.
+     */
+    public function __construct(
+        protected string $userId,
+        protected string $teamId,
+    ) {}
 }

--- a/src/Client/Requests/Users/AttachDeviceId.php
+++ b/src/Client/Requests/Users/AttachDeviceId.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,16 +17,12 @@ use Saloon\Http\Request;
  */
 class AttachDeviceId extends Request
 {
-	protected Method $method = Method::PUT;
+    protected Method $method = Method::PUT;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/users/sessions/device';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/sessions/device";
-	}
-
-
-	public function __construct()
-	{
-	}
+    public function __construct() {}
 }

--- a/src/Client/Requests/Users/AutocompleteUsers.php
+++ b/src/Client/Requests/Users/AutocompleteUsers.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -18,34 +19,30 @@ use Saloon\Http\Request;
  */
 class AutocompleteUsers extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/users/autocomplete';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/autocomplete";
-	}
+    /**
+     * @param  null|string  $teamId  Team ID
+     * @param  null|string  $channelId  Channel ID
+     * @param  string  $name  Username, nickname first name or last name
+     * @param  null|int  $limit  The maximum number of users to return in each subresult
+     *
+     * __Available as of server version 5.6. Defaults to `100` if not provided or on an earlier server version.__
+     */
+    public function __construct(
+        protected ?string $teamId,
+        protected ?string $channelId,
+        protected string $name,
+        protected ?int $limit = null,
+    ) {}
 
-
-	/**
-	 * @param null|string $teamId Team ID
-	 * @param null|string $channelId Channel ID
-	 * @param string $name Username, nickname first name or last name
-	 * @param null|int $limit The maximum number of users to return in each subresult
-	 *
-	 * __Available as of server version 5.6. Defaults to `100` if not provided or on an earlier server version.__
-	 */
-	public function __construct(
-		protected ?string $teamId = null,
-		protected ?string $channelId = null,
-		protected string $name,
-		protected ?int $limit = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['team_id' => $this->teamId, 'channel_id' => $this->channelId, 'name' => $this->name, 'limit' => $this->limit]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['team_id' => $this->teamId, 'channel_id' => $this->channelId, 'name' => $this->name, 'limit' => $this->limit]);
+    }
 }

--- a/src/Client/Requests/Users/CheckUserMfa.php
+++ b/src/Client/Requests/Users/CheckUserMfa.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -19,18 +20,14 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class CheckUserMfa extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/users/mfa';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/mfa";
-	}
-
-
-	public function __construct()
-	{
-	}
+    public function __construct() {}
 }

--- a/src/Client/Requests/Users/CreateUser.php
+++ b/src/Client/Requests/Users/CreateUser.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -20,30 +21,26 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class CreateUser extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/users';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users";
-	}
+    /**
+     * @param  null|string  $t  Token id from an email invitation
+     * @param  null|string  $iid  Token id from an invitation link
+     */
+    public function __construct(
+        protected ?string $t = null,
+        protected ?string $iid = null,
+    ) {}
 
-
-	/**
-	 * @param null|string $t Token id from an email invitation
-	 * @param null|string $iid Token id from an invitation link
-	 */
-	public function __construct(
-		protected ?string $t = null,
-		protected ?string $iid = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['t' => $this->t, 'iid' => $this->iid]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['t' => $this->t, 'iid' => $this->iid]);
+    }
 }

--- a/src/Client/Requests/Users/CreateUserAccessToken.php
+++ b/src/Client/Requests/Users/CreateUserAccessToken.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -22,22 +23,19 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class CreateUserAccessToken extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/tokens";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/tokens";
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function __construct(
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function __construct(
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Users/DeleteUser.php
+++ b/src/Client/Requests/Users/DeleteUser.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -21,20 +22,17 @@ use Saloon\Http\Request;
  */
 class DeleteUser extends Request
 {
-	protected Method $method = Method::DELETE;
+    protected Method $method = Method::DELETE;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}";
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function __construct(
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function __construct(
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Users/DemoteUserToGuest.php
+++ b/src/Client/Requests/Users/DemoteUserToGuest.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -24,22 +25,19 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class DemoteUserToGuest extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/demote";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/demote";
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function __construct(
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function __construct(
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Users/DisableUserAccessToken.php
+++ b/src/Client/Requests/Users/DisableUserAccessToken.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -23,18 +24,14 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class DisableUserAccessToken extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/users/tokens/disable';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/tokens/disable";
-	}
-
-
-	public function __construct()
-	{
-	}
+    public function __construct() {}
 }

--- a/src/Client/Requests/Users/EnableUserAccessToken.php
+++ b/src/Client/Requests/Users/EnableUserAccessToken.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -22,18 +23,14 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class EnableUserAccessToken extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/users/tokens/enable';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/tokens/enable";
-	}
-
-
-	public function __construct()
-	{
-	}
+    public function __construct() {}
 }

--- a/src/Client/Requests/Users/GenerateMfaSecret.php
+++ b/src/Client/Requests/Users/GenerateMfaSecret.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -19,22 +20,19 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class GenerateMfaSecret extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/mfa/generate";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/mfa/generate";
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function __construct(
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function __construct(
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Users/GetChannelMembersWithTeamDataForUser.php
+++ b/src/Client/Requests/Users/GetChannelMembersWithTeamDataForUser.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -19,30 +20,26 @@ use Saloon\Http\Request;
  */
 class GetChannelMembersWithTeamDataForUser extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/channel_members";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/channel_members";
-	}
+    /**
+     * @param  string  $userId  The ID of the user. This can also be "me" which will point to the current user.
+     * @param  null|int  $page  Page specifies which part of the results to return, by PageSize.
+     * @param  null|int  $pageSize  PageSize specifies the size of the returned chunk of results.
+     */
+    public function __construct(
+        protected string $userId,
+        protected ?int $page = null,
+        protected ?int $pageSize = null,
+    ) {}
 
-
-	/**
-	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
-	 * @param null|int $page Page specifies which part of the results to return, by PageSize.
-	 * @param null|int $pageSize PageSize specifies the size of the returned chunk of results.
-	 */
-	public function __construct(
-		protected string $userId,
-		protected ?int $page = null,
-		protected ?int $pageSize = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['page' => $this->page, 'pageSize' => $this->pageSize]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['page' => $this->page, 'pageSize' => $this->pageSize]);
+    }
 }

--- a/src/Client/Requests/Users/GetKnownUsers.php
+++ b/src/Client/Requests/Users/GetKnownUsers.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -21,16 +22,12 @@ use Saloon\Http\Request;
  */
 class GetKnownUsers extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/users/known';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/known";
-	}
-
-
-	public function __construct()
-	{
-	}
+    public function __construct() {}
 }

--- a/src/Client/Requests/Users/GetSessions.php
+++ b/src/Client/Requests/Users/GetSessions.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -17,20 +18,17 @@ use Saloon\Http\Request;
  */
 class GetSessions extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/sessions";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/sessions";
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function __construct(
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function __construct(
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Users/GetTotalUsersStats.php
+++ b/src/Client/Requests/Users/GetTotalUsersStats.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -15,16 +16,12 @@ use Saloon\Http\Request;
  */
 class GetTotalUsersStats extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/users/stats';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/stats";
-	}
-
-
-	public function __construct()
-	{
-	}
+    public function __construct() {}
 }

--- a/src/Client/Requests/Users/GetTotalUsersStatsFiltered.php
+++ b/src/Client/Requests/Users/GetTotalUsersStatsFiltered.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -19,52 +20,48 @@ use Saloon\Http\Request;
  */
 class GetTotalUsersStatsFiltered extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/users/stats/filtered';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/stats/filtered";
-	}
+    /**
+     * @param  null|string  $inTeam  The ID of the team to get user stats for.
+     * @param  null|string  $inChannel  The ID of the channel to get user stats for.
+     * @param  null|bool  $includeDeleted  If deleted accounts should be included in the count.
+     * @param  null|bool  $includeBots  If bot accounts should be included in the count.
+     * @param  null|string  $roles  Comma separated string used to filter users based on any of the specified system roles
+     *
+     * Example: `?roles=system_admin,system_user` will include users that are either system admins or system users
+     * @param  null|string  $channelRoles  Comma separated string used to filter users based on any of the specified channel roles, can only be used in conjunction with `in_channel`
+     *
+     * Example: `?in_channel=4eb6axxw7fg3je5iyasnfudc5y&channel_roles=channel_user` will include users that are only channel users and not admins or guests
+     * @param  null|string  $teamRoles  Comma separated string used to filter users based on any of the specified team roles, can only be used in conjunction with `in_team`
+     *
+     * Example: `?in_team=4eb6axxw7fg3je5iyasnfudc5y&team_roles=team_user` will include users that are only team users and not admins or guests
+     */
+    public function __construct(
+        protected ?string $inTeam = null,
+        protected ?string $inChannel = null,
+        protected ?bool $includeDeleted = null,
+        protected ?bool $includeBots = null,
+        protected ?string $roles = null,
+        protected ?string $channelRoles = null,
+        protected ?string $teamRoles = null,
+    ) {}
 
-
-	/**
-	 * @param null|string $inTeam The ID of the team to get user stats for.
-	 * @param null|string $inChannel The ID of the channel to get user stats for.
-	 * @param null|bool $includeDeleted If deleted accounts should be included in the count.
-	 * @param null|bool $includeBots If bot accounts should be included in the count.
-	 * @param null|string $roles Comma separated string used to filter users based on any of the specified system roles
-	 *
-	 * Example: `?roles=system_admin,system_user` will include users that are either system admins or system users
-	 * @param null|string $channelRoles Comma separated string used to filter users based on any of the specified channel roles, can only be used in conjunction with `in_channel`
-	 *
-	 * Example: `?in_channel=4eb6axxw7fg3je5iyasnfudc5y&channel_roles=channel_user` will include users that are only channel users and not admins or guests
-	 * @param null|string $teamRoles Comma separated string used to filter users based on any of the specified team roles, can only be used in conjunction with `in_team`
-	 *
-	 * Example: `?in_team=4eb6axxw7fg3je5iyasnfudc5y&team_roles=team_user` will include users that are only team users and not admins or guests
-	 */
-	public function __construct(
-		protected ?string $inTeam = null,
-		protected ?string $inChannel = null,
-		protected ?bool $includeDeleted = null,
-		protected ?bool $includeBots = null,
-		protected ?string $roles = null,
-		protected ?string $channelRoles = null,
-		protected ?string $teamRoles = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter([
-			'in_team' => $this->inTeam,
-			'in_channel' => $this->inChannel,
-			'include_deleted' => $this->includeDeleted,
-			'include_bots' => $this->includeBots,
-			'roles' => $this->roles,
-			'channel_roles' => $this->channelRoles,
-			'team_roles' => $this->teamRoles,
-		]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter([
+            'in_team' => $this->inTeam,
+            'in_channel' => $this->inChannel,
+            'include_deleted' => $this->includeDeleted,
+            'include_bots' => $this->includeBots,
+            'roles' => $this->roles,
+            'channel_roles' => $this->channelRoles,
+            'team_roles' => $this->teamRoles,
+        ]);
+    }
 }

--- a/src/Client/Requests/Users/GetUploadsForUser.php
+++ b/src/Client/Requests/Users/GetUploadsForUser.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -19,20 +20,17 @@ use Saloon\Http\Request;
  */
 class GetUploadsForUser extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/uploads";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/uploads";
-	}
-
-
-	/**
-	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
-	 */
-	public function __construct(
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $userId  The ID of the user. This can also be "me" which will point to the current user.
+     */
+    public function __construct(
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Users/GetUser.php
+++ b/src/Client/Requests/Users/GetUser.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,20 +17,17 @@ use Saloon\Http\Request;
  */
 class GetUser extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}";
-	}
-
-
-	/**
-	 * @param string $userId User GUID. This can also be "me" which will point to the current user.
-	 */
-	public function __construct(
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $userId  User GUID. This can also be "me" which will point to the current user.
+     */
+    public function __construct(
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Users/GetUserAccessToken.php
+++ b/src/Client/Requests/Users/GetUserAccessToken.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -20,20 +21,17 @@ use Saloon\Http\Request;
  */
 class GetUserAccessToken extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/tokens/{$this->tokenId}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/tokens/{$this->tokenId}";
-	}
-
-
-	/**
-	 * @param string $tokenId User access token GUID
-	 */
-	public function __construct(
-		protected string $tokenId,
-	) {
-	}
+    /**
+     * @param  string  $tokenId  User access token GUID
+     */
+    public function __construct(
+        protected string $tokenId,
+    ) {}
 }

--- a/src/Client/Requests/Users/GetUserAccessTokens.php
+++ b/src/Client/Requests/Users/GetUserAccessTokens.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -20,26 +21,22 @@ use Saloon\Http\Request;
  */
 class GetUserAccessTokens extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/users/tokens';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/tokens";
-	}
+    /**
+     * @param  null|int  $page  The page to select.
+     */
+    public function __construct(
+        protected ?int $page = null,
+    ) {}
 
-
-	/**
-	 * @param null|int $page The page to select.
-	 */
-	public function __construct(
-		protected ?int $page = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['page' => $this->page]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['page' => $this->page]);
+    }
 }

--- a/src/Client/Requests/Users/GetUserAccessTokensForUser.php
+++ b/src/Client/Requests/Users/GetUserAccessTokensForUser.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -21,28 +22,24 @@ use Saloon\Http\Request;
  */
 class GetUserAccessTokensForUser extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/tokens";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/tokens";
-	}
+    /**
+     * @param  string  $userId  User GUID
+     * @param  null|int  $page  The page to select.
+     */
+    public function __construct(
+        protected string $userId,
+        protected ?int $page = null,
+    ) {}
 
-
-	/**
-	 * @param string $userId User GUID
-	 * @param null|int $page The page to select.
-	 */
-	public function __construct(
-		protected string $userId,
-		protected ?int $page = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['page' => $this->page]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['page' => $this->page]);
+    }
 }

--- a/src/Client/Requests/Users/GetUserAudits.php
+++ b/src/Client/Requests/Users/GetUserAudits.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,20 +17,17 @@ use Saloon\Http\Request;
  */
 class GetUserAudits extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/audits";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/audits";
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function __construct(
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function __construct(
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Users/GetUserByEmail.php
+++ b/src/Client/Requests/Users/GetUserByEmail.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -17,20 +18,17 @@ use Saloon\Http\Request;
  */
 class GetUserByEmail extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/email/{$this->email}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/email/{$this->email}";
-	}
-
-
-	/**
-	 * @param string $email User Email
-	 */
-	public function __construct(
-		protected string $email,
-	) {
-	}
+    /**
+     * @param  string  $email  User Email
+     */
+    public function __construct(
+        protected string $email,
+    ) {}
 }

--- a/src/Client/Requests/Users/GetUserByUsername.php
+++ b/src/Client/Requests/Users/GetUserByUsername.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,20 +17,17 @@ use Saloon\Http\Request;
  */
 class GetUserByUsername extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/username/{$this->username}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/username/{$this->username}";
-	}
-
-
-	/**
-	 * @param string $username Username
-	 */
-	public function __construct(
-		protected string $username,
-	) {
-	}
+    /**
+     * @param  string  $username  Username
+     */
+    public function __construct(
+        protected string $username,
+    ) {}
 }

--- a/src/Client/Requests/Users/GetUserTermsOfService.php
+++ b/src/Client/Requests/Users/GetUserTermsOfService.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -20,20 +21,17 @@ use Saloon\Http\Request;
  */
 class GetUserTermsOfService extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/terms_of_service";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/terms_of_service";
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function __construct(
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function __construct(
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Users/GetUsers.php
+++ b/src/Client/Requests/Users/GetUsers.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -21,95 +22,91 @@ use Saloon\Http\Request;
  */
 class GetUsers extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/users';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users";
-	}
+    /**
+     * @param  null|int  $page  The page to select.
+     * @param  null|string  $inTeam  The ID of the team to get users for.
+     * @param  null|string  $notInTeam  The ID of the team to exclude users for. Must not be used with "in_team" query parameter.
+     * @param  null|string  $inChannel  The ID of the channel to get users for.
+     * @param  null|string  $notInChannel  The ID of the channel to exclude users for. Must be used with "in_channel" query parameter.
+     * @param  null|string  $inGroup  The ID of the group to get users for. Must have `manage_system` permission.
+     * @param  null|bool  $groupConstrained  When used with `not_in_channel` or `not_in_team`, returns only the users that are allowed to join the channel or team based on its group constrains.
+     * @param  null|bool  $withoutTeam  Whether or not to list users that are not on any team. This option takes precendence over `in_team`, `in_channel`, and `not_in_channel`.
+     * @param  null|bool  $active  Whether or not to list only users that are active. This option cannot be used along with the `inactive` option.
+     * @param  null|bool  $inactive  Whether or not to list only users that are deactivated. This option cannot be used along with the `active` option.
+     * @param  null|string  $role  Returns users that have this role.
+     * @param  null|string  $sort  Sort is only available in conjunction with certain options below. The paging parameter is also always available.
+     *
+     * ##### `in_team`
+     * Can be "", "last_activity_at" or "create_at".
+     * When left blank, sorting is done by username.
+     * __Minimum server version__: 4.0
+     * ##### `in_channel`
+     * Can be "", "status".
+     * When left blank, sorting is done by username. `status` will sort by User's current status (Online, Away, DND, Offline), then by Username.
+     * __Minimum server version__: 4.7
+     * ##### `in_group`
+     * Can be "", "display_name".
+     * When left blank, sorting is done by username. `display_name` will sort alphabetically by user's display name.
+     * __Minimum server version__: 7.7
+     * @param  null|string  $roles  Comma separated string used to filter users based on any of the specified system roles
+     *
+     * Example: `?roles=system_admin,system_user` will return users that are either system admins or system users
+     *
+     * __Minimum server version__: 5.26
+     * @param  null|string  $channelRoles  Comma separated string used to filter users based on any of the specified channel roles, can only be used in conjunction with `in_channel`
+     *
+     * Example: `?in_channel=4eb6axxw7fg3je5iyasnfudc5y&channel_roles=channel_user` will return users that are only channel users and not admins or guests
+     *
+     * __Minimum server version__: 5.26
+     * @param  null|string  $teamRoles  Comma separated string used to filter users based on any of the specified team roles, can only be used in conjunction with `in_team`
+     *
+     * Example: `?in_team=4eb6axxw7fg3je5iyasnfudc5y&team_roles=team_user` will return users that are only team users and not admins or guests
+     *
+     * __Minimum server version__: 5.26
+     */
+    public function __construct(
+        protected ?int $page = null,
+        protected ?string $inTeam = null,
+        protected ?string $notInTeam = null,
+        protected ?string $inChannel = null,
+        protected ?string $notInChannel = null,
+        protected ?string $inGroup = null,
+        protected ?bool $groupConstrained = null,
+        protected ?bool $withoutTeam = null,
+        protected ?bool $active = null,
+        protected ?bool $inactive = null,
+        protected ?string $role = null,
+        protected ?string $sort = null,
+        protected ?string $roles = null,
+        protected ?string $channelRoles = null,
+        protected ?string $teamRoles = null,
+    ) {}
 
-
-	/**
-	 * @param null|int $page The page to select.
-	 * @param null|string $inTeam The ID of the team to get users for.
-	 * @param null|string $notInTeam The ID of the team to exclude users for. Must not be used with "in_team" query parameter.
-	 * @param null|string $inChannel The ID of the channel to get users for.
-	 * @param null|string $notInChannel The ID of the channel to exclude users for. Must be used with "in_channel" query parameter.
-	 * @param null|string $inGroup The ID of the group to get users for. Must have `manage_system` permission.
-	 * @param null|bool $groupConstrained When used with `not_in_channel` or `not_in_team`, returns only the users that are allowed to join the channel or team based on its group constrains.
-	 * @param null|bool $withoutTeam Whether or not to list users that are not on any team. This option takes precendence over `in_team`, `in_channel`, and `not_in_channel`.
-	 * @param null|bool $active Whether or not to list only users that are active. This option cannot be used along with the `inactive` option.
-	 * @param null|bool $inactive Whether or not to list only users that are deactivated. This option cannot be used along with the `active` option.
-	 * @param null|string $role Returns users that have this role.
-	 * @param null|string $sort Sort is only available in conjunction with certain options below. The paging parameter is also always available.
-	 *
-	 * ##### `in_team`
-	 * Can be "", "last_activity_at" or "create_at".
-	 * When left blank, sorting is done by username.
-	 * __Minimum server version__: 4.0
-	 * ##### `in_channel`
-	 * Can be "", "status".
-	 * When left blank, sorting is done by username. `status` will sort by User's current status (Online, Away, DND, Offline), then by Username.
-	 * __Minimum server version__: 4.7
-	 * ##### `in_group`
-	 * Can be "", "display_name".
-	 * When left blank, sorting is done by username. `display_name` will sort alphabetically by user's display name.
-	 * __Minimum server version__: 7.7
-	 * @param null|string $roles Comma separated string used to filter users based on any of the specified system roles
-	 *
-	 * Example: `?roles=system_admin,system_user` will return users that are either system admins or system users
-	 *
-	 * __Minimum server version__: 5.26
-	 * @param null|string $channelRoles Comma separated string used to filter users based on any of the specified channel roles, can only be used in conjunction with `in_channel`
-	 *
-	 * Example: `?in_channel=4eb6axxw7fg3je5iyasnfudc5y&channel_roles=channel_user` will return users that are only channel users and not admins or guests
-	 *
-	 * __Minimum server version__: 5.26
-	 * @param null|string $teamRoles Comma separated string used to filter users based on any of the specified team roles, can only be used in conjunction with `in_team`
-	 *
-	 * Example: `?in_team=4eb6axxw7fg3je5iyasnfudc5y&team_roles=team_user` will return users that are only team users and not admins or guests
-	 *
-	 * __Minimum server version__: 5.26
-	 */
-	public function __construct(
-		protected ?int $page = null,
-		protected ?string $inTeam = null,
-		protected ?string $notInTeam = null,
-		protected ?string $inChannel = null,
-		protected ?string $notInChannel = null,
-		protected ?string $inGroup = null,
-		protected ?bool $groupConstrained = null,
-		protected ?bool $withoutTeam = null,
-		protected ?bool $active = null,
-		protected ?bool $inactive = null,
-		protected ?string $role = null,
-		protected ?string $sort = null,
-		protected ?string $roles = null,
-		protected ?string $channelRoles = null,
-		protected ?string $teamRoles = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter([
-			'page' => $this->page,
-			'in_team' => $this->inTeam,
-			'not_in_team' => $this->notInTeam,
-			'in_channel' => $this->inChannel,
-			'not_in_channel' => $this->notInChannel,
-			'in_group' => $this->inGroup,
-			'group_constrained' => $this->groupConstrained,
-			'without_team' => $this->withoutTeam,
-			'active' => $this->active,
-			'inactive' => $this->inactive,
-			'role' => $this->role,
-			'sort' => $this->sort,
-			'roles' => $this->roles,
-			'channel_roles' => $this->channelRoles,
-			'team_roles' => $this->teamRoles,
-		]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter([
+            'page' => $this->page,
+            'in_team' => $this->inTeam,
+            'not_in_team' => $this->notInTeam,
+            'in_channel' => $this->inChannel,
+            'not_in_channel' => $this->notInChannel,
+            'in_group' => $this->inGroup,
+            'group_constrained' => $this->groupConstrained,
+            'without_team' => $this->withoutTeam,
+            'active' => $this->active,
+            'inactive' => $this->inactive,
+            'role' => $this->role,
+            'sort' => $this->sort,
+            'roles' => $this->roles,
+            'channel_roles' => $this->channelRoles,
+            'team_roles' => $this->teamRoles,
+        ]);
+    }
 }

--- a/src/Client/Requests/Users/GetUsersByGroupChannelIds.php
+++ b/src/Client/Requests/Users/GetUsersByGroupChannelIds.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -27,18 +28,14 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class GetUsersByGroupChannelIds extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/users/group_channels';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/group_channels";
-	}
-
-
-	public function __construct()
-	{
-	}
+    public function __construct() {}
 }

--- a/src/Client/Requests/Users/GetUsersByIds.php
+++ b/src/Client/Requests/Users/GetUsersByIds.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -18,30 +19,26 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class GetUsersByIds extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/users/ids';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/ids";
-	}
+    /**
+     * @param  null|int  $since  Only return users that have been modified since the given Unix timestamp (in milliseconds).
+     *
+     * __Minimum server version__: 5.14
+     */
+    public function __construct(
+        protected ?int $since = null,
+    ) {}
 
-
-	/**
-	 * @param null|int $since Only return users that have been modified since the given Unix timestamp (in milliseconds).
-	 *
-	 * __Minimum server version__: 5.14
-	 */
-	public function __construct(
-		protected ?int $since = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['since' => $this->since]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['since' => $this->since]);
+    }
 }

--- a/src/Client/Requests/Users/GetUsersByUsernames.php
+++ b/src/Client/Requests/Users/GetUsersByUsernames.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -18,18 +19,14 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class GetUsersByUsernames extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/users/usernames';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/usernames";
-	}
-
-
-	public function __construct()
-	{
-	}
+    public function __construct() {}
 }

--- a/src/Client/Requests/Users/Login.php
+++ b/src/Client/Requests/Users/Login.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -16,18 +17,14 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class Login extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/users/login';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/login";
-	}
-
-
-	public function __construct()
-	{
-	}
+    public function __construct() {}
 }

--- a/src/Client/Requests/Users/LoginByCwsToken.php
+++ b/src/Client/Requests/Users/LoginByCwsToken.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -18,18 +19,14 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class LoginByCwsToken extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/users/login/cws';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/login/cws";
-	}
-
-
-	public function __construct()
-	{
-	}
+    public function __construct() {}
 }

--- a/src/Client/Requests/Users/Logout.php
+++ b/src/Client/Requests/Users/Logout.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -16,18 +17,14 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class Logout extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/users/logout';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/logout";
-	}
-
-
-	public function __construct()
-	{
-	}
+    public function __construct() {}
 }

--- a/src/Client/Requests/Users/MigrateAuthToLdap.php
+++ b/src/Client/Requests/Users/MigrateAuthToLdap.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -20,18 +21,14 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class MigrateAuthToLdap extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/users/migrate_auth/ldap';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/migrate_auth/ldap";
-	}
-
-
-	public function __construct()
-	{
-	}
+    public function __construct() {}
 }

--- a/src/Client/Requests/Users/MigrateAuthToSaml.php
+++ b/src/Client/Requests/Users/MigrateAuthToSaml.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -20,18 +21,14 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class MigrateAuthToSaml extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/users/migrate_auth/saml';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/migrate_auth/saml";
-	}
-
-
-	public function __construct()
-	{
-	}
+    public function __construct() {}
 }

--- a/src/Client/Requests/Users/PatchUser.php
+++ b/src/Client/Requests/Users/PatchUser.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -18,20 +19,17 @@ use Saloon\Http\Request;
  */
 class PatchUser extends Request
 {
-	protected Method $method = Method::PUT;
+    protected Method $method = Method::PUT;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/patch";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/patch";
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function __construct(
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function __construct(
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Users/PermanentDeleteAllUsers.php
+++ b/src/Client/Requests/Users/PermanentDeleteAllUsers.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -19,16 +20,12 @@ use Saloon\Http\Request;
  */
 class PermanentDeleteAllUsers extends Request
 {
-	protected Method $method = Method::DELETE;
+    protected Method $method = Method::DELETE;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/users';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users";
-	}
-
-
-	public function __construct()
-	{
-	}
+    public function __construct() {}
 }

--- a/src/Client/Requests/Users/PromoteGuestToUser.php
+++ b/src/Client/Requests/Users/PromoteGuestToUser.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -25,22 +26,19 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class PromoteGuestToUser extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/promote";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/promote";
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function __construct(
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function __construct(
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Users/PublishUserTyping.php
+++ b/src/Client/Requests/Users/PublishUserTyping.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -20,22 +21,19 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class PublishUserTyping extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/typing";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/typing";
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function __construct(
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function __construct(
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Users/RegisterTermsOfServiceAction.php
+++ b/src/Client/Requests/Users/RegisterTermsOfServiceAction.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -22,22 +23,19 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class RegisterTermsOfServiceAction extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/terms_of_service";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/terms_of_service";
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function __construct(
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function __construct(
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Users/ResetPassword.php
+++ b/src/Client/Requests/Users/ResetPassword.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -18,18 +19,14 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class ResetPassword extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/users/password/reset';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/password/reset";
-	}
-
-
-	public function __construct()
-	{
-	}
+    public function __construct() {}
 }

--- a/src/Client/Requests/Users/RevokeAllSessions.php
+++ b/src/Client/Requests/Users/RevokeAllSessions.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -20,22 +21,19 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class RevokeAllSessions extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/sessions/revoke/all";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/sessions/revoke/all";
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function __construct(
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function __construct(
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Users/RevokeSession.php
+++ b/src/Client/Requests/Users/RevokeSession.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -18,22 +19,19 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class RevokeSession extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/sessions/revoke";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/sessions/revoke";
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function __construct(
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function __construct(
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Users/RevokeSessionsFromAllUsers.php
+++ b/src/Client/Requests/Users/RevokeSessionsFromAllUsers.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -23,18 +24,14 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class RevokeSessionsFromAllUsers extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/users/sessions/revoke/all';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/sessions/revoke/all";
-	}
-
-
-	public function __construct()
-	{
-	}
+    public function __construct() {}
 }

--- a/src/Client/Requests/Users/RevokeUserAccessToken.php
+++ b/src/Client/Requests/Users/RevokeUserAccessToken.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -22,18 +23,14 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class RevokeUserAccessToken extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/users/tokens/revoke';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/tokens/revoke";
-	}
-
-
-	public function __construct()
-	{
-	}
+    public function __construct() {}
 }

--- a/src/Client/Requests/Users/SearchUserAccessTokens.php
+++ b/src/Client/Requests/Users/SearchUserAccessTokens.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -22,18 +23,14 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class SearchUserAccessTokens extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/users/tokens/search';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/tokens/search";
-	}
-
-
-	public function __construct()
-	{
-	}
+    public function __construct() {}
 }

--- a/src/Client/Requests/Users/SearchUsers.php
+++ b/src/Client/Requests/Users/SearchUsers.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -20,18 +21,14 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class SearchUsers extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/users/search';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/search";
-	}
-
-
-	public function __construct()
-	{
-	}
+    public function __construct() {}
 }

--- a/src/Client/Requests/Users/SendPasswordResetEmail.php
+++ b/src/Client/Requests/Users/SendPasswordResetEmail.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -19,18 +20,14 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class SendPasswordResetEmail extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/users/password/reset/send';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/password/reset/send";
-	}
-
-
-	public function __construct()
-	{
-	}
+    public function __construct() {}
 }

--- a/src/Client/Requests/Users/SendVerificationEmail.php
+++ b/src/Client/Requests/Users/SendVerificationEmail.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -19,18 +20,14 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class SendVerificationEmail extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/users/email/verify/send';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/email/verify/send";
-	}
-
-
-	public function __construct()
-	{
-	}
+    public function __construct() {}
 }

--- a/src/Client/Requests/Users/SwitchAccountType.php
+++ b/src/Client/Requests/Users/SwitchAccountType.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -38,18 +39,14 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class SwitchAccountType extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/users/login/switch';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/login/switch";
-	}
-
-
-	public function __construct()
-	{
-	}
+    public function __construct() {}
 }

--- a/src/Client/Requests/Users/UpdateUser.php
+++ b/src/Client/Requests/Users/UpdateUser.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -18,20 +19,17 @@ use Saloon\Http\Request;
  */
 class UpdateUser extends Request
 {
-	protected Method $method = Method::PUT;
+    protected Method $method = Method::PUT;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}";
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function __construct(
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function __construct(
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Users/UpdateUserActive.php
+++ b/src/Client/Requests/Users/UpdateUserActive.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -24,20 +25,17 @@ use Saloon\Http\Request;
  */
 class UpdateUserActive extends Request
 {
-	protected Method $method = Method::PUT;
+    protected Method $method = Method::PUT;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/active";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/active";
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function __construct(
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function __construct(
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Users/UpdateUserAuth.php
+++ b/src/Client/Requests/Users/UpdateUserAuth.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -19,20 +20,17 @@ use Saloon\Http\Request;
  */
 class UpdateUserAuth extends Request
 {
-	protected Method $method = Method::PUT;
+    protected Method $method = Method::PUT;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/auth";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/auth";
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function __construct(
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function __construct(
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Users/UpdateUserMfa.php
+++ b/src/Client/Requests/Users/UpdateUserMfa.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -18,20 +19,17 @@ use Saloon\Http\Request;
  */
 class UpdateUserMfa extends Request
 {
-	protected Method $method = Method::PUT;
+    protected Method $method = Method::PUT;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/mfa";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/mfa";
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function __construct(
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function __construct(
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Users/UpdateUserPassword.php
+++ b/src/Client/Requests/Users/UpdateUserPassword.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -17,20 +18,17 @@ use Saloon\Http\Request;
  */
 class UpdateUserPassword extends Request
 {
-	protected Method $method = Method::PUT;
+    protected Method $method = Method::PUT;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/password";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/password";
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function __construct(
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function __construct(
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Users/UpdateUserRoles.php
+++ b/src/Client/Requests/Users/UpdateUserRoles.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -17,20 +18,17 @@ use Saloon\Http\Request;
  */
 class UpdateUserRoles extends Request
 {
-	protected Method $method = Method::PUT;
+    protected Method $method = Method::PUT;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/roles";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/roles";
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function __construct(
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function __construct(
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Users/VerifyUserEmail.php
+++ b/src/Client/Requests/Users/VerifyUserEmail.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -18,18 +19,14 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class VerifyUserEmail extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/users/email/verify';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/email/verify";
-	}
-
-
-	public function __construct()
-	{
-	}
+    public function __construct() {}
 }

--- a/src/Client/Requests/Users/VerifyUserEmailWithoutToken.php
+++ b/src/Client/Requests/Users/VerifyUserEmailWithoutToken.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Users;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -22,22 +23,19 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class VerifyUserEmailWithoutToken extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/email/verify/member";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/users/{$this->userId}/email/verify/member";
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function __construct(
-		protected string $userId,
-	) {
-	}
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function __construct(
+        protected string $userId,
+    ) {}
 }

--- a/src/Client/Requests/Webhooks/CreateIncomingWebhook.php
+++ b/src/Client/Requests/Webhooks/CreateIncomingWebhook.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Webhooks;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -21,18 +22,14 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class CreateIncomingWebhook extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/hooks/incoming';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/hooks/incoming";
-	}
-
-
-	public function __construct()
-	{
-	}
+    public function __construct() {}
 }

--- a/src/Client/Requests/Webhooks/CreateOutgoingWebhook.php
+++ b/src/Client/Requests/Webhooks/CreateOutgoingWebhook.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Webhooks;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -21,18 +22,14 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class CreateOutgoingWebhook extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/hooks/outgoing';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/hooks/outgoing";
-	}
-
-
-	public function __construct()
-	{
-	}
+    public function __construct() {}
 }

--- a/src/Client/Requests/Webhooks/DeleteIncomingWebhook.php
+++ b/src/Client/Requests/Webhooks/DeleteIncomingWebhook.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Webhooks;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,20 +17,17 @@ use Saloon\Http\Request;
  */
 class DeleteIncomingWebhook extends Request
 {
-	protected Method $method = Method::DELETE;
+    protected Method $method = Method::DELETE;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/hooks/incoming/{$this->hookId}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/hooks/incoming/{$this->hookId}";
-	}
-
-
-	/**
-	 * @param string $hookId Incoming webhook GUID
-	 */
-	public function __construct(
-		protected string $hookId,
-	) {
-	}
+    /**
+     * @param  string  $hookId  Incoming webhook GUID
+     */
+    public function __construct(
+        protected string $hookId,
+    ) {}
 }

--- a/src/Client/Requests/Webhooks/DeleteOutgoingWebhook.php
+++ b/src/Client/Requests/Webhooks/DeleteOutgoingWebhook.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Webhooks;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,20 +17,17 @@ use Saloon\Http\Request;
  */
 class DeleteOutgoingWebhook extends Request
 {
-	protected Method $method = Method::DELETE;
+    protected Method $method = Method::DELETE;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/hooks/outgoing/{$this->hookId}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/hooks/outgoing/{$this->hookId}";
-	}
-
-
-	/**
-	 * @param string $hookId Outgoing webhook GUID
-	 */
-	public function __construct(
-		protected string $hookId,
-	) {
-	}
+    /**
+     * @param  string  $hookId  Outgoing webhook GUID
+     */
+    public function __construct(
+        protected string $hookId,
+    ) {}
 }

--- a/src/Client/Requests/Webhooks/GetIncomingWebhook.php
+++ b/src/Client/Requests/Webhooks/GetIncomingWebhook.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Webhooks;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,20 +17,17 @@ use Saloon\Http\Request;
  */
 class GetIncomingWebhook extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/hooks/incoming/{$this->hookId}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/hooks/incoming/{$this->hookId}";
-	}
-
-
-	/**
-	 * @param string $hookId Incoming Webhook GUID
-	 */
-	public function __construct(
-		protected string $hookId,
-	) {
-	}
+    /**
+     * @param  string  $hookId  Incoming Webhook GUID
+     */
+    public function __construct(
+        protected string $hookId,
+    ) {}
 }

--- a/src/Client/Requests/Webhooks/GetIncomingWebhooks.php
+++ b/src/Client/Requests/Webhooks/GetIncomingWebhooks.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Webhooks;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -17,28 +18,24 @@ use Saloon\Http\Request;
  */
 class GetIncomingWebhooks extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/hooks/incoming';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/hooks/incoming";
-	}
+    /**
+     * @param  null|int  $page  The page to select.
+     * @param  null|string  $teamId  The ID of the team to get hooks for.
+     */
+    public function __construct(
+        protected ?int $page = null,
+        protected ?string $teamId = null,
+    ) {}
 
-
-	/**
-	 * @param null|int $page The page to select.
-	 * @param null|string $teamId The ID of the team to get hooks for.
-	 */
-	public function __construct(
-		protected ?int $page = null,
-		protected ?string $teamId = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['page' => $this->page, 'team_id' => $this->teamId]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['page' => $this->page, 'team_id' => $this->teamId]);
+    }
 }

--- a/src/Client/Requests/Webhooks/GetOutgoingWebhook.php
+++ b/src/Client/Requests/Webhooks/GetOutgoingWebhook.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Webhooks;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,20 +17,17 @@ use Saloon\Http\Request;
  */
 class GetOutgoingWebhook extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/hooks/outgoing/{$this->hookId}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/hooks/outgoing/{$this->hookId}";
-	}
-
-
-	/**
-	 * @param string $hookId Outgoing webhook GUID
-	 */
-	public function __construct(
-		protected string $hookId,
-	) {
-	}
+    /**
+     * @param  string  $hookId  Outgoing webhook GUID
+     */
+    public function __construct(
+        protected string $hookId,
+    ) {}
 }

--- a/src/Client/Requests/Webhooks/GetOutgoingWebhooks.php
+++ b/src/Client/Requests/Webhooks/GetOutgoingWebhooks.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Webhooks;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -17,30 +18,26 @@ use Saloon\Http\Request;
  */
 class GetOutgoingWebhooks extends Request
 {
-	protected Method $method = Method::GET;
+    protected Method $method = Method::GET;
 
+    public function resolveEndpoint(): string
+    {
+        return '/api/v4/hooks/outgoing';
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/hooks/outgoing";
-	}
+    /**
+     * @param  null|int  $page  The page to select.
+     * @param  null|string  $teamId  The ID of the team to get hooks for.
+     * @param  null|string  $channelId  The ID of the channel to get hooks for.
+     */
+    public function __construct(
+        protected ?int $page = null,
+        protected ?string $teamId = null,
+        protected ?string $channelId = null,
+    ) {}
 
-
-	/**
-	 * @param null|int $page The page to select.
-	 * @param null|string $teamId The ID of the team to get hooks for.
-	 * @param null|string $channelId The ID of the channel to get hooks for.
-	 */
-	public function __construct(
-		protected ?int $page = null,
-		protected ?string $teamId = null,
-		protected ?string $channelId = null,
-	) {
-	}
-
-
-	public function defaultQuery(): array
-	{
-		return array_filter(['page' => $this->page, 'team_id' => $this->teamId, 'channel_id' => $this->channelId]);
-	}
+    public function defaultQuery(): array
+    {
+        return array_filter(['page' => $this->page, 'team_id' => $this->teamId, 'channel_id' => $this->channelId]);
+    }
 }

--- a/src/Client/Requests/Webhooks/RegenOutgoingHookToken.php
+++ b/src/Client/Requests/Webhooks/RegenOutgoingHookToken.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Webhooks;
 
-use DateTime;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -18,22 +19,19 @@ use Saloon\Traits\Body\HasJsonBody;
  */
 class RegenOutgoingHookToken extends Request implements HasBody
 {
-	use HasJsonBody;
+    use HasJsonBody;
 
-	protected Method $method = Method::POST;
+    protected Method $method = Method::POST;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/hooks/outgoing/{$this->hookId}/regen_token";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/hooks/outgoing/{$this->hookId}/regen_token";
-	}
-
-
-	/**
-	 * @param string $hookId Outgoing webhook GUID
-	 */
-	public function __construct(
-		protected string $hookId,
-	) {
-	}
+    /**
+     * @param  string  $hookId  Outgoing webhook GUID
+     */
+    public function __construct(
+        protected string $hookId,
+    ) {}
 }

--- a/src/Client/Requests/Webhooks/UpdateIncomingWebhook.php
+++ b/src/Client/Requests/Webhooks/UpdateIncomingWebhook.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Webhooks;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,20 +17,17 @@ use Saloon\Http\Request;
  */
 class UpdateIncomingWebhook extends Request
 {
-	protected Method $method = Method::PUT;
+    protected Method $method = Method::PUT;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/hooks/incoming/{$this->hookId}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/hooks/incoming/{$this->hookId}";
-	}
-
-
-	/**
-	 * @param string $hookId Incoming Webhook GUID
-	 */
-	public function __construct(
-		protected string $hookId,
-	) {
-	}
+    /**
+     * @param  string  $hookId  Incoming Webhook GUID
+     */
+    public function __construct(
+        protected string $hookId,
+    ) {}
 }

--- a/src/Client/Requests/Webhooks/UpdateOutgoingWebhook.php
+++ b/src/Client/Requests/Webhooks/UpdateOutgoingWebhook.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Requests\Webhooks;
 
-use DateTime;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -16,20 +17,17 @@ use Saloon\Http\Request;
  */
 class UpdateOutgoingWebhook extends Request
 {
-	protected Method $method = Method::PUT;
+    protected Method $method = Method::PUT;
 
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/hooks/outgoing/{$this->hookId}";
+    }
 
-	public function resolveEndpoint(): string
-	{
-		return "/api/v4/hooks/outgoing/{$this->hookId}";
-	}
-
-
-	/**
-	 * @param string $hookId outgoing Webhook GUID
-	 */
-	public function __construct(
-		protected string $hookId,
-	) {
-	}
+    /**
+     * @param  string  $hookId  outgoing Webhook GUID
+     */
+    public function __construct(
+        protected string $hookId,
+    ) {}
 }

--- a/src/Client/Resource/Bots.php
+++ b/src/Client/Resource/Bots.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Resource;
 
 use ConduitUI\Mattermost\Client\Requests\Bots\AssignBot;
@@ -16,85 +18,77 @@ use Saloon\Http\Response;
 
 class Bots extends BaseResource
 {
-	/**
-	 * @param int $page The page to select.
-	 * @param bool $includeDeleted If deleted bots should be returned.
-	 * @param bool $onlyOrphaned When true, only orphaned bots will be returned. A bot is consitered orphaned if it's owner has been deactivated.
-	 */
-	public function getBots(?int $page = null, ?bool $includeDeleted = null, ?bool $onlyOrphaned = null): Response
-	{
-		return $this->connector->send(new GetBots($page, $includeDeleted, $onlyOrphaned));
-	}
+    /**
+     * @param  int  $page  The page to select.
+     * @param  bool  $includeDeleted  If deleted bots should be returned.
+     * @param  bool  $onlyOrphaned  When true, only orphaned bots will be returned. A bot is consitered orphaned if it's owner has been deactivated.
+     */
+    public function getBots(?int $page = null, ?bool $includeDeleted = null, ?bool $onlyOrphaned = null): Response
+    {
+        return $this->connector->send(new GetBots($page, $includeDeleted, $onlyOrphaned));
+    }
 
+    public function createBot(): Response
+    {
+        return $this->connector->send(new CreateBot);
+    }
 
-	public function createBot(): Response
-	{
-		return $this->connector->send(new CreateBot());
-	}
+    /**
+     * @param  string  $botUserId  Bot user ID
+     * @param  bool  $includeDeleted  If deleted bots should be returned.
+     */
+    public function getBot(string $botUserId, ?bool $includeDeleted = null): Response
+    {
+        return $this->connector->send(new GetBot($botUserId, $includeDeleted));
+    }
 
+    /**
+     * @param  string  $botUserId  Bot user ID
+     */
+    public function patchBot(string $botUserId): Response
+    {
+        return $this->connector->send(new PatchBot($botUserId));
+    }
 
-	/**
-	 * @param string $botUserId Bot user ID
-	 * @param bool $includeDeleted If deleted bots should be returned.
-	 */
-	public function getBot(string $botUserId, ?bool $includeDeleted = null): Response
-	{
-		return $this->connector->send(new GetBot($botUserId, $includeDeleted));
-	}
+    /**
+     * @param  string  $botUserId  Bot user ID
+     * @param  string  $userId  The user ID to assign the bot to.
+     */
+    public function assignBot(string $botUserId, string $userId): Response
+    {
+        return $this->connector->send(new AssignBot($botUserId, $userId));
+    }
 
+    /**
+     * @param  string  $botUserId  Bot user ID
+     * @param  bool  $setSystemAdmin  Whether to give the user the system admin role.
+     */
+    public function convertBotToUser(string $botUserId, ?bool $setSystemAdmin = null): Response
+    {
+        return $this->connector->send(new ConvertBotToUser($botUserId, $setSystemAdmin));
+    }
 
-	/**
-	 * @param string $botUserId Bot user ID
-	 */
-	public function patchBot(string $botUserId): Response
-	{
-		return $this->connector->send(new PatchBot($botUserId));
-	}
+    /**
+     * @param  string  $botUserId  Bot user ID
+     */
+    public function disableBot(string $botUserId): Response
+    {
+        return $this->connector->send(new DisableBot($botUserId));
+    }
 
+    /**
+     * @param  string  $botUserId  Bot user ID
+     */
+    public function enableBot(string $botUserId): Response
+    {
+        return $this->connector->send(new EnableBot($botUserId));
+    }
 
-	/**
-	 * @param string $botUserId Bot user ID
-	 * @param string $userId The user ID to assign the bot to.
-	 */
-	public function assignBot(string $botUserId, string $userId): Response
-	{
-		return $this->connector->send(new AssignBot($botUserId, $userId));
-	}
-
-
-	/**
-	 * @param string $botUserId Bot user ID
-	 * @param bool $setSystemAdmin Whether to give the user the system admin role.
-	 */
-	public function convertBotToUser(string $botUserId, ?bool $setSystemAdmin = null): Response
-	{
-		return $this->connector->send(new ConvertBotToUser($botUserId, $setSystemAdmin));
-	}
-
-
-	/**
-	 * @param string $botUserId Bot user ID
-	 */
-	public function disableBot(string $botUserId): Response
-	{
-		return $this->connector->send(new DisableBot($botUserId));
-	}
-
-
-	/**
-	 * @param string $botUserId Bot user ID
-	 */
-	public function enableBot(string $botUserId): Response
-	{
-		return $this->connector->send(new EnableBot($botUserId));
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function convertUserToBot(string $userId): Response
-	{
-		return $this->connector->send(new ConvertUserToBot($userId));
-	}
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function convertUserToBot(string $userId): Response
+    {
+        return $this->connector->send(new ConvertUserToBot($userId));
+    }
 }

--- a/src/Client/Resource/Channels.php
+++ b/src/Client/Resource/Channels.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Resource;
 
 use ConduitUI\Mattermost\Client\Requests\Channels\AddChannelMember;
@@ -22,10 +24,10 @@ use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelMembersByIds;
 use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelMembersForUser;
 use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelMembersTimezones;
 use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelModerations;
-use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelStats;
-use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelUnread;
 use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelsForTeamForUser;
 use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelsForUser;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelStats;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelUnread;
 use ConduitUI\Mattermost\Client\Requests\Channels\GetDeletedChannelsForTeam;
 use ConduitUI\Mattermost\Client\Requests\Channels\GetPinnedPosts;
 use ConduitUI\Mattermost\Client\Requests\Channels\GetPrivateChannelsForTeam;
@@ -59,516 +61,462 @@ use Saloon\Http\Response;
 
 class Channels extends BaseResource
 {
-	/**
-	 * @param string $notAssociatedToGroup A group id to exclude channels that are associated with that group via GroupChannel records. This can also be left blank with `not_associated_to_group=`.
-	 * @param int $page The page to select.
-	 * @param bool $excludeDefaultChannels Whether to exclude default channels (ex Town Square, Off-Topic) from the results.
-	 * @param bool $includeDeleted Include channels that have been archived. This correlates to the `DeleteAt` flag being set in the database.
-	 * @param bool $includeTotalCount Appends a total count of returned channels inside the response object - ex: `{ "channels": [], "total_count" : 0 }`.
-	 * @param bool $excludePolicyConstrained If set to true, channels which are part of a data retention policy will be excluded. The `sysconsole_read_compliance` permission is required to use this parameter.
-	 * __Minimum server version__: 5.35
-	 */
-	public function getAllChannels(
-		?string $notAssociatedToGroup = null,
-		?int $page = null,
-		?bool $excludeDefaultChannels = null,
-		?bool $includeDeleted = null,
-		?bool $includeTotalCount = null,
-		?bool $excludePolicyConstrained = null,
-	): Response
-	{
-		return $this->connector->send(new GetAllChannels($notAssociatedToGroup, $page, $excludeDefaultChannels, $includeDeleted, $includeTotalCount, $excludePolicyConstrained));
-	}
-
-
-	public function createChannel(): Response
-	{
-		return $this->connector->send(new CreateChannel());
-	}
-
-
-	public function createDirectChannel(): Response
-	{
-		return $this->connector->send(new CreateDirectChannel());
-	}
-
-
-	public function createGroupChannel(): Response
-	{
-		return $this->connector->send(new CreateGroupChannel());
-	}
-
-
-	public function searchGroupChannels(): Response
-	{
-		return $this->connector->send(new SearchGroupChannels());
-	}
-
-
-	/**
-	 * @param string $userId User ID to perform the view action for
-	 */
-	public function viewChannel(string $userId): Response
-	{
-		return $this->connector->send(new ViewChannel($userId));
-	}
-
-
-	/**
-	 * @param bool $systemConsole Is the request from system_console. If this is set to true, it filters channels by the logged in user.
-	 */
-	public function searchAllChannels(?bool $systemConsole = null): Response
-	{
-		return $this->connector->send(new SearchAllChannels($systemConsole));
-	}
-
-
-	/**
-	 * @param string $channelId Channel GUID
-	 */
-	public function getChannel(string $channelId): Response
-	{
-		return $this->connector->send(new GetChannel($channelId));
-	}
-
-
-	/**
-	 * @param string $channelId Channel GUID
-	 */
-	public function updateChannel(string $channelId): Response
-	{
-		return $this->connector->send(new UpdateChannel($channelId));
-	}
-
-
-	/**
-	 * @param string $channelId Channel GUID
-	 */
-	public function deleteChannel(string $channelId): Response
-	{
-		return $this->connector->send(new DeleteChannel($channelId));
-	}
-
-
-	/**
-	 * @param string $channelId Channel GUID
-	 * @param bool $includeTimezones Defines if member timezone counts should be returned or not
-	 */
-	public function getChannelMemberCountsByGroup(string $channelId, ?bool $includeTimezones = null): Response
-	{
-		return $this->connector->send(new GetChannelMemberCountsByGroup($channelId, $includeTimezones));
-	}
-
-
-	/**
-	 * @param string $channelId Channel GUID
-	 * @param int $page The page to select.
-	 */
-	public function getChannelMembers(string $channelId, ?int $page = null): Response
-	{
-		return $this->connector->send(new GetChannelMembers($channelId, $page));
-	}
-
-
-	/**
-	 * @param string $channelId The channel ID
-	 */
-	public function addChannelMember(string $channelId): Response
-	{
-		return $this->connector->send(new AddChannelMember($channelId));
-	}
-
-
-	/**
-	 * @param string $channelId Channel GUID
-	 */
-	public function getChannelMembersByIds(string $channelId): Response
-	{
-		return $this->connector->send(new GetChannelMembersByIds($channelId));
-	}
-
-
-	/**
-	 * @param string $channelId Channel GUID
-	 * @param string $userId User GUID
-	 */
-	public function getChannelMember(string $channelId, string $userId): Response
-	{
-		return $this->connector->send(new GetChannelMember($channelId, $userId));
-	}
-
-
-	/**
-	 * @param string $channelId Channel GUID
-	 * @param string $userId User GUID
-	 */
-	public function removeUserFromChannel(string $channelId, string $userId): Response
-	{
-		return $this->connector->send(new RemoveUserFromChannel($channelId, $userId));
-	}
-
-
-	/**
-	 * @param string $channelId Channel GUID
-	 * @param string $userId User GUID
-	 */
-	public function updateChannelNotifyProps(string $channelId, string $userId): Response
-	{
-		return $this->connector->send(new UpdateChannelNotifyProps($channelId, $userId));
-	}
-
-
-	/**
-	 * @param string $channelId Channel GUID
-	 * @param string $userId User GUID
-	 */
-	public function updateChannelRoles(string $channelId, string $userId): Response
-	{
-		return $this->connector->send(new UpdateChannelRoles($channelId, $userId));
-	}
-
-
-	/**
-	 * @param string $channelId Channel GUID
-	 * @param string $userId User GUID
-	 */
-	public function updateChannelMemberSchemeRoles(string $channelId, string $userId): Response
-	{
-		return $this->connector->send(new UpdateChannelMemberSchemeRoles($channelId, $userId));
-	}
-
-
-	/**
-	 * @param string $channelId Channel GUID
-	 * @param string $groupIds A comma-separated list of group ids.
-	 * @param int $page The page to select.
-	 */
-	public function channelMembersMinusGroupMembers(string $channelId, string $groupIds, ?int $page = null): Response
-	{
-		return $this->connector->send(new ChannelMembersMinusGroupMembers($channelId, $groupIds, $page));
-	}
-
-
-	/**
-	 * @param string $channelId Channel GUID
-	 */
-	public function getChannelModerations(string $channelId): Response
-	{
-		return $this->connector->send(new GetChannelModerations($channelId));
-	}
-
-
-	/**
-	 * @param string $channelId Channel GUID
-	 */
-	public function patchChannelModerations(string $channelId): Response
-	{
-		return $this->connector->send(new PatchChannelModerations($channelId));
-	}
-
-
-	/**
-	 * @param string $channelId Channel GUID
-	 */
-	public function moveChannel(string $channelId): Response
-	{
-		return $this->connector->send(new MoveChannel($channelId));
-	}
-
-
-	/**
-	 * @param string $channelId Channel GUID
-	 */
-	public function patchChannel(string $channelId): Response
-	{
-		return $this->connector->send(new PatchChannel($channelId));
-	}
-
-
-	/**
-	 * @param string $channelId Channel GUID
-	 */
-	public function getPinnedPosts(string $channelId): Response
-	{
-		return $this->connector->send(new GetPinnedPosts($channelId));
-	}
-
-
-	/**
-	 * @param string $channelId Channel GUID
-	 */
-	public function updateChannelPrivacy(string $channelId): Response
-	{
-		return $this->connector->send(new UpdateChannelPrivacy($channelId));
-	}
-
-
-	/**
-	 * @param string $channelId Channel GUID
-	 */
-	public function restoreChannel(string $channelId): Response
-	{
-		return $this->connector->send(new RestoreChannel($channelId));
-	}
-
-
-	/**
-	 * @param string $channelId Channel GUID
-	 */
-	public function updateChannelScheme(string $channelId): Response
-	{
-		return $this->connector->send(new UpdateChannelScheme($channelId));
-	}
-
-
-	/**
-	 * @param string $channelId Channel GUID
-	 */
-	public function getChannelStats(string $channelId): Response
-	{
-		return $this->connector->send(new GetChannelStats($channelId));
-	}
-
-
-	/**
-	 * @param string $channelId Channel GUID
-	 */
-	public function getChannelMembersTimezones(string $channelId): Response
-	{
-		return $this->connector->send(new GetChannelMembersTimezones($channelId));
-	}
-
-
-	/**
-	 * @param string $teamName Team Name
-	 * @param string $channelName Channel Name
-	 * @param bool $includeDeleted Defines if deleted channels should be returned or not (Mattermost Server 5.26.0+)
-	 */
-	public function getChannelByNameForTeamName(
-		string $teamName,
-		string $channelName,
-		?bool $includeDeleted = null,
-	): Response
-	{
-		return $this->connector->send(new GetChannelByNameForTeamName($teamName, $channelName, $includeDeleted));
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param int $page The page to select.
-	 */
-	public function getPublicChannelsForTeam(string $teamId, ?int $page = null): Response
-	{
-		return $this->connector->send(new GetPublicChannelsForTeam($teamId, $page));
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param string $name Name or display name
-	 */
-	public function autocompleteChannelsForTeam(string $teamId, string $name): Response
-	{
-		return $this->connector->send(new AutocompleteChannelsForTeam($teamId, $name));
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param int $page The page to select.
-	 */
-	public function getDeletedChannelsForTeam(string $teamId, ?int $page = null): Response
-	{
-		return $this->connector->send(new GetDeletedChannelsForTeam($teamId, $page));
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 */
-	public function getPublicChannelsByIdsForTeam(string $teamId): Response
-	{
-		return $this->connector->send(new GetPublicChannelsByIdsForTeam($teamId));
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param string $channelName Channel Name
-	 * @param bool $includeDeleted Defines if deleted channels should be returned or not (Mattermost Server 5.26.0+)
-	 */
-	public function getChannelByName(string $teamId, string $channelName, ?bool $includeDeleted = null): Response
-	{
-		return $this->connector->send(new GetChannelByName($teamId, $channelName, $includeDeleted));
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param int $page The page to select.
-	 */
-	public function getPrivateChannelsForTeam(string $teamId, ?int $page = null): Response
-	{
-		return $this->connector->send(new GetPrivateChannelsForTeam($teamId, $page));
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 */
-	public function searchChannels(string $teamId): Response
-	{
-		return $this->connector->send(new SearchChannels($teamId));
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 */
-	public function searchArchivedChannels(string $teamId): Response
-	{
-		return $this->connector->send(new SearchArchivedChannels($teamId));
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param string $name Name or display name
-	 */
-	public function autocompleteChannelsForTeamForSearch(string $teamId, string $name): Response
-	{
-		return $this->connector->send(new AutocompleteChannelsForTeamForSearch($teamId, $name));
-	}
-
-
-	/**
-	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
-	 * @param int $lastDeleteAt Filters the deleted channels by this time in epoch format. Does not have any effect if include_deleted is set to false.
-	 * @param bool $includeDeleted Defines if deleted channels should be returned or not
-	 */
-	public function getChannelsForUser(string $userId, ?int $lastDeleteAt = null, ?bool $includeDeleted = null): Response
-	{
-		return $this->connector->send(new GetChannelsForUser($userId, $lastDeleteAt, $includeDeleted));
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 * @param string $channelId Channel GUID
-	 */
-	public function getChannelUnread(string $userId, string $channelId): Response
-	{
-		return $this->connector->send(new GetChannelUnread($userId, $channelId));
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 * @param string $teamId Team GUID
-	 * @param bool $includeDeleted Defines if deleted channels should be returned or not
-	 * @param int $lastDeleteAt Filters the deleted channels by this time in epoch format. Does not have any effect if include_deleted is set to false.
-	 */
-	public function getChannelsForTeamForUser(
-		string $userId,
-		string $teamId,
-		?bool $includeDeleted = null,
-		?int $lastDeleteAt = null,
-	): Response
-	{
-		return $this->connector->send(new GetChannelsForTeamForUser($userId, $teamId, $includeDeleted, $lastDeleteAt));
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param string $userId User GUID
-	 */
-	public function getSidebarCategoriesForTeamForUser(string $teamId, string $userId): Response
-	{
-		return $this->connector->send(new GetSidebarCategoriesForTeamForUser($teamId, $userId));
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param string $userId User GUID
-	 */
-	public function updateSidebarCategoriesForTeamForUser(string $teamId, string $userId): Response
-	{
-		return $this->connector->send(new UpdateSidebarCategoriesForTeamForUser($teamId, $userId));
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param string $userId User GUID
-	 */
-	public function createSidebarCategoryForTeamForUser(string $teamId, string $userId): Response
-	{
-		return $this->connector->send(new CreateSidebarCategoryForTeamForUser($teamId, $userId));
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param string $userId User GUID
-	 */
-	public function getSidebarCategoryOrderForTeamForUser(string $teamId, string $userId): Response
-	{
-		return $this->connector->send(new GetSidebarCategoryOrderForTeamForUser($teamId, $userId));
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param string $userId User GUID
-	 */
-	public function updateSidebarCategoryOrderForTeamForUser(string $teamId, string $userId): Response
-	{
-		return $this->connector->send(new UpdateSidebarCategoryOrderForTeamForUser($teamId, $userId));
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param string $userId User GUID
-	 * @param string $categoryId Category GUID
-	 */
-	public function getSidebarCategoryForTeamForUser(string $teamId, string $userId, string $categoryId): Response
-	{
-		return $this->connector->send(new GetSidebarCategoryForTeamForUser($teamId, $userId, $categoryId));
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param string $userId User GUID
-	 * @param string $categoryId Category GUID
-	 */
-	public function updateSidebarCategoryForTeamForUser(string $teamId, string $userId, string $categoryId): Response
-	{
-		return $this->connector->send(new UpdateSidebarCategoryForTeamForUser($teamId, $userId, $categoryId));
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param string $userId User GUID
-	 * @param string $categoryId Category GUID
-	 */
-	public function removeSidebarCategoryForTeamForUser(string $teamId, string $userId, string $categoryId): Response
-	{
-		return $this->connector->send(new RemoveSidebarCategoryForTeamForUser($teamId, $userId, $categoryId));
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 * @param string $teamId Team GUID
-	 */
-	public function getChannelMembersForUser(string $userId, string $teamId): Response
-	{
-		return $this->connector->send(new GetChannelMembersForUser($userId, $teamId));
-	}
+    /**
+     * @param  string  $notAssociatedToGroup  A group id to exclude channels that are associated with that group via GroupChannel records. This can also be left blank with `not_associated_to_group=`.
+     * @param  int  $page  The page to select.
+     * @param  bool  $excludeDefaultChannels  Whether to exclude default channels (ex Town Square, Off-Topic) from the results.
+     * @param  bool  $includeDeleted  Include channels that have been archived. This correlates to the `DeleteAt` flag being set in the database.
+     * @param  bool  $includeTotalCount  Appends a total count of returned channels inside the response object - ex: `{ "channels": [], "total_count" : 0 }`.
+     * @param  bool  $excludePolicyConstrained  If set to true, channels which are part of a data retention policy will be excluded. The `sysconsole_read_compliance` permission is required to use this parameter.
+     *                                          __Minimum server version__: 5.35
+     */
+    public function getAllChannels(
+        ?string $notAssociatedToGroup = null,
+        ?int $page = null,
+        ?bool $excludeDefaultChannels = null,
+        ?bool $includeDeleted = null,
+        ?bool $includeTotalCount = null,
+        ?bool $excludePolicyConstrained = null,
+    ): Response {
+        return $this->connector->send(new GetAllChannels($notAssociatedToGroup, $page, $excludeDefaultChannels, $includeDeleted, $includeTotalCount, $excludePolicyConstrained));
+    }
+
+    public function createChannel(): Response
+    {
+        return $this->connector->send(new CreateChannel);
+    }
+
+    public function createDirectChannel(): Response
+    {
+        return $this->connector->send(new CreateDirectChannel);
+    }
+
+    public function createGroupChannel(): Response
+    {
+        return $this->connector->send(new CreateGroupChannel);
+    }
+
+    public function searchGroupChannels(): Response
+    {
+        return $this->connector->send(new SearchGroupChannels);
+    }
+
+    /**
+     * @param  string  $userId  User ID to perform the view action for
+     */
+    public function viewChannel(string $userId): Response
+    {
+        return $this->connector->send(new ViewChannel($userId));
+    }
+
+    /**
+     * @param  bool  $systemConsole  Is the request from system_console. If this is set to true, it filters channels by the logged in user.
+     */
+    public function searchAllChannels(?bool $systemConsole = null): Response
+    {
+        return $this->connector->send(new SearchAllChannels($systemConsole));
+    }
+
+    /**
+     * @param  string  $channelId  Channel GUID
+     */
+    public function getChannel(string $channelId): Response
+    {
+        return $this->connector->send(new GetChannel($channelId));
+    }
+
+    /**
+     * @param  string  $channelId  Channel GUID
+     */
+    public function updateChannel(string $channelId): Response
+    {
+        return $this->connector->send(new UpdateChannel($channelId));
+    }
+
+    /**
+     * @param  string  $channelId  Channel GUID
+     */
+    public function deleteChannel(string $channelId): Response
+    {
+        return $this->connector->send(new DeleteChannel($channelId));
+    }
+
+    /**
+     * @param  string  $channelId  Channel GUID
+     * @param  bool  $includeTimezones  Defines if member timezone counts should be returned or not
+     */
+    public function getChannelMemberCountsByGroup(string $channelId, ?bool $includeTimezones = null): Response
+    {
+        return $this->connector->send(new GetChannelMemberCountsByGroup($channelId, $includeTimezones));
+    }
+
+    /**
+     * @param  string  $channelId  Channel GUID
+     * @param  int  $page  The page to select.
+     */
+    public function getChannelMembers(string $channelId, ?int $page = null): Response
+    {
+        return $this->connector->send(new GetChannelMembers($channelId, $page));
+    }
+
+    /**
+     * @param  string  $channelId  The channel ID
+     */
+    public function addChannelMember(string $channelId): Response
+    {
+        return $this->connector->send(new AddChannelMember($channelId));
+    }
+
+    /**
+     * @param  string  $channelId  Channel GUID
+     */
+    public function getChannelMembersByIds(string $channelId): Response
+    {
+        return $this->connector->send(new GetChannelMembersByIds($channelId));
+    }
+
+    /**
+     * @param  string  $channelId  Channel GUID
+     * @param  string  $userId  User GUID
+     */
+    public function getChannelMember(string $channelId, string $userId): Response
+    {
+        return $this->connector->send(new GetChannelMember($channelId, $userId));
+    }
+
+    /**
+     * @param  string  $channelId  Channel GUID
+     * @param  string  $userId  User GUID
+     */
+    public function removeUserFromChannel(string $channelId, string $userId): Response
+    {
+        return $this->connector->send(new RemoveUserFromChannel($channelId, $userId));
+    }
+
+    /**
+     * @param  string  $channelId  Channel GUID
+     * @param  string  $userId  User GUID
+     */
+    public function updateChannelNotifyProps(string $channelId, string $userId): Response
+    {
+        return $this->connector->send(new UpdateChannelNotifyProps($channelId, $userId));
+    }
+
+    /**
+     * @param  string  $channelId  Channel GUID
+     * @param  string  $userId  User GUID
+     */
+    public function updateChannelRoles(string $channelId, string $userId): Response
+    {
+        return $this->connector->send(new UpdateChannelRoles($channelId, $userId));
+    }
+
+    /**
+     * @param  string  $channelId  Channel GUID
+     * @param  string  $userId  User GUID
+     */
+    public function updateChannelMemberSchemeRoles(string $channelId, string $userId): Response
+    {
+        return $this->connector->send(new UpdateChannelMemberSchemeRoles($channelId, $userId));
+    }
+
+    /**
+     * @param  string  $channelId  Channel GUID
+     * @param  string  $groupIds  A comma-separated list of group ids.
+     * @param  int  $page  The page to select.
+     */
+    public function channelMembersMinusGroupMembers(string $channelId, string $groupIds, ?int $page = null): Response
+    {
+        return $this->connector->send(new ChannelMembersMinusGroupMembers($channelId, $groupIds, $page));
+    }
+
+    /**
+     * @param  string  $channelId  Channel GUID
+     */
+    public function getChannelModerations(string $channelId): Response
+    {
+        return $this->connector->send(new GetChannelModerations($channelId));
+    }
+
+    /**
+     * @param  string  $channelId  Channel GUID
+     */
+    public function patchChannelModerations(string $channelId): Response
+    {
+        return $this->connector->send(new PatchChannelModerations($channelId));
+    }
+
+    /**
+     * @param  string  $channelId  Channel GUID
+     */
+    public function moveChannel(string $channelId): Response
+    {
+        return $this->connector->send(new MoveChannel($channelId));
+    }
+
+    /**
+     * @param  string  $channelId  Channel GUID
+     */
+    public function patchChannel(string $channelId): Response
+    {
+        return $this->connector->send(new PatchChannel($channelId));
+    }
+
+    /**
+     * @param  string  $channelId  Channel GUID
+     */
+    public function getPinnedPosts(string $channelId): Response
+    {
+        return $this->connector->send(new GetPinnedPosts($channelId));
+    }
+
+    /**
+     * @param  string  $channelId  Channel GUID
+     */
+    public function updateChannelPrivacy(string $channelId): Response
+    {
+        return $this->connector->send(new UpdateChannelPrivacy($channelId));
+    }
+
+    /**
+     * @param  string  $channelId  Channel GUID
+     */
+    public function restoreChannel(string $channelId): Response
+    {
+        return $this->connector->send(new RestoreChannel($channelId));
+    }
+
+    /**
+     * @param  string  $channelId  Channel GUID
+     */
+    public function updateChannelScheme(string $channelId): Response
+    {
+        return $this->connector->send(new UpdateChannelScheme($channelId));
+    }
+
+    /**
+     * @param  string  $channelId  Channel GUID
+     */
+    public function getChannelStats(string $channelId): Response
+    {
+        return $this->connector->send(new GetChannelStats($channelId));
+    }
+
+    /**
+     * @param  string  $channelId  Channel GUID
+     */
+    public function getChannelMembersTimezones(string $channelId): Response
+    {
+        return $this->connector->send(new GetChannelMembersTimezones($channelId));
+    }
+
+    /**
+     * @param  string  $teamName  Team Name
+     * @param  string  $channelName  Channel Name
+     * @param  bool  $includeDeleted  Defines if deleted channels should be returned or not (Mattermost Server 5.26.0+)
+     */
+    public function getChannelByNameForTeamName(
+        string $teamName,
+        string $channelName,
+        ?bool $includeDeleted = null,
+    ): Response {
+        return $this->connector->send(new GetChannelByNameForTeamName($teamName, $channelName, $includeDeleted));
+    }
+
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  int  $page  The page to select.
+     */
+    public function getPublicChannelsForTeam(string $teamId, ?int $page = null): Response
+    {
+        return $this->connector->send(new GetPublicChannelsForTeam($teamId, $page));
+    }
+
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  string  $name  Name or display name
+     */
+    public function autocompleteChannelsForTeam(string $teamId, string $name): Response
+    {
+        return $this->connector->send(new AutocompleteChannelsForTeam($teamId, $name));
+    }
+
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  int  $page  The page to select.
+     */
+    public function getDeletedChannelsForTeam(string $teamId, ?int $page = null): Response
+    {
+        return $this->connector->send(new GetDeletedChannelsForTeam($teamId, $page));
+    }
+
+    /**
+     * @param  string  $teamId  Team GUID
+     */
+    public function getPublicChannelsByIdsForTeam(string $teamId): Response
+    {
+        return $this->connector->send(new GetPublicChannelsByIdsForTeam($teamId));
+    }
+
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  string  $channelName  Channel Name
+     * @param  bool  $includeDeleted  Defines if deleted channels should be returned or not (Mattermost Server 5.26.0+)
+     */
+    public function getChannelByName(string $teamId, string $channelName, ?bool $includeDeleted = null): Response
+    {
+        return $this->connector->send(new GetChannelByName($teamId, $channelName, $includeDeleted));
+    }
+
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  int  $page  The page to select.
+     */
+    public function getPrivateChannelsForTeam(string $teamId, ?int $page = null): Response
+    {
+        return $this->connector->send(new GetPrivateChannelsForTeam($teamId, $page));
+    }
+
+    /**
+     * @param  string  $teamId  Team GUID
+     */
+    public function searchChannels(string $teamId): Response
+    {
+        return $this->connector->send(new SearchChannels($teamId));
+    }
+
+    /**
+     * @param  string  $teamId  Team GUID
+     */
+    public function searchArchivedChannels(string $teamId): Response
+    {
+        return $this->connector->send(new SearchArchivedChannels($teamId));
+    }
+
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  string  $name  Name or display name
+     */
+    public function autocompleteChannelsForTeamForSearch(string $teamId, string $name): Response
+    {
+        return $this->connector->send(new AutocompleteChannelsForTeamForSearch($teamId, $name));
+    }
+
+    /**
+     * @param  string  $userId  The ID of the user. This can also be "me" which will point to the current user.
+     * @param  int  $lastDeleteAt  Filters the deleted channels by this time in epoch format. Does not have any effect if include_deleted is set to false.
+     * @param  bool  $includeDeleted  Defines if deleted channels should be returned or not
+     */
+    public function getChannelsForUser(string $userId, ?int $lastDeleteAt = null, ?bool $includeDeleted = null): Response
+    {
+        return $this->connector->send(new GetChannelsForUser($userId, $lastDeleteAt, $includeDeleted));
+    }
+
+    /**
+     * @param  string  $userId  User GUID
+     * @param  string  $channelId  Channel GUID
+     */
+    public function getChannelUnread(string $userId, string $channelId): Response
+    {
+        return $this->connector->send(new GetChannelUnread($userId, $channelId));
+    }
+
+    /**
+     * @param  string  $userId  User GUID
+     * @param  string  $teamId  Team GUID
+     * @param  bool  $includeDeleted  Defines if deleted channels should be returned or not
+     * @param  int  $lastDeleteAt  Filters the deleted channels by this time in epoch format. Does not have any effect if include_deleted is set to false.
+     */
+    public function getChannelsForTeamForUser(
+        string $userId,
+        string $teamId,
+        ?bool $includeDeleted = null,
+        ?int $lastDeleteAt = null,
+    ): Response {
+        return $this->connector->send(new GetChannelsForTeamForUser($userId, $teamId, $includeDeleted, $lastDeleteAt));
+    }
+
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  string  $userId  User GUID
+     */
+    public function getSidebarCategoriesForTeamForUser(string $teamId, string $userId): Response
+    {
+        return $this->connector->send(new GetSidebarCategoriesForTeamForUser($teamId, $userId));
+    }
+
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  string  $userId  User GUID
+     */
+    public function updateSidebarCategoriesForTeamForUser(string $teamId, string $userId): Response
+    {
+        return $this->connector->send(new UpdateSidebarCategoriesForTeamForUser($teamId, $userId));
+    }
+
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  string  $userId  User GUID
+     */
+    public function createSidebarCategoryForTeamForUser(string $teamId, string $userId): Response
+    {
+        return $this->connector->send(new CreateSidebarCategoryForTeamForUser($teamId, $userId));
+    }
+
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  string  $userId  User GUID
+     */
+    public function getSidebarCategoryOrderForTeamForUser(string $teamId, string $userId): Response
+    {
+        return $this->connector->send(new GetSidebarCategoryOrderForTeamForUser($teamId, $userId));
+    }
+
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  string  $userId  User GUID
+     */
+    public function updateSidebarCategoryOrderForTeamForUser(string $teamId, string $userId): Response
+    {
+        return $this->connector->send(new UpdateSidebarCategoryOrderForTeamForUser($teamId, $userId));
+    }
+
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  string  $userId  User GUID
+     * @param  string  $categoryId  Category GUID
+     */
+    public function getSidebarCategoryForTeamForUser(string $teamId, string $userId, string $categoryId): Response
+    {
+        return $this->connector->send(new GetSidebarCategoryForTeamForUser($teamId, $userId, $categoryId));
+    }
+
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  string  $userId  User GUID
+     * @param  string  $categoryId  Category GUID
+     */
+    public function updateSidebarCategoryForTeamForUser(string $teamId, string $userId, string $categoryId): Response
+    {
+        return $this->connector->send(new UpdateSidebarCategoryForTeamForUser($teamId, $userId, $categoryId));
+    }
+
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  string  $userId  User GUID
+     * @param  string  $categoryId  Category GUID
+     */
+    public function removeSidebarCategoryForTeamForUser(string $teamId, string $userId, string $categoryId): Response
+    {
+        return $this->connector->send(new RemoveSidebarCategoryForTeamForUser($teamId, $userId, $categoryId));
+    }
+
+    /**
+     * @param  string  $userId  User GUID
+     * @param  string  $teamId  Team GUID
+     */
+    public function getChannelMembersForUser(string $userId, string $teamId): Response
+    {
+        return $this->connector->send(new GetChannelMembersForUser($userId, $teamId));
+    }
 }

--- a/src/Client/Resource/Commands.php
+++ b/src/Client/Resource/Commands.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Resource;
 
 use ConduitUI\Mattermost\Client\Requests\Commands\CreateCommand;
@@ -16,79 +18,71 @@ use Saloon\Http\Response;
 
 class Commands extends BaseResource
 {
-	/**
-	 * @param string $teamId The team id.
-	 * @param bool $customOnly To get only the custom commands. If set to false will get the custom
-	 * if the user have access plus the system commands, otherwise just the system commands.
-	 */
-	public function listCommands(?string $teamId = null, ?bool $customOnly = null): Response
-	{
-		return $this->connector->send(new ListCommands($teamId, $customOnly));
-	}
+    /**
+     * @param  string  $teamId  The team id.
+     * @param  bool  $customOnly  To get only the custom commands. If set to false will get the custom
+     *                            if the user have access plus the system commands, otherwise just the system commands.
+     */
+    public function listCommands(?string $teamId = null, ?bool $customOnly = null): Response
+    {
+        return $this->connector->send(new ListCommands($teamId, $customOnly));
+    }
 
+    public function createCommand(): Response
+    {
+        return $this->connector->send(new CreateCommand);
+    }
 
-	public function createCommand(): Response
-	{
-		return $this->connector->send(new CreateCommand());
-	}
+    public function executeCommand(): Response
+    {
+        return $this->connector->send(new ExecuteCommand);
+    }
 
+    /**
+     * @param  string  $commandId  ID of the command to get
+     */
+    public function getCommandById(string $commandId): Response
+    {
+        return $this->connector->send(new GetCommandById($commandId));
+    }
 
-	public function executeCommand(): Response
-	{
-		return $this->connector->send(new ExecuteCommand());
-	}
+    /**
+     * @param  string  $commandId  ID of the command to update
+     */
+    public function updateCommand(string $commandId): Response
+    {
+        return $this->connector->send(new UpdateCommand($commandId));
+    }
 
+    /**
+     * @param  string  $commandId  ID of the command to delete
+     */
+    public function deleteCommand(string $commandId): Response
+    {
+        return $this->connector->send(new DeleteCommand($commandId));
+    }
 
-	/**
-	 * @param string $commandId ID of the command to get
-	 */
-	public function getCommandById(string $commandId): Response
-	{
-		return $this->connector->send(new GetCommandById($commandId));
-	}
+    /**
+     * @param  string  $commandId  ID of the command to move
+     */
+    public function moveCommand(string $commandId): Response
+    {
+        return $this->connector->send(new MoveCommand($commandId));
+    }
 
+    /**
+     * @param  string  $commandId  ID of the command to generate the new token
+     */
+    public function regenCommandToken(string $commandId): Response
+    {
+        return $this->connector->send(new RegenCommandToken($commandId));
+    }
 
-	/**
-	 * @param string $commandId ID of the command to update
-	 */
-	public function updateCommand(string $commandId): Response
-	{
-		return $this->connector->send(new UpdateCommand($commandId));
-	}
-
-
-	/**
-	 * @param string $commandId ID of the command to delete
-	 */
-	public function deleteCommand(string $commandId): Response
-	{
-		return $this->connector->send(new DeleteCommand($commandId));
-	}
-
-
-	/**
-	 * @param string $commandId ID of the command to move
-	 */
-	public function moveCommand(string $commandId): Response
-	{
-		return $this->connector->send(new MoveCommand($commandId));
-	}
-
-
-	/**
-	 * @param string $commandId ID of the command to generate the new token
-	 */
-	public function regenCommandToken(string $commandId): Response
-	{
-		return $this->connector->send(new RegenCommandToken($commandId));
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 */
-	public function listAutocompleteCommands(string $teamId): Response
-	{
-		return $this->connector->send(new ListAutocompleteCommands($teamId));
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     */
+    public function listAutocompleteCommands(string $teamId): Response
+    {
+        return $this->connector->send(new ListAutocompleteCommands($teamId));
+    }
 }

--- a/src/Client/Resource/DataRetention.php
+++ b/src/Client/Resource/DataRetention.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Resource;
 
 use ConduitUI\Mattermost\Client\Requests\DataRetention\GetChannelPoliciesForUser;
@@ -9,22 +11,21 @@ use Saloon\Http\Response;
 
 class DataRetention extends BaseResource
 {
-	/**
-	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
-	 * @param int $page The page to select.
-	 */
-	public function getChannelPoliciesForUser(string $userId, ?int $page = null): Response
-	{
-		return $this->connector->send(new GetChannelPoliciesForUser($userId, $page));
-	}
+    /**
+     * @param  string  $userId  The ID of the user. This can also be "me" which will point to the current user.
+     * @param  int  $page  The page to select.
+     */
+    public function getChannelPoliciesForUser(string $userId, ?int $page = null): Response
+    {
+        return $this->connector->send(new GetChannelPoliciesForUser($userId, $page));
+    }
 
-
-	/**
-	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
-	 * @param int $page The page to select.
-	 */
-	public function getTeamPoliciesForUser(string $userId, ?int $page = null): Response
-	{
-		return $this->connector->send(new GetTeamPoliciesForUser($userId, $page));
-	}
+    /**
+     * @param  string  $userId  The ID of the user. This can also be "me" which will point to the current user.
+     * @param  int  $page  The page to select.
+     */
+    public function getTeamPoliciesForUser(string $userId, ?int $page = null): Response
+    {
+        return $this->connector->send(new GetTeamPoliciesForUser($userId, $page));
+    }
 }

--- a/src/Client/Resource/Emoji.php
+++ b/src/Client/Resource/Emoji.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Resource;
 
 use ConduitUI\Mattermost\Client\Requests\Emoji\AutocompleteEmoji;
@@ -15,69 +17,62 @@ use Saloon\Http\Response;
 
 class Emoji extends BaseResource
 {
-	/**
-	 * @param int $page The page to select.
-	 * @param string $sort Either blank for no sorting or "name" to sort by emoji names. Minimum server version for sorting is 4.7.
-	 */
-	public function getEmojiList(?int $page = null, ?string $sort = null): Response
-	{
-		return $this->connector->send(new GetEmojiList($page, $sort));
-	}
+    /**
+     * @param  int  $page  The page to select.
+     * @param  string  $sort  Either blank for no sorting or "name" to sort by emoji names. Minimum server version for sorting is 4.7.
+     */
+    public function getEmojiList(?int $page = null, ?string $sort = null): Response
+    {
+        return $this->connector->send(new GetEmojiList($page, $sort));
+    }
 
+    public function createEmoji(): Response
+    {
+        return $this->connector->send(new CreateEmoji);
+    }
 
-	public function createEmoji(): Response
-	{
-		return $this->connector->send(new CreateEmoji());
-	}
+    /**
+     * @param  string  $name  The emoji name to search.
+     */
+    public function autocompleteEmoji(string $name): Response
+    {
+        return $this->connector->send(new AutocompleteEmoji($name));
+    }
 
+    /**
+     * @param  string  $emojiName  Emoji name
+     */
+    public function getEmojiByName(string $emojiName): Response
+    {
+        return $this->connector->send(new GetEmojiByName($emojiName));
+    }
 
-	/**
-	 * @param string $name The emoji name to search.
-	 */
-	public function autocompleteEmoji(string $name): Response
-	{
-		return $this->connector->send(new AutocompleteEmoji($name));
-	}
+    public function searchEmoji(): Response
+    {
+        return $this->connector->send(new SearchEmoji);
+    }
 
+    /**
+     * @param  string  $emojiId  Emoji GUID
+     */
+    public function getEmoji(string $emojiId): Response
+    {
+        return $this->connector->send(new GetEmoji($emojiId));
+    }
 
-	/**
-	 * @param string $emojiName Emoji name
-	 */
-	public function getEmojiByName(string $emojiName): Response
-	{
-		return $this->connector->send(new GetEmojiByName($emojiName));
-	}
+    /**
+     * @param  string  $emojiId  Emoji GUID
+     */
+    public function deleteEmoji(string $emojiId): Response
+    {
+        return $this->connector->send(new DeleteEmoji($emojiId));
+    }
 
-
-	public function searchEmoji(): Response
-	{
-		return $this->connector->send(new SearchEmoji());
-	}
-
-
-	/**
-	 * @param string $emojiId Emoji GUID
-	 */
-	public function getEmoji(string $emojiId): Response
-	{
-		return $this->connector->send(new GetEmoji($emojiId));
-	}
-
-
-	/**
-	 * @param string $emojiId Emoji GUID
-	 */
-	public function deleteEmoji(string $emojiId): Response
-	{
-		return $this->connector->send(new DeleteEmoji($emojiId));
-	}
-
-
-	/**
-	 * @param string $emojiId Emoji GUID
-	 */
-	public function getEmojiImage(string $emojiId): Response
-	{
-		return $this->connector->send(new GetEmojiImage($emojiId));
-	}
+    /**
+     * @param  string  $emojiId  Emoji GUID
+     */
+    public function getEmojiImage(string $emojiId): Response
+    {
+        return $this->connector->send(new GetEmojiImage($emojiId));
+    }
 }

--- a/src/Client/Resource/Files.php
+++ b/src/Client/Resource/Files.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Resource;
 
 use ConduitUI\Mattermost\Client\Requests\Files\GetFile;
@@ -14,67 +16,61 @@ use Saloon\Http\Response;
 
 class Files extends BaseResource
 {
-	/**
-	 * @param string $channelId The ID of the channel that this file will be uploaded to
-	 * @param string $filename The name of the file to be uploaded
-	 */
-	public function uploadFile(?string $channelId = null, ?string $filename = null): Response
-	{
-		return $this->connector->send(new UploadFile($channelId, $filename));
-	}
+    /**
+     * @param  string  $channelId  The ID of the channel that this file will be uploaded to
+     * @param  string  $filename  The name of the file to be uploaded
+     */
+    public function uploadFile(?string $channelId = null, ?string $filename = null): Response
+    {
+        return $this->connector->send(new UploadFile($channelId, $filename));
+    }
 
+    /**
+     * @param  string  $fileId  The ID of the file to get
+     */
+    public function getFile(string $fileId): Response
+    {
+        return $this->connector->send(new GetFile($fileId));
+    }
 
-	/**
-	 * @param string $fileId The ID of the file to get
-	 */
-	public function getFile(string $fileId): Response
-	{
-		return $this->connector->send(new GetFile($fileId));
-	}
+    /**
+     * @param  string  $fileId  The ID of the file info to get
+     */
+    public function getFileInfo(string $fileId): Response
+    {
+        return $this->connector->send(new GetFileInfo($fileId));
+    }
 
+    /**
+     * @param  string  $fileId  The ID of the file to get a link for
+     */
+    public function getFileLink(string $fileId): Response
+    {
+        return $this->connector->send(new GetFileLink($fileId));
+    }
 
-	/**
-	 * @param string $fileId The ID of the file info to get
-	 */
-	public function getFileInfo(string $fileId): Response
-	{
-		return $this->connector->send(new GetFileInfo($fileId));
-	}
+    /**
+     * @param  string  $fileId  The ID of the file to get
+     */
+    public function getFilePreview(string $fileId): Response
+    {
+        return $this->connector->send(new GetFilePreview($fileId));
+    }
 
+    /**
+     * @param  string  $fileId  The ID of the file to get
+     * @param  string  $h  File hash
+     */
+    public function getFilePublic(string $fileId, string $h): Response
+    {
+        return $this->connector->send(new GetFilePublic($fileId, $h));
+    }
 
-	/**
-	 * @param string $fileId The ID of the file to get a link for
-	 */
-	public function getFileLink(string $fileId): Response
-	{
-		return $this->connector->send(new GetFileLink($fileId));
-	}
-
-
-	/**
-	 * @param string $fileId The ID of the file to get
-	 */
-	public function getFilePreview(string $fileId): Response
-	{
-		return $this->connector->send(new GetFilePreview($fileId));
-	}
-
-
-	/**
-	 * @param string $fileId The ID of the file to get
-	 * @param string $h File hash
-	 */
-	public function getFilePublic(string $fileId, string $h): Response
-	{
-		return $this->connector->send(new GetFilePublic($fileId, $h));
-	}
-
-
-	/**
-	 * @param string $fileId The ID of the file to get
-	 */
-	public function getFileThumbnail(string $fileId): Response
-	{
-		return $this->connector->send(new GetFileThumbnail($fileId));
-	}
+    /**
+     * @param  string  $fileId  The ID of the file to get
+     */
+    public function getFileThumbnail(string $fileId): Response
+    {
+        return $this->connector->send(new GetFileThumbnail($fileId));
+    }
 }

--- a/src/Client/Resource/Groups.php
+++ b/src/Client/Resource/Groups.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Resource;
 
 use ConduitUI\Mattermost\Client\Requests\Groups\GetGroupsAssociatedToChannelsByTeam;
@@ -11,54 +13,49 @@ use Saloon\Http\Response;
 
 class Groups extends BaseResource
 {
-	/**
-	 * @param string $channelId Channel GUID
-	 * @param int $page The page to select.
-	 * @param bool $filterAllowReference Boolean which filters the group entries with the `allow_reference` attribute set.
-	 */
-	public function getGroupsByChannel(
-		string $channelId,
-		?int $page = null,
-		?bool $filterAllowReference = null,
-	): Response
-	{
-		return $this->connector->send(new GetGroupsByChannel($channelId, $page, $filterAllowReference));
-	}
+    /**
+     * @param  string  $channelId  Channel GUID
+     * @param  int  $page  The page to select.
+     * @param  bool  $filterAllowReference  Boolean which filters the group entries with the `allow_reference` attribute set.
+     */
+    public function getGroupsByChannel(
+        string $channelId,
+        ?int $page = null,
+        ?bool $filterAllowReference = null,
+    ): Response {
+        return $this->connector->send(new GetGroupsByChannel($channelId, $page, $filterAllowReference));
+    }
 
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  int  $page  The page to select.
+     * @param  bool  $filterAllowReference  Boolean which filters in the group entries with the `allow_reference` attribute set.
+     */
+    public function getGroupsByTeam(string $teamId, ?int $page = null, ?bool $filterAllowReference = null): Response
+    {
+        return $this->connector->send(new GetGroupsByTeam($teamId, $page, $filterAllowReference));
+    }
 
-	/**
-	 * @param string $teamId Team GUID
-	 * @param int $page The page to select.
-	 * @param bool $filterAllowReference Boolean which filters in the group entries with the `allow_reference` attribute set.
-	 */
-	public function getGroupsByTeam(string $teamId, ?int $page = null, ?bool $filterAllowReference = null): Response
-	{
-		return $this->connector->send(new GetGroupsByTeam($teamId, $page, $filterAllowReference));
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  int  $page  The page to select.
+     * @param  bool  $filterAllowReference  Boolean which filters in the group entries with the `allow_reference` attribute set.
+     * @param  bool  $paginate  Boolean to determine whether the pagination should be applied or not
+     */
+    public function getGroupsAssociatedToChannelsByTeam(
+        string $teamId,
+        ?int $page = null,
+        ?bool $filterAllowReference = null,
+        ?bool $paginate = null,
+    ): Response {
+        return $this->connector->send(new GetGroupsAssociatedToChannelsByTeam($teamId, $page, $filterAllowReference, $paginate));
+    }
 
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param int $page The page to select.
-	 * @param bool $filterAllowReference Boolean which filters in the group entries with the `allow_reference` attribute set.
-	 * @param bool $paginate Boolean to determine whether the pagination should be applied or not
-	 */
-	public function getGroupsAssociatedToChannelsByTeam(
-		string $teamId,
-		?int $page = null,
-		?bool $filterAllowReference = null,
-		?bool $paginate = null,
-	): Response
-	{
-		return $this->connector->send(new GetGroupsAssociatedToChannelsByTeam($teamId, $page, $filterAllowReference, $paginate));
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function getGroupsByUserId(string $userId): Response
-	{
-		return $this->connector->send(new GetGroupsByUserId($userId));
-	}
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function getGroupsByUserId(string $userId): Response
+    {
+        return $this->connector->send(new GetGroupsByUserId($userId));
+    }
 }

--- a/src/Client/Resource/Insights.php
+++ b/src/Client/Resource/Insights.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Resource;
 
 use ConduitUI\Mattermost\Client\Requests\Insights\GetNewTeamMembers;
@@ -15,119 +17,112 @@ use Saloon\Http\Response;
 
 class Insights extends BaseResource
 {
-	/**
-	 * @param string $teamId Team GUID
-	 * @param string $timeRange Time range can be "today", "7_day", or "28_day".
-	 * - `today`: channels with posts on the current day.
-	 * - `7_day`: channels with posts in the last 7 days.
-	 * - `28_day`: channels with posts in the last 28 days.
-	 * @param int $page The page to select.
-	 */
-	public function getTopChannelsForTeam(string $teamId, string $timeRange, ?int $page = null): Response
-	{
-		return $this->connector->send(new GetTopChannelsForTeam($teamId, $timeRange, $page));
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  string  $timeRange  Time range can be "today", "7_day", or "28_day".
+     *                             - `today`: channels with posts on the current day.
+     *                             - `7_day`: channels with posts in the last 7 days.
+     *                             - `28_day`: channels with posts in the last 28 days.
+     * @param  int  $page  The page to select.
+     */
+    public function getTopChannelsForTeam(string $teamId, string $timeRange, ?int $page = null): Response
+    {
+        return $this->connector->send(new GetTopChannelsForTeam($teamId, $timeRange, $page));
+    }
 
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  string  $timeRange  Time range can be "today", "7_day", or "28_day".
+     *                             - `today`: reactions posted on the current day.
+     *                             - `7_day`: reactions posted in the last 7 days.
+     *                             - `28_day`: reactions posted in the last 28 days.
+     * @param  int  $page  The page to select.
+     */
+    public function getTopReactionsForTeam(string $teamId, string $timeRange, ?int $page = null): Response
+    {
+        return $this->connector->send(new GetTopReactionsForTeam($teamId, $timeRange, $page));
+    }
 
-	/**
-	 * @param string $teamId Team GUID
-	 * @param string $timeRange Time range can be "today", "7_day", or "28_day".
-	 * - `today`: reactions posted on the current day.
-	 * - `7_day`: reactions posted in the last 7 days.
-	 * - `28_day`: reactions posted in the last 28 days.
-	 * @param int $page The page to select.
-	 */
-	public function getTopReactionsForTeam(string $teamId, string $timeRange, ?int $page = null): Response
-	{
-		return $this->connector->send(new GetTopReactionsForTeam($teamId, $timeRange, $page));
-	}
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  string  $timeRange  Time range can be "today", "7_day", or "28_day".
+     *                             - `today`: team members who joined during the current day.
+     *                             - `7_day`: team members who joined in the last 7 days.
+     *                             - `28_day`: team members who joined in the last 28 days.
+     * @param  int  $page  The page to select.
+     */
+    public function getNewTeamMembers(string $teamId, string $timeRange, ?int $page = null): Response
+    {
+        return $this->connector->send(new GetNewTeamMembers($teamId, $timeRange, $page));
+    }
 
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  string  $timeRange  Time range can be "today", "7_day", or "28_day".
+     *                             - `today`: threads with activity on the current day.
+     *                             - `7_day`: threads with activity in the last 7 days.
+     *                             - `28_day`: threads with activity in the last 28 days.
+     * @param  int  $page  The page to select.
+     */
+    public function getTopThreadsForTeam(string $teamId, string $timeRange, ?int $page = null): Response
+    {
+        return $this->connector->send(new GetTopThreadsForTeam($teamId, $timeRange, $page));
+    }
 
-	/**
-	 * @param string $teamId Team GUID
-	 * @param string $timeRange Time range can be "today", "7_day", or "28_day".
-	 * - `today`: team members who joined during the current day.
-	 * - `7_day`: team members who joined in the last 7 days.
-	 * - `28_day`: team members who joined in the last 28 days.
-	 * @param int $page The page to select.
-	 */
-	public function getNewTeamMembers(string $teamId, string $timeRange, ?int $page = null): Response
-	{
-		return $this->connector->send(new GetNewTeamMembers($teamId, $timeRange, $page));
-	}
+    /**
+     * @param  string  $timeRange  Time range can be "today", "7_day", or "28_day".
+     *                             - `today`: channels with posts on the current day.
+     *                             - `7_day`: channels with posts in the last 7 days.
+     *                             - `28_day`: channels with posts in the last 28 days.
+     * @param  int  $page  The page to select.
+     * @param  string  $teamId  Team ID will scope the response to a given team.
+     *                          ##### Permissions
+     *                          Must have `view_team` permission for the team.
+     */
+    public function getTopChannelsForUser(string $timeRange, ?int $page = null, ?string $teamId = null): Response
+    {
+        return $this->connector->send(new GetTopChannelsForUser($timeRange, $page, $teamId));
+    }
 
+    /**
+     * @param  string  $timeRange  Time range can be "today", "7_day", or "28_day".
+     *                             - `today`: threads with activity on the current day.
+     *                             - `7_day`: threads with activity in the last 7 days.
+     *                             - `28_day`: threads with activity in the last 28 days.
+     * @param  int  $page  The page to select.
+     */
+    public function getTopDmsForUser(string $timeRange, ?int $page = null): Response
+    {
+        return $this->connector->send(new GetTopDmsForUser($timeRange, $page));
+    }
 
-	/**
-	 * @param string $teamId Team GUID
-	 * @param string $timeRange Time range can be "today", "7_day", or "28_day".
-	 * - `today`: threads with activity on the current day.
-	 * - `7_day`: threads with activity in the last 7 days.
-	 * - `28_day`: threads with activity in the last 28 days.
-	 * @param int $page The page to select.
-	 */
-	public function getTopThreadsForTeam(string $teamId, string $timeRange, ?int $page = null): Response
-	{
-		return $this->connector->send(new GetTopThreadsForTeam($teamId, $timeRange, $page));
-	}
+    /**
+     * @param  string  $timeRange  Time range can be "today", "7_day", or "28_day".
+     *                             - `today`: reactions posted on the current day.
+     *                             - `7_day`: reactions posted in the last 7 days.
+     *                             - `28_day`: reactions posted in the last 28 days.
+     * @param  int  $page  The page to select.
+     * @param  string  $teamId  Team ID will scope the response to a given team and exclude direct and group messages.
+     *                          ##### Permissions
+     *                          Must have `view_team` permission for the team.
+     */
+    public function getTopReactionsForUser(string $timeRange, ?int $page = null, ?string $teamId = null): Response
+    {
+        return $this->connector->send(new GetTopReactionsForUser($timeRange, $page, $teamId));
+    }
 
-
-	/**
-	 * @param string $timeRange Time range can be "today", "7_day", or "28_day".
-	 * - `today`: channels with posts on the current day.
-	 * - `7_day`: channels with posts in the last 7 days.
-	 * - `28_day`: channels with posts in the last 28 days.
-	 * @param int $page The page to select.
-	 * @param string $teamId Team ID will scope the response to a given team.
-	 * ##### Permissions
-	 * Must have `view_team` permission for the team.
-	 */
-	public function getTopChannelsForUser(string $timeRange, ?int $page = null, ?string $teamId = null): Response
-	{
-		return $this->connector->send(new GetTopChannelsForUser($timeRange, $page, $teamId));
-	}
-
-
-	/**
-	 * @param string $timeRange Time range can be "today", "7_day", or "28_day".
-	 * - `today`: threads with activity on the current day.
-	 * - `7_day`: threads with activity in the last 7 days.
-	 * - `28_day`: threads with activity in the last 28 days.
-	 * @param int $page The page to select.
-	 */
-	public function getTopDmsForUser(string $timeRange, ?int $page = null): Response
-	{
-		return $this->connector->send(new GetTopDmsForUser($timeRange, $page));
-	}
-
-
-	/**
-	 * @param string $timeRange Time range can be "today", "7_day", or "28_day".
-	 * - `today`: reactions posted on the current day.
-	 * - `7_day`: reactions posted in the last 7 days.
-	 * - `28_day`: reactions posted in the last 28 days.
-	 * @param int $page The page to select.
-	 * @param string $teamId Team ID will scope the response to a given team and exclude direct and group messages.
-	 * ##### Permissions
-	 * Must have `view_team` permission for the team.
-	 */
-	public function getTopReactionsForUser(string $timeRange, ?int $page = null, ?string $teamId = null): Response
-	{
-		return $this->connector->send(new GetTopReactionsForUser($timeRange, $page, $teamId));
-	}
-
-
-	/**
-	 * @param string $timeRange Time range can be "today", "7_day", or "28_day".
-	 * - `today`: threads with activity on the current day.
-	 * - `7_day`: threads with activity in the last 7 days.
-	 * - `28_day`: threads with activity in the last 28 days.
-	 * @param int $page The page to select.
-	 * @param string $teamId Team ID will scope the response to a given team.
-	 * ##### Permissions
-	 * Must have `view_team` permission for the team.
-	 */
-	public function getTopThreadsForUser(string $timeRange, ?int $page = null, ?string $teamId = null): Response
-	{
-		return $this->connector->send(new GetTopThreadsForUser($timeRange, $page, $teamId));
-	}
+    /**
+     * @param  string  $timeRange  Time range can be "today", "7_day", or "28_day".
+     *                             - `today`: threads with activity on the current day.
+     *                             - `7_day`: threads with activity in the last 7 days.
+     *                             - `28_day`: threads with activity in the last 28 days.
+     * @param  int  $page  The page to select.
+     * @param  string  $teamId  Team ID will scope the response to a given team.
+     *                          ##### Permissions
+     *                          Must have `view_team` permission for the team.
+     */
+    public function getTopThreadsForUser(string $timeRange, ?int $page = null, ?string $teamId = null): Response
+    {
+        return $this->connector->send(new GetTopThreadsForUser($timeRange, $page, $teamId));
+    }
 }

--- a/src/Client/Resource/Oauth.php
+++ b/src/Client/Resource/Oauth.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Resource;
 
 use ConduitUI\Mattermost\Client\Requests\Oauth\GetAuthorizedOauthAppsForUser;
@@ -8,12 +10,12 @@ use Saloon\Http\Response;
 
 class Oauth extends BaseResource
 {
-	/**
-	 * @param string $userId User GUID
-	 * @param int $page The page to select.
-	 */
-	public function getAuthorizedOauthAppsForUser(string $userId, ?int $page = null): Response
-	{
-		return $this->connector->send(new GetAuthorizedOauthAppsForUser($userId, $page));
-	}
+    /**
+     * @param  string  $userId  User GUID
+     * @param  int  $page  The page to select.
+     */
+    public function getAuthorizedOauthAppsForUser(string $userId, ?int $page = null): Response
+    {
+        return $this->connector->send(new GetAuthorizedOauthAppsForUser($userId, $page));
+    }
 }

--- a/src/Client/Resource/Posts.php
+++ b/src/Client/Resource/Posts.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Resource;
 
 use ConduitUI\Mattermost\Client\Requests\Posts\CreatePost;
@@ -9,10 +11,10 @@ use ConduitUI\Mattermost\Client\Requests\Posts\DoPostAction;
 use ConduitUI\Mattermost\Client\Requests\Posts\GetFileInfosForPost;
 use ConduitUI\Mattermost\Client\Requests\Posts\GetFlaggedPostsForUser;
 use ConduitUI\Mattermost\Client\Requests\Posts\GetPost;
-use ConduitUI\Mattermost\Client\Requests\Posts\GetPostThread;
 use ConduitUI\Mattermost\Client\Requests\Posts\GetPostsAroundLastUnread;
 use ConduitUI\Mattermost\Client\Requests\Posts\GetPostsByIds;
 use ConduitUI\Mattermost\Client\Requests\Posts\GetPostsForChannel;
+use ConduitUI\Mattermost\Client\Requests\Posts\GetPostThread;
 use ConduitUI\Mattermost\Client\Requests\Posts\PatchPost;
 use ConduitUI\Mattermost\Client\Requests\Posts\PinPost;
 use ConduitUI\Mattermost\Client\Requests\Posts\SaveAcknowledgementForPost;
@@ -26,232 +28,210 @@ use Saloon\Http\Response;
 
 class Posts extends BaseResource
 {
-	/**
-	 * @param string $channelId The channel ID to get the posts for
-	 * @param int $page The page to select
-	 * @param int $since Provide a non-zero value in Unix time milliseconds to select posts modified after that time
-	 * @param string $before A post id to select the posts that came before this one
-	 * @param bool $includeDeleted Whether to include deleted posts or not. Must have system admin permissions.
-	 */
-	public function getPostsForChannel(
-		string $channelId,
-		?int $page = null,
-		?int $since = null,
-		?string $before = null,
-		?bool $includeDeleted = null,
-	): Response
-	{
-		return $this->connector->send(new GetPostsForChannel($channelId, $page, $since, $before, $includeDeleted));
-	}
+    /**
+     * @param  string  $channelId  The channel ID to get the posts for
+     * @param  int  $page  The page to select
+     * @param  int  $since  Provide a non-zero value in Unix time milliseconds to select posts modified after that time
+     * @param  string  $before  A post id to select the posts that came before this one
+     * @param  bool  $includeDeleted  Whether to include deleted posts or not. Must have system admin permissions.
+     */
+    public function getPostsForChannel(
+        string $channelId,
+        ?int $page = null,
+        ?int $since = null,
+        ?string $before = null,
+        ?bool $includeDeleted = null,
+    ): Response {
+        return $this->connector->send(new GetPostsForChannel($channelId, $page, $since, $before, $includeDeleted));
+    }
 
+    /**
+     * @param  bool  $setOnline  Whether to set the user status as online or not.
+     */
+    public function createPost(?bool $setOnline = null): Response
+    {
+        return $this->connector->send(new CreatePost($setOnline));
+    }
 
-	/**
-	 * @param bool $setOnline Whether to set the user status as online or not.
-	 */
-	public function createPost(?bool $setOnline = null): Response
-	{
-		return $this->connector->send(new CreatePost($setOnline));
-	}
+    public function createPostEphemeral(): Response
+    {
+        return $this->connector->send(new CreatePostEphemeral);
+    }
 
+    public function getPostsByIds(): Response
+    {
+        return $this->connector->send(new GetPostsByIds);
+    }
 
-	public function createPostEphemeral(): Response
-	{
-		return $this->connector->send(new CreatePostEphemeral());
-	}
+    /**
+     * @param  string  $postId  ID of the post to get
+     * @param  bool  $includeDeleted  Defines if result should include deleted posts, must have 'manage_system' (admin) permission.
+     */
+    public function getPost(string $postId, ?bool $includeDeleted = null): Response
+    {
+        return $this->connector->send(new GetPost($postId, $includeDeleted));
+    }
 
+    /**
+     * @param  string  $postId  ID of the post to update
+     */
+    public function updatePost(string $postId): Response
+    {
+        return $this->connector->send(new UpdatePost($postId));
+    }
 
-	public function getPostsByIds(): Response
-	{
-		return $this->connector->send(new GetPostsByIds());
-	}
+    /**
+     * @param  string  $postId  ID of the post to delete
+     */
+    public function deletePost(string $postId): Response
+    {
+        return $this->connector->send(new DeletePost($postId));
+    }
 
+    /**
+     * @param  string  $postId  Post GUID
+     * @param  string  $actionId  Action GUID
+     */
+    public function doPostAction(string $postId, string $actionId): Response
+    {
+        return $this->connector->send(new DoPostAction($postId, $actionId));
+    }
 
-	/**
-	 * @param string $postId ID of the post to get
-	 * @param bool $includeDeleted Defines if result should include deleted posts, must have 'manage_system' (admin) permission.
-	 */
-	public function getPost(string $postId, ?bool $includeDeleted = null): Response
-	{
-		return $this->connector->send(new GetPost($postId, $includeDeleted));
-	}
+    /**
+     * @param  string  $postId  ID of the post
+     * @param  bool  $includeDeleted  Defines if result should include deleted posts, must have 'manage_system' (admin) permission.
+     */
+    public function getFileInfosForPost(string $postId, ?bool $includeDeleted = null): Response
+    {
+        return $this->connector->send(new GetFileInfosForPost($postId, $includeDeleted));
+    }
 
+    /**
+     * @param  string  $postId  Post GUID
+     */
+    public function patchPost(string $postId): Response
+    {
+        return $this->connector->send(new PatchPost($postId));
+    }
 
-	/**
-	 * @param string $postId ID of the post to update
-	 */
-	public function updatePost(string $postId): Response
-	{
-		return $this->connector->send(new UpdatePost($postId));
-	}
+    /**
+     * @param  string  $postId  Post GUID
+     */
+    public function pinPost(string $postId): Response
+    {
+        return $this->connector->send(new PinPost($postId));
+    }
 
+    /**
+     * @param  string  $postId  ID of a post in the thread
+     * @param  int  $perPage  The number of posts per page
+     * @param  string  $fromPost  The post_id to return the next page of posts from
+     * @param  int  $fromCreateAt  The create_at timestamp to return the next page of posts from
+     * @param  string  $direction  The direction to return the posts. Either up or down.
+     * @param  bool  $skipFetchThreads  Whether to skip fetching threads or not
+     * @param  bool  $collapsedThreads  Whether the client uses CRT or not
+     * @param  bool  $collapsedThreadsExtended  Whether to return the associated users as part of the response or not
+     */
+    public function getPostThread(
+        string $postId,
+        ?int $perPage = null,
+        ?string $fromPost = null,
+        ?int $fromCreateAt = null,
+        ?string $direction = null,
+        ?bool $skipFetchThreads = null,
+        ?bool $collapsedThreads = null,
+        ?bool $collapsedThreadsExtended = null,
+    ): Response {
+        return $this->connector->send(new GetPostThread($postId, $perPage, $fromPost, $fromCreateAt, $direction, $skipFetchThreads, $collapsedThreads, $collapsedThreadsExtended));
+    }
 
-	/**
-	 * @param string $postId ID of the post to delete
-	 */
-	public function deletePost(string $postId): Response
-	{
-		return $this->connector->send(new DeletePost($postId));
-	}
+    /**
+     * @param  string  $postId  Post GUID
+     */
+    public function unpinPost(string $postId): Response
+    {
+        return $this->connector->send(new UnpinPost($postId));
+    }
 
+    /**
+     * @param  string  $teamId  Team GUID
+     */
+    public function searchPosts(string $teamId): Response
+    {
+        return $this->connector->send(new SearchPosts($teamId));
+    }
 
-	/**
-	 * @param string $postId Post GUID
-	 * @param string $actionId Action GUID
-	 */
-	public function doPostAction(string $postId, string $actionId): Response
-	{
-		return $this->connector->send(new DoPostAction($postId, $actionId));
-	}
+    /**
+     * @param  string  $userId  ID of the user
+     * @param  string  $channelId  The channel ID to get the posts for
+     * @param  int  $limitBefore  Number of posts before the oldest unread posts. Maximum is 200 posts if limit is set greater than that.
+     * @param  int  $limitAfter  Number of posts after and including the oldest unread post. Maximum is 200 posts if limit is set greater than that.
+     * @param  bool  $skipFetchThreads  Whether to skip fetching threads or not
+     * @param  bool  $collapsedThreads  Whether the client uses CRT or not
+     * @param  bool  $collapsedThreadsExtended  Whether to return the associated users as part of the response or not
+     */
+    public function getPostsAroundLastUnread(
+        string $userId,
+        string $channelId,
+        ?int $limitBefore = null,
+        ?int $limitAfter = null,
+        ?bool $skipFetchThreads = null,
+        ?bool $collapsedThreads = null,
+        ?bool $collapsedThreadsExtended = null,
+    ): Response {
+        return $this->connector->send(new GetPostsAroundLastUnread($userId, $channelId, $limitBefore, $limitAfter, $skipFetchThreads, $collapsedThreads, $collapsedThreadsExtended));
+    }
 
+    /**
+     * @param  string  $userId  ID of the user
+     * @param  string  $teamId  Team ID
+     * @param  string  $channelId  Channel ID
+     * @param  int  $page  The page to select
+     */
+    public function getFlaggedPostsForUser(
+        string $userId,
+        ?string $teamId = null,
+        ?string $channelId = null,
+        ?int $page = null,
+    ): Response {
+        return $this->connector->send(new GetFlaggedPostsForUser($userId, $teamId, $channelId, $page));
+    }
 
-	/**
-	 * @param string $postId ID of the post
-	 * @param bool $includeDeleted Defines if result should include deleted posts, must have 'manage_system' (admin) permission.
-	 */
-	public function getFileInfosForPost(string $postId, ?bool $includeDeleted = null): Response
-	{
-		return $this->connector->send(new GetFileInfosForPost($postId, $includeDeleted));
-	}
+    /**
+     * @param  string  $userId  User GUID
+     * @param  string  $postId  Post GUID
+     */
+    public function saveAcknowledgementForPost(string $userId, string $postId): Response
+    {
+        return $this->connector->send(new SaveAcknowledgementForPost($userId, $postId));
+    }
 
+    /**
+     * @todo Fix duplicated method name
+     *
+     * @param  string  $userId  User GUID
+     * @param  string  $postId  Post GUID
+     */
+    public function saveAcknowledgementForPostDuplicate1(string $userId, string $postId): Response
+    {
+        return $this->connector->send(new SaveAcknowledgementForPost($userId, $postId));
+    }
 
-	/**
-	 * @param string $postId Post GUID
-	 */
-	public function patchPost(string $postId): Response
-	{
-		return $this->connector->send(new PatchPost($postId));
-	}
+    /**
+     * @param  string  $userId  User GUID
+     * @param  string  $postId  Post GUID
+     */
+    public function setPostReminder(string $userId, string $postId): Response
+    {
+        return $this->connector->send(new SetPostReminder($userId, $postId));
+    }
 
-
-	/**
-	 * @param string $postId Post GUID
-	 */
-	public function pinPost(string $postId): Response
-	{
-		return $this->connector->send(new PinPost($postId));
-	}
-
-
-	/**
-	 * @param string $postId ID of a post in the thread
-	 * @param int $perPage The number of posts per page
-	 * @param string $fromPost The post_id to return the next page of posts from
-	 * @param int $fromCreateAt The create_at timestamp to return the next page of posts from
-	 * @param string $direction The direction to return the posts. Either up or down.
-	 * @param bool $skipFetchThreads Whether to skip fetching threads or not
-	 * @param bool $collapsedThreads Whether the client uses CRT or not
-	 * @param bool $collapsedThreadsExtended Whether to return the associated users as part of the response or not
-	 */
-	public function getPostThread(
-		string $postId,
-		?int $perPage = null,
-		?string $fromPost = null,
-		?int $fromCreateAt = null,
-		?string $direction = null,
-		?bool $skipFetchThreads = null,
-		?bool $collapsedThreads = null,
-		?bool $collapsedThreadsExtended = null,
-	): Response
-	{
-		return $this->connector->send(new GetPostThread($postId, $perPage, $fromPost, $fromCreateAt, $direction, $skipFetchThreads, $collapsedThreads, $collapsedThreadsExtended));
-	}
-
-
-	/**
-	 * @param string $postId Post GUID
-	 */
-	public function unpinPost(string $postId): Response
-	{
-		return $this->connector->send(new UnpinPost($postId));
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 */
-	public function searchPosts(string $teamId): Response
-	{
-		return $this->connector->send(new SearchPosts($teamId));
-	}
-
-
-	/**
-	 * @param string $userId ID of the user
-	 * @param string $channelId The channel ID to get the posts for
-	 * @param int $limitBefore Number of posts before the oldest unread posts. Maximum is 200 posts if limit is set greater than that.
-	 * @param int $limitAfter Number of posts after and including the oldest unread post. Maximum is 200 posts if limit is set greater than that.
-	 * @param bool $skipFetchThreads Whether to skip fetching threads or not
-	 * @param bool $collapsedThreads Whether the client uses CRT or not
-	 * @param bool $collapsedThreadsExtended Whether to return the associated users as part of the response or not
-	 */
-	public function getPostsAroundLastUnread(
-		string $userId,
-		string $channelId,
-		?int $limitBefore = null,
-		?int $limitAfter = null,
-		?bool $skipFetchThreads = null,
-		?bool $collapsedThreads = null,
-		?bool $collapsedThreadsExtended = null,
-	): Response
-	{
-		return $this->connector->send(new GetPostsAroundLastUnread($userId, $channelId, $limitBefore, $limitAfter, $skipFetchThreads, $collapsedThreads, $collapsedThreadsExtended));
-	}
-
-
-	/**
-	 * @param string $userId ID of the user
-	 * @param string $teamId Team ID
-	 * @param string $channelId Channel ID
-	 * @param int $page The page to select
-	 */
-	public function getFlaggedPostsForUser(
-		string $userId,
-		?string $teamId = null,
-		?string $channelId = null,
-		?int $page = null,
-	): Response
-	{
-		return $this->connector->send(new GetFlaggedPostsForUser($userId, $teamId, $channelId, $page));
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 * @param string $postId Post GUID
-	 */
-	public function saveAcknowledgementForPost(string $userId, string $postId): Response
-	{
-		return $this->connector->send(new SaveAcknowledgementForPost($userId, $postId));
-	}
-
-
-	/**
-	 * @todo Fix duplicated method name
-	 * @param string $userId User GUID
-	 * @param string $postId Post GUID
-	 */
-	public function saveAcknowledgementForPostDuplicate1(string $userId, string $postId): Response
-	{
-		return $this->connector->send(new SaveAcknowledgementForPost($userId, $postId));
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 * @param string $postId Post GUID
-	 */
-	public function setPostReminder(string $userId, string $postId): Response
-	{
-		return $this->connector->send(new SetPostReminder($userId, $postId));
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 * @param string $postId Post GUID
-	 */
-	public function setPostUnread(string $userId, string $postId): Response
-	{
-		return $this->connector->send(new SetPostUnread($userId, $postId));
-	}
+    /**
+     * @param  string  $userId  User GUID
+     * @param  string  $postId  Post GUID
+     */
+    public function setPostUnread(string $userId, string $postId): Response
+    {
+        return $this->connector->send(new SetPostUnread($userId, $postId));
+    }
 }

--- a/src/Client/Resource/Preferences.php
+++ b/src/Client/Resource/Preferences.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Resource;
 
 use ConduitUI\Mattermost\Client\Requests\Preferences\DeletePreferences;
@@ -12,50 +14,46 @@ use Saloon\Http\Response;
 
 class Preferences extends BaseResource
 {
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function getPreferences(string $userId): Response
-	{
-		return $this->connector->send(new GetPreferences($userId));
-	}
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function getPreferences(string $userId): Response
+    {
+        return $this->connector->send(new GetPreferences($userId));
+    }
 
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function updatePreferences(string $userId): Response
+    {
+        return $this->connector->send(new UpdatePreferences($userId));
+    }
 
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function updatePreferences(string $userId): Response
-	{
-		return $this->connector->send(new UpdatePreferences($userId));
-	}
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function deletePreferences(string $userId): Response
+    {
+        return $this->connector->send(new DeletePreferences($userId));
+    }
 
+    /**
+     * @param  string  $userId  User GUID
+     * @param  string  $category  The category of a group of preferences
+     */
+    public function getPreferencesByCategory(string $userId, string $category): Response
+    {
+        return $this->connector->send(new GetPreferencesByCategory($userId, $category));
+    }
 
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function deletePreferences(string $userId): Response
-	{
-		return $this->connector->send(new DeletePreferences($userId));
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 * @param string $category The category of a group of preferences
-	 */
-	public function getPreferencesByCategory(string $userId, string $category): Response
-	{
-		return $this->connector->send(new GetPreferencesByCategory($userId, $category));
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 * @param string $category The category of a group of preferences
-	 * @param string $preferenceName The name of the preference
-	 */
-	public function getPreferencesByCategoryByName(string $userId, string $category, string $preferenceName): Response
-	{
-		return $this->connector->send(new GetPreferencesByCategoryByName($userId, $category, $preferenceName));
-	}
+    /**
+     * @param  string  $userId  User GUID
+     * @param  string  $category  The category of a group of preferences
+     * @param  string  $preferenceName  The name of the preference
+     */
+    public function getPreferencesByCategoryByName(string $userId, string $category, string $preferenceName): Response
+    {
+        return $this->connector->send(new GetPreferencesByCategoryByName($userId, $category, $preferenceName));
+    }
 }

--- a/src/Client/Resource/Reactions.php
+++ b/src/Client/Resource/Reactions.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Resource;
 
 use ConduitUI\Mattermost\Client\Requests\Reactions\DeleteReaction;
@@ -11,34 +13,31 @@ use Saloon\Http\Response;
 
 class Reactions extends BaseResource
 {
-	public function getBulkReactions(): Response
-	{
-		return $this->connector->send(new GetBulkReactions());
-	}
+    public function getBulkReactions(): Response
+    {
+        return $this->connector->send(new GetBulkReactions);
+    }
 
+    /**
+     * @param  string  $postId  ID of a post
+     */
+    public function getReactions(string $postId): Response
+    {
+        return $this->connector->send(new GetReactions($postId));
+    }
 
-	/**
-	 * @param string $postId ID of a post
-	 */
-	public function getReactions(string $postId): Response
-	{
-		return $this->connector->send(new GetReactions($postId));
-	}
+    public function saveReaction(): Response
+    {
+        return $this->connector->send(new SaveReaction);
+    }
 
-
-	public function saveReaction(): Response
-	{
-		return $this->connector->send(new SaveReaction());
-	}
-
-
-	/**
-	 * @param string $userId ID of the user
-	 * @param string $postId ID of the post
-	 * @param string $emojiName emoji name
-	 */
-	public function deleteReaction(string $userId, string $postId, string $emojiName): Response
-	{
-		return $this->connector->send(new DeleteReaction($userId, $postId, $emojiName));
-	}
+    /**
+     * @param  string  $userId  ID of the user
+     * @param  string  $postId  ID of the post
+     * @param  string  $emojiName  emoji name
+     */
+    public function deleteReaction(string $userId, string $postId, string $emojiName): Response
+    {
+        return $this->connector->send(new DeleteReaction($userId, $postId, $emojiName));
+    }
 }

--- a/src/Client/Resource/Status.php
+++ b/src/Client/Resource/Status.php
@@ -1,9 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Resource;
 
-use ConduitUI\Mattermost\Client\Requests\Status\GetUserStatus;
 use ConduitUI\Mattermost\Client\Requests\Status\GetUsersStatusesByIds;
+use ConduitUI\Mattermost\Client\Requests\Status\GetUserStatus;
 use ConduitUI\Mattermost\Client\Requests\Status\PostUserRecentCustomStatusDelete;
 use ConduitUI\Mattermost\Client\Requests\Status\RemoveRecentCustomStatus;
 use ConduitUI\Mattermost\Client\Requests\Status\UnsetUserCustomStatus;
@@ -14,62 +16,56 @@ use Saloon\Http\Response;
 
 class Status extends BaseResource
 {
-	public function getUsersStatusesByIds(): Response
-	{
-		return $this->connector->send(new GetUsersStatusesByIds());
-	}
+    public function getUsersStatusesByIds(): Response
+    {
+        return $this->connector->send(new GetUsersStatusesByIds);
+    }
 
+    /**
+     * @param  string  $userId  User ID
+     */
+    public function getUserStatus(string $userId): Response
+    {
+        return $this->connector->send(new GetUserStatus($userId));
+    }
 
-	/**
-	 * @param string $userId User ID
-	 */
-	public function getUserStatus(string $userId): Response
-	{
-		return $this->connector->send(new GetUserStatus($userId));
-	}
+    /**
+     * @param  string  $userId  User ID
+     */
+    public function updateUserStatus(string $userId): Response
+    {
+        return $this->connector->send(new UpdateUserStatus($userId));
+    }
 
+    /**
+     * @param  string  $userId  User ID
+     */
+    public function updateUserCustomStatus(string $userId): Response
+    {
+        return $this->connector->send(new UpdateUserCustomStatus($userId));
+    }
 
-	/**
-	 * @param string $userId User ID
-	 */
-	public function updateUserStatus(string $userId): Response
-	{
-		return $this->connector->send(new UpdateUserStatus($userId));
-	}
+    /**
+     * @param  string  $userId  User ID
+     */
+    public function unsetUserCustomStatus(string $userId): Response
+    {
+        return $this->connector->send(new UnsetUserCustomStatus($userId));
+    }
 
+    /**
+     * @param  string  $userId  User ID
+     */
+    public function removeRecentCustomStatus(string $userId): Response
+    {
+        return $this->connector->send(new RemoveRecentCustomStatus($userId));
+    }
 
-	/**
-	 * @param string $userId User ID
-	 */
-	public function updateUserCustomStatus(string $userId): Response
-	{
-		return $this->connector->send(new UpdateUserCustomStatus($userId));
-	}
-
-
-	/**
-	 * @param string $userId User ID
-	 */
-	public function unsetUserCustomStatus(string $userId): Response
-	{
-		return $this->connector->send(new UnsetUserCustomStatus($userId));
-	}
-
-
-	/**
-	 * @param string $userId User ID
-	 */
-	public function removeRecentCustomStatus(string $userId): Response
-	{
-		return $this->connector->send(new RemoveRecentCustomStatus($userId));
-	}
-
-
-	/**
-	 * @param string $userId User ID
-	 */
-	public function postUserRecentCustomStatusDelete(string $userId): Response
-	{
-		return $this->connector->send(new PostUserRecentCustomStatusDelete($userId));
-	}
+    /**
+     * @param  string  $userId  User ID
+     */
+    public function postUserRecentCustomStatusDelete(string $userId): Response
+    {
+        return $this->connector->send(new PostUserRecentCustomStatusDelete($userId));
+    }
 }

--- a/src/Client/Resource/System.php
+++ b/src/Client/Resource/System.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Resource;
 
 use ConduitUI\Mattermost\Client\Requests\System\GenerateSupportPacket;
@@ -12,42 +14,38 @@ use Saloon\Http\Response;
 
 class System extends BaseResource
 {
-	public function markNoticesViewed(): Response
-	{
-		return $this->connector->send(new MarkNoticesViewed());
-	}
+    public function markNoticesViewed(): Response
+    {
+        return $this->connector->send(new MarkNoticesViewed);
+    }
 
+    /**
+     * @param  string  $teamId  ID of the team
+     * @param  string  $clientVersion  Version of the client (desktop/mobile/web) that issues the request
+     * @param  string  $locale  Client locale
+     * @param  string  $client  Client type (web/mobile-ios/mobile-android/desktop)
+     */
+    public function getNotices(string $teamId, string $clientVersion, ?string $locale, string $client): Response
+    {
+        return $this->connector->send(new GetNotices($teamId, $clientVersion, $locale, $client));
+    }
 
-	/**
-	 * @param string $teamId ID of the team
-	 * @param string $clientVersion Version of the client (desktop/mobile/web) that issues the request
-	 * @param string $locale Client locale
-	 * @param string $client Client type (web/mobile-ios/mobile-android/desktop)
-	 */
-	public function getNotices(string $teamId, string $clientVersion, ?string $locale = null, string $client): Response
-	{
-		return $this->connector->send(new GetNotices($teamId, $clientVersion, $locale, $client));
-	}
+    /**
+     * @param  bool  $getServerStatus  Check the status of the database and file storage as well
+     * @param  string  $deviceId  Check whether this device id can receive push notifications
+     */
+    public function getPing(?bool $getServerStatus = null, ?string $deviceId = null): Response
+    {
+        return $this->connector->send(new GetPing($getServerStatus, $deviceId));
+    }
 
+    public function generateSupportPacket(): Response
+    {
+        return $this->connector->send(new GenerateSupportPacket);
+    }
 
-	/**
-	 * @param bool $getServerStatus Check the status of the database and file storage as well
-	 * @param string $deviceId Check whether this device id can receive push notifications
-	 */
-	public function getPing(?bool $getServerStatus = null, ?string $deviceId = null): Response
-	{
-		return $this->connector->send(new GetPing($getServerStatus, $deviceId));
-	}
-
-
-	public function generateSupportPacket(): Response
-	{
-		return $this->connector->send(new GenerateSupportPacket());
-	}
-
-
-	public function getSupportedTimezone(): Response
-	{
-		return $this->connector->send(new GetSupportedTimezone());
-	}
+    public function getSupportedTimezone(): Response
+    {
+        return $this->connector->send(new GetSupportedTimezone);
+    }
 }

--- a/src/Client/Resource/Teams.php
+++ b/src/Client/Resource/Teams.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Resource;
 
 use ConduitUI\Mattermost\Client\Requests\Teams\AddTeamMember;
@@ -15,10 +17,10 @@ use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamMember;
 use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamMembers;
 use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamMembersByIds;
 use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamMembersForUser;
-use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamStats;
-use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamUnread;
 use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamsForUser;
+use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamStats;
 use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamsUnreadForUser;
+use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamUnread;
 use ConduitUI\Mattermost\Client\Requests\Teams\ImportTeam;
 use ConduitUI\Mattermost\Client\Requests\Teams\InvalidateEmailInvites;
 use ConduitUI\Mattermost\Client\Requests\Teams\InviteGuestsToTeam;
@@ -44,349 +46,311 @@ use Saloon\Http\Response;
 
 class Teams extends BaseResource
 {
-	/**
-	 * @param int $page The page to select.
-	 * @param bool $includeTotalCount Appends a total count of returned teams inside the response object - ex: `{ "teams": [], "total_count" : 0 }`.
-	 * @param bool $excludePolicyConstrained If set to true, teams which are part of a data retention policy will be excluded. The `sysconsole_read_compliance` permission is required to use this parameter.
-	 * __Minimum server version__: 5.35
-	 */
-	public function getAllTeams(
-		?int $page = null,
-		?bool $includeTotalCount = null,
-		?bool $excludePolicyConstrained = null,
-	): Response
-	{
-		return $this->connector->send(new GetAllTeams($page, $includeTotalCount, $excludePolicyConstrained));
-	}
-
-
-	public function createTeam(): Response
-	{
-		return $this->connector->send(new CreateTeam());
-	}
-
-
-	/**
-	 * @param string $inviteId Invite id for a team
-	 */
-	public function getTeamInviteInfo(string $inviteId): Response
-	{
-		return $this->connector->send(new GetTeamInviteInfo($inviteId));
-	}
-
-
-	public function invalidateEmailInvites(): Response
-	{
-		return $this->connector->send(new InvalidateEmailInvites());
-	}
-
-
-	/**
-	 * @param string $token Token id from the invitation
-	 */
-	public function addTeamMemberFromInvite(string $token): Response
-	{
-		return $this->connector->send(new AddTeamMemberFromInvite($token));
-	}
-
-
-	/**
-	 * @param string $name Team Name
-	 */
-	public function getTeamByName(string $name): Response
-	{
-		return $this->connector->send(new GetTeamByName($name));
-	}
-
-
-	/**
-	 * @param string $name Team Name
-	 */
-	public function teamExists(string $name): Response
-	{
-		return $this->connector->send(new TeamExists($name));
-	}
-
-
-	public function searchTeams(): Response
-	{
-		return $this->connector->send(new SearchTeams());
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 */
-	public function getTeam(string $teamId): Response
-	{
-		return $this->connector->send(new GetTeam($teamId));
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 */
-	public function updateTeam(string $teamId): Response
-	{
-		return $this->connector->send(new UpdateTeam($teamId));
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param bool $permanent Permanently delete the team, to be used for compliance reasons only. As of server version 5.0, `ServiceSettings.EnableAPITeamDeletion` must be set to `true` in the server's configuration.
-	 */
-	public function softDeleteTeam(string $teamId, ?bool $permanent = null): Response
-	{
-		return $this->connector->send(new SoftDeleteTeam($teamId, $permanent));
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 */
-	public function searchFiles(string $teamId): Response
-	{
-		return $this->connector->send(new SearchFiles($teamId));
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 */
-	public function getTeamIcon(string $teamId): Response
-	{
-		return $this->connector->send(new GetTeamIcon($teamId));
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 */
-	public function setTeamIcon(string $teamId): Response
-	{
-		return $this->connector->send(new SetTeamIcon($teamId));
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 */
-	public function removeTeamIcon(string $teamId): Response
-	{
-		return $this->connector->send(new RemoveTeamIcon($teamId));
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 */
-	public function importTeam(string $teamId): Response
-	{
-		return $this->connector->send(new ImportTeam($teamId));
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 */
-	public function inviteGuestsToTeam(string $teamId): Response
-	{
-		return $this->connector->send(new InviteGuestsToTeam($teamId));
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 */
-	public function inviteUsersToTeam(string $teamId): Response
-	{
-		return $this->connector->send(new InviteUsersToTeam($teamId));
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param int $page The page to select.
-	 */
-	public function getTeamMembers(string $teamId, ?int $page = null): Response
-	{
-		return $this->connector->send(new GetTeamMembers($teamId, $page));
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 */
-	public function addTeamMember(string $teamId): Response
-	{
-		return $this->connector->send(new AddTeamMember($teamId));
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param bool $graceful Instead of aborting the operation if a user cannot be added, return an arrray that will contain both the success and added members and the ones with error, in form of `[{"member": {...}, "user_id", "...", "error": {...}}]`
-	 */
-	public function addTeamMembers(string $teamId, ?bool $graceful = null): Response
-	{
-		return $this->connector->send(new AddTeamMembers($teamId, $graceful));
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 */
-	public function getTeamMembersByIds(string $teamId): Response
-	{
-		return $this->connector->send(new GetTeamMembersByIds($teamId));
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param string $userId User GUID
-	 */
-	public function getTeamMember(string $teamId, string $userId): Response
-	{
-		return $this->connector->send(new GetTeamMember($teamId, $userId));
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param string $userId User GUID
-	 */
-	public function removeTeamMember(string $teamId, string $userId): Response
-	{
-		return $this->connector->send(new RemoveTeamMember($teamId, $userId));
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param string $userId User GUID
-	 */
-	public function updateTeamMemberRoles(string $teamId, string $userId): Response
-	{
-		return $this->connector->send(new UpdateTeamMemberRoles($teamId, $userId));
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param string $userId User GUID
-	 */
-	public function updateTeamMemberSchemeRoles(string $teamId, string $userId): Response
-	{
-		return $this->connector->send(new UpdateTeamMemberSchemeRoles($teamId, $userId));
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 * @param string $groupIds A comma-separated list of group ids.
-	 * @param int $page The page to select.
-	 */
-	public function teamMembersMinusGroupMembers(string $teamId, string $groupIds, ?int $page = null): Response
-	{
-		return $this->connector->send(new TeamMembersMinusGroupMembers($teamId, $groupIds, $page));
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 */
-	public function patchTeam(string $teamId): Response
-	{
-		return $this->connector->send(new PatchTeam($teamId));
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 */
-	public function updateTeamPrivacy(string $teamId): Response
-	{
-		return $this->connector->send(new UpdateTeamPrivacy($teamId));
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 */
-	public function regenerateTeamInviteId(string $teamId): Response
-	{
-		return $this->connector->send(new RegenerateTeamInviteId($teamId));
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 */
-	public function restoreTeam(string $teamId): Response
-	{
-		return $this->connector->send(new RestoreTeam($teamId));
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 */
-	public function updateTeamScheme(string $teamId): Response
-	{
-		return $this->connector->send(new UpdateTeamScheme($teamId));
-	}
-
-
-	/**
-	 * @param string $teamId Team GUID
-	 */
-	public function getTeamStats(string $teamId): Response
-	{
-		return $this->connector->send(new GetTeamStats($teamId));
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function getTeamsForUser(string $userId): Response
-	{
-		return $this->connector->send(new GetTeamsForUser($userId));
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function getTeamMembersForUser(string $userId): Response
-	{
-		return $this->connector->send(new GetTeamMembersForUser($userId));
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 * @param string $excludeTeam Optional team id to be excluded from the results
-	 * @param bool $includeCollapsedThreads Boolean to determine whether the collapsed threads should be included or not
-	 */
-	public function getTeamsUnreadForUser(
-		string $userId,
-		string $excludeTeam,
-		?bool $includeCollapsedThreads = null,
-	): Response
-	{
-		return $this->connector->send(new GetTeamsUnreadForUser($userId, $excludeTeam, $includeCollapsedThreads));
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 * @param string $teamId Team GUID
-	 */
-	public function getTeamUnread(string $userId, string $teamId): Response
-	{
-		return $this->connector->send(new GetTeamUnread($userId, $teamId));
-	}
+    /**
+     * @param  int  $page  The page to select.
+     * @param  bool  $includeTotalCount  Appends a total count of returned teams inside the response object - ex: `{ "teams": [], "total_count" : 0 }`.
+     * @param  bool  $excludePolicyConstrained  If set to true, teams which are part of a data retention policy will be excluded. The `sysconsole_read_compliance` permission is required to use this parameter.
+     *                                          __Minimum server version__: 5.35
+     */
+    public function getAllTeams(
+        ?int $page = null,
+        ?bool $includeTotalCount = null,
+        ?bool $excludePolicyConstrained = null,
+    ): Response {
+        return $this->connector->send(new GetAllTeams($page, $includeTotalCount, $excludePolicyConstrained));
+    }
+
+    public function createTeam(): Response
+    {
+        return $this->connector->send(new CreateTeam);
+    }
+
+    /**
+     * @param  string  $inviteId  Invite id for a team
+     */
+    public function getTeamInviteInfo(string $inviteId): Response
+    {
+        return $this->connector->send(new GetTeamInviteInfo($inviteId));
+    }
+
+    public function invalidateEmailInvites(): Response
+    {
+        return $this->connector->send(new InvalidateEmailInvites);
+    }
+
+    /**
+     * @param  string  $token  Token id from the invitation
+     */
+    public function addTeamMemberFromInvite(string $token): Response
+    {
+        return $this->connector->send(new AddTeamMemberFromInvite($token));
+    }
+
+    /**
+     * @param  string  $name  Team Name
+     */
+    public function getTeamByName(string $name): Response
+    {
+        return $this->connector->send(new GetTeamByName($name));
+    }
+
+    /**
+     * @param  string  $name  Team Name
+     */
+    public function teamExists(string $name): Response
+    {
+        return $this->connector->send(new TeamExists($name));
+    }
+
+    public function searchTeams(): Response
+    {
+        return $this->connector->send(new SearchTeams);
+    }
+
+    /**
+     * @param  string  $teamId  Team GUID
+     */
+    public function getTeam(string $teamId): Response
+    {
+        return $this->connector->send(new GetTeam($teamId));
+    }
+
+    /**
+     * @param  string  $teamId  Team GUID
+     */
+    public function updateTeam(string $teamId): Response
+    {
+        return $this->connector->send(new UpdateTeam($teamId));
+    }
+
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  bool  $permanent  Permanently delete the team, to be used for compliance reasons only. As of server version 5.0, `ServiceSettings.EnableAPITeamDeletion` must be set to `true` in the server's configuration.
+     */
+    public function softDeleteTeam(string $teamId, ?bool $permanent = null): Response
+    {
+        return $this->connector->send(new SoftDeleteTeam($teamId, $permanent));
+    }
+
+    /**
+     * @param  string  $teamId  Team GUID
+     */
+    public function searchFiles(string $teamId): Response
+    {
+        return $this->connector->send(new SearchFiles($teamId));
+    }
+
+    /**
+     * @param  string  $teamId  Team GUID
+     */
+    public function getTeamIcon(string $teamId): Response
+    {
+        return $this->connector->send(new GetTeamIcon($teamId));
+    }
+
+    /**
+     * @param  string  $teamId  Team GUID
+     */
+    public function setTeamIcon(string $teamId): Response
+    {
+        return $this->connector->send(new SetTeamIcon($teamId));
+    }
+
+    /**
+     * @param  string  $teamId  Team GUID
+     */
+    public function removeTeamIcon(string $teamId): Response
+    {
+        return $this->connector->send(new RemoveTeamIcon($teamId));
+    }
+
+    /**
+     * @param  string  $teamId  Team GUID
+     */
+    public function importTeam(string $teamId): Response
+    {
+        return $this->connector->send(new ImportTeam($teamId));
+    }
+
+    /**
+     * @param  string  $teamId  Team GUID
+     */
+    public function inviteGuestsToTeam(string $teamId): Response
+    {
+        return $this->connector->send(new InviteGuestsToTeam($teamId));
+    }
+
+    /**
+     * @param  string  $teamId  Team GUID
+     */
+    public function inviteUsersToTeam(string $teamId): Response
+    {
+        return $this->connector->send(new InviteUsersToTeam($teamId));
+    }
+
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  int  $page  The page to select.
+     */
+    public function getTeamMembers(string $teamId, ?int $page = null): Response
+    {
+        return $this->connector->send(new GetTeamMembers($teamId, $page));
+    }
+
+    /**
+     * @param  string  $teamId  Team GUID
+     */
+    public function addTeamMember(string $teamId): Response
+    {
+        return $this->connector->send(new AddTeamMember($teamId));
+    }
+
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  bool  $graceful  Instead of aborting the operation if a user cannot be added, return an arrray that will contain both the success and added members and the ones with error, in form of `[{"member": {...}, "user_id", "...", "error": {...}}]`
+     */
+    public function addTeamMembers(string $teamId, ?bool $graceful = null): Response
+    {
+        return $this->connector->send(new AddTeamMembers($teamId, $graceful));
+    }
+
+    /**
+     * @param  string  $teamId  Team GUID
+     */
+    public function getTeamMembersByIds(string $teamId): Response
+    {
+        return $this->connector->send(new GetTeamMembersByIds($teamId));
+    }
+
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  string  $userId  User GUID
+     */
+    public function getTeamMember(string $teamId, string $userId): Response
+    {
+        return $this->connector->send(new GetTeamMember($teamId, $userId));
+    }
+
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  string  $userId  User GUID
+     */
+    public function removeTeamMember(string $teamId, string $userId): Response
+    {
+        return $this->connector->send(new RemoveTeamMember($teamId, $userId));
+    }
+
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  string  $userId  User GUID
+     */
+    public function updateTeamMemberRoles(string $teamId, string $userId): Response
+    {
+        return $this->connector->send(new UpdateTeamMemberRoles($teamId, $userId));
+    }
+
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  string  $userId  User GUID
+     */
+    public function updateTeamMemberSchemeRoles(string $teamId, string $userId): Response
+    {
+        return $this->connector->send(new UpdateTeamMemberSchemeRoles($teamId, $userId));
+    }
+
+    /**
+     * @param  string  $teamId  Team GUID
+     * @param  string  $groupIds  A comma-separated list of group ids.
+     * @param  int  $page  The page to select.
+     */
+    public function teamMembersMinusGroupMembers(string $teamId, string $groupIds, ?int $page = null): Response
+    {
+        return $this->connector->send(new TeamMembersMinusGroupMembers($teamId, $groupIds, $page));
+    }
+
+    /**
+     * @param  string  $teamId  Team GUID
+     */
+    public function patchTeam(string $teamId): Response
+    {
+        return $this->connector->send(new PatchTeam($teamId));
+    }
+
+    /**
+     * @param  string  $teamId  Team GUID
+     */
+    public function updateTeamPrivacy(string $teamId): Response
+    {
+        return $this->connector->send(new UpdateTeamPrivacy($teamId));
+    }
+
+    /**
+     * @param  string  $teamId  Team GUID
+     */
+    public function regenerateTeamInviteId(string $teamId): Response
+    {
+        return $this->connector->send(new RegenerateTeamInviteId($teamId));
+    }
+
+    /**
+     * @param  string  $teamId  Team GUID
+     */
+    public function restoreTeam(string $teamId): Response
+    {
+        return $this->connector->send(new RestoreTeam($teamId));
+    }
+
+    /**
+     * @param  string  $teamId  Team GUID
+     */
+    public function updateTeamScheme(string $teamId): Response
+    {
+        return $this->connector->send(new UpdateTeamScheme($teamId));
+    }
+
+    /**
+     * @param  string  $teamId  Team GUID
+     */
+    public function getTeamStats(string $teamId): Response
+    {
+        return $this->connector->send(new GetTeamStats($teamId));
+    }
+
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function getTeamsForUser(string $userId): Response
+    {
+        return $this->connector->send(new GetTeamsForUser($userId));
+    }
+
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function getTeamMembersForUser(string $userId): Response
+    {
+        return $this->connector->send(new GetTeamMembersForUser($userId));
+    }
+
+    /**
+     * @param  string  $userId  User GUID
+     * @param  string  $excludeTeam  Optional team id to be excluded from the results
+     * @param  bool  $includeCollapsedThreads  Boolean to determine whether the collapsed threads should be included or not
+     */
+    public function getTeamsUnreadForUser(
+        string $userId,
+        string $excludeTeam,
+        ?bool $includeCollapsedThreads = null,
+    ): Response {
+        return $this->connector->send(new GetTeamsUnreadForUser($userId, $excludeTeam, $includeCollapsedThreads));
+    }
+
+    /**
+     * @param  string  $userId  User GUID
+     * @param  string  $teamId  Team GUID
+     */
+    public function getTeamUnread(string $userId, string $teamId): Response
+    {
+        return $this->connector->send(new GetTeamUnread($userId, $teamId));
+    }
 }

--- a/src/Client/Resource/Threads.php
+++ b/src/Client/Resource/Threads.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Resource;
 
 use ConduitUI\Mattermost\Client\Requests\Threads\GetThreadMentionCountsByChannel;
@@ -15,111 +17,102 @@ use Saloon\Http\Response;
 
 class Threads extends BaseResource
 {
-	/**
-	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
-	 * @param string $teamId The ID of the team in which the thread is.
-	 * @param int $since Since filters the threads based on their LastUpdateAt timestamp.
-	 * @param bool $deleted Deleted will specify that even deleted threads should be returned (For mobile sync).
-	 * @param bool $extended Extended will enrich the response with participant details.
-	 * @param int $page Page specifies which part of the results to return, by PageSize.
-	 * @param int $pageSize PageSize specifies the size of the returned chunk of results.
-	 * @param bool $totalsOnly Setting this to true will only return the total counts.
-	 * @param bool $threadsOnly Setting this to true will only return threads.
-	 */
-	public function getUserThreads(
-		string $userId,
-		string $teamId,
-		?int $since = null,
-		?bool $deleted = null,
-		?bool $extended = null,
-		?int $page = null,
-		?int $pageSize = null,
-		?bool $totalsOnly = null,
-		?bool $threadsOnly = null,
-	): Response
-	{
-		return $this->connector->send(new GetUserThreads($userId, $teamId, $since, $deleted, $extended, $page, $pageSize, $totalsOnly, $threadsOnly));
-	}
+    /**
+     * @param  string  $userId  The ID of the user. This can also be "me" which will point to the current user.
+     * @param  string  $teamId  The ID of the team in which the thread is.
+     * @param  int  $since  Since filters the threads based on their LastUpdateAt timestamp.
+     * @param  bool  $deleted  Deleted will specify that even deleted threads should be returned (For mobile sync).
+     * @param  bool  $extended  Extended will enrich the response with participant details.
+     * @param  int  $page  Page specifies which part of the results to return, by PageSize.
+     * @param  int  $pageSize  PageSize specifies the size of the returned chunk of results.
+     * @param  bool  $totalsOnly  Setting this to true will only return the total counts.
+     * @param  bool  $threadsOnly  Setting this to true will only return threads.
+     */
+    public function getUserThreads(
+        string $userId,
+        string $teamId,
+        ?int $since = null,
+        ?bool $deleted = null,
+        ?bool $extended = null,
+        ?int $page = null,
+        ?int $pageSize = null,
+        ?bool $totalsOnly = null,
+        ?bool $threadsOnly = null,
+    ): Response {
+        return $this->connector->send(new GetUserThreads($userId, $teamId, $since, $deleted, $extended, $page, $pageSize, $totalsOnly, $threadsOnly));
+    }
 
+    /**
+     * @param  string  $userId  The ID of the user. This can also be "me" which will point to the current user.
+     * @param  string  $teamId  The ID of the team in which the thread is.
+     */
+    public function getThreadMentionCountsByChannel(string $userId, string $teamId): Response
+    {
+        return $this->connector->send(new GetThreadMentionCountsByChannel($userId, $teamId));
+    }
 
-	/**
-	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
-	 * @param string $teamId The ID of the team in which the thread is.
-	 */
-	public function getThreadMentionCountsByChannel(string $userId, string $teamId): Response
-	{
-		return $this->connector->send(new GetThreadMentionCountsByChannel($userId, $teamId));
-	}
+    /**
+     * @param  string  $userId  The ID of the user. This can also be "me" which will point to the current user.
+     * @param  string  $teamId  The ID of the team in which the thread is.
+     */
+    public function updateThreadsReadForUser(string $userId, string $teamId): Response
+    {
+        return $this->connector->send(new UpdateThreadsReadForUser($userId, $teamId));
+    }
 
+    /**
+     * @param  string  $userId  The ID of the user. This can also be "me" which will point to the current user.
+     * @param  string  $teamId  The ID of the team in which the thread is.
+     * @param  string  $threadId  The ID of the thread to follow
+     */
+    public function getUserThread(string $userId, string $teamId, string $threadId): Response
+    {
+        return $this->connector->send(new GetUserThread($userId, $teamId, $threadId));
+    }
 
-	/**
-	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
-	 * @param string $teamId The ID of the team in which the thread is.
-	 */
-	public function updateThreadsReadForUser(string $userId, string $teamId): Response
-	{
-		return $this->connector->send(new UpdateThreadsReadForUser($userId, $teamId));
-	}
+    /**
+     * @param  string  $userId  The ID of the user. This can also be "me" which will point to the current user.
+     * @param  string  $teamId  The ID of the team in which the thread is.
+     * @param  string  $threadId  The ID of the thread to follow
+     */
+    public function startFollowingThread(string $userId, string $teamId, string $threadId): Response
+    {
+        return $this->connector->send(new StartFollowingThread($userId, $teamId, $threadId));
+    }
 
+    /**
+     * @param  string  $userId  The ID of the user. This can also be "me" which will point to the current user.
+     * @param  string  $teamId  The ID of the team in which the thread is.
+     * @param  string  $threadId  The ID of the thread to update
+     */
+    public function stopFollowingThread(string $userId, string $teamId, string $threadId): Response
+    {
+        return $this->connector->send(new StopFollowingThread($userId, $teamId, $threadId));
+    }
 
-	/**
-	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
-	 * @param string $teamId The ID of the team in which the thread is.
-	 * @param string $threadId The ID of the thread to follow
-	 */
-	public function getUserThread(string $userId, string $teamId, string $threadId): Response
-	{
-		return $this->connector->send(new GetUserThread($userId, $teamId, $threadId));
-	}
+    /**
+     * @param  string  $userId  The ID of the user. This can also be "me" which will point to the current user.
+     * @param  string  $teamId  The ID of the team in which the thread is.
+     * @param  string  $threadId  The ID of the thread to update
+     * @param  string  $timestamp  The timestamp to which the thread's "last read" state will be reset.
+     */
+    public function updateThreadReadForUser(
+        string $userId,
+        string $teamId,
+        string $threadId,
+        string $timestamp,
+    ): Response {
+        return $this->connector->send(new UpdateThreadReadForUser($userId, $teamId, $threadId, $timestamp));
+    }
 
-
-	/**
-	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
-	 * @param string $teamId The ID of the team in which the thread is.
-	 * @param string $threadId The ID of the thread to follow
-	 */
-	public function startFollowingThread(string $userId, string $teamId, string $threadId): Response
-	{
-		return $this->connector->send(new StartFollowingThread($userId, $teamId, $threadId));
-	}
-
-
-	/**
-	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
-	 * @param string $teamId The ID of the team in which the thread is.
-	 * @param string $threadId The ID of the thread to update
-	 */
-	public function stopFollowingThread(string $userId, string $teamId, string $threadId): Response
-	{
-		return $this->connector->send(new StopFollowingThread($userId, $teamId, $threadId));
-	}
-
-
-	/**
-	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
-	 * @param string $teamId The ID of the team in which the thread is.
-	 * @param string $threadId The ID of the thread to update
-	 * @param string $timestamp The timestamp to which the thread's "last read" state will be reset.
-	 */
-	public function updateThreadReadForUser(
-		string $userId,
-		string $teamId,
-		string $threadId,
-		string $timestamp,
-	): Response
-	{
-		return $this->connector->send(new UpdateThreadReadForUser($userId, $teamId, $threadId, $timestamp));
-	}
-
-
-	/**
-	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
-	 * @param string $teamId The ID of the team in which the thread is.
-	 * @param string $threadId The ID of the thread to update
-	 * @param string $postId The ID of a post belonging to the thread to mark as unread.
-	 */
-	public function setThreadUnreadByPostId(string $userId, string $teamId, string $threadId, string $postId): Response
-	{
-		return $this->connector->send(new SetThreadUnreadByPostId($userId, $teamId, $threadId, $postId));
-	}
+    /**
+     * @param  string  $userId  The ID of the user. This can also be "me" which will point to the current user.
+     * @param  string  $teamId  The ID of the team in which the thread is.
+     * @param  string  $threadId  The ID of the thread to update
+     * @param  string  $postId  The ID of a post belonging to the thread to mark as unread.
+     */
+    public function setThreadUnreadByPostId(string $userId, string $teamId, string $threadId, string $postId): Response
+    {
+        return $this->connector->send(new SetThreadUnreadByPostId($userId, $teamId, $threadId, $postId));
+    }
 }

--- a/src/Client/Resource/Users.php
+++ b/src/Client/Resource/Users.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Resource;
 
 use ConduitUI\Mattermost\Client\Requests\Users\AttachDeviceId;
@@ -25,11 +27,11 @@ use ConduitUI\Mattermost\Client\Requests\Users\GetUserAccessTokensForUser;
 use ConduitUI\Mattermost\Client\Requests\Users\GetUserAudits;
 use ConduitUI\Mattermost\Client\Requests\Users\GetUserByEmail;
 use ConduitUI\Mattermost\Client\Requests\Users\GetUserByUsername;
-use ConduitUI\Mattermost\Client\Requests\Users\GetUserTermsOfService;
 use ConduitUI\Mattermost\Client\Requests\Users\GetUsers;
 use ConduitUI\Mattermost\Client\Requests\Users\GetUsersByGroupChannelIds;
 use ConduitUI\Mattermost\Client\Requests\Users\GetUsersByIds;
 use ConduitUI\Mattermost\Client\Requests\Users\GetUsersByUsernames;
+use ConduitUI\Mattermost\Client\Requests\Users\GetUserTermsOfService;
 use ConduitUI\Mattermost\Client\Requests\Users\Login;
 use ConduitUI\Mattermost\Client\Requests\Users\LoginByCwsToken;
 use ConduitUI\Mattermost\Client\Requests\Users\Logout;
@@ -63,532 +65,473 @@ use Saloon\Http\Response;
 
 class Users extends BaseResource
 {
-	/**
-	 * @param int $page The page to select.
-	 * @param string $inTeam The ID of the team to get users for.
-	 * @param string $notInTeam The ID of the team to exclude users for. Must not be used with "in_team" query parameter.
-	 * @param string $inChannel The ID of the channel to get users for.
-	 * @param string $notInChannel The ID of the channel to exclude users for. Must be used with "in_channel" query parameter.
-	 * @param string $inGroup The ID of the group to get users for. Must have `manage_system` permission.
-	 * @param bool $groupConstrained When used with `not_in_channel` or `not_in_team`, returns only the users that are allowed to join the channel or team based on its group constrains.
-	 * @param bool $withoutTeam Whether or not to list users that are not on any team. This option takes precendence over `in_team`, `in_channel`, and `not_in_channel`.
-	 * @param bool $active Whether or not to list only users that are active. This option cannot be used along with the `inactive` option.
-	 * @param bool $inactive Whether or not to list only users that are deactivated. This option cannot be used along with the `active` option.
-	 * @param string $role Returns users that have this role.
-	 * @param string $sort Sort is only available in conjunction with certain options below. The paging parameter is also always available.
-	 *
-	 * ##### `in_team`
-	 * Can be "", "last_activity_at" or "create_at".
-	 * When left blank, sorting is done by username.
-	 * __Minimum server version__: 4.0
-	 * ##### `in_channel`
-	 * Can be "", "status".
-	 * When left blank, sorting is done by username. `status` will sort by User's current status (Online, Away, DND, Offline), then by Username.
-	 * __Minimum server version__: 4.7
-	 * ##### `in_group`
-	 * Can be "", "display_name".
-	 * When left blank, sorting is done by username. `display_name` will sort alphabetically by user's display name.
-	 * __Minimum server version__: 7.7
-	 * @param string $roles Comma separated string used to filter users based on any of the specified system roles
-	 *
-	 * Example: `?roles=system_admin,system_user` will return users that are either system admins or system users
-	 *
-	 * __Minimum server version__: 5.26
-	 * @param string $channelRoles Comma separated string used to filter users based on any of the specified channel roles, can only be used in conjunction with `in_channel`
-	 *
-	 * Example: `?in_channel=4eb6axxw7fg3je5iyasnfudc5y&channel_roles=channel_user` will return users that are only channel users and not admins or guests
-	 *
-	 * __Minimum server version__: 5.26
-	 * @param string $teamRoles Comma separated string used to filter users based on any of the specified team roles, can only be used in conjunction with `in_team`
-	 *
-	 * Example: `?in_team=4eb6axxw7fg3je5iyasnfudc5y&team_roles=team_user` will return users that are only team users and not admins or guests
-	 *
-	 * __Minimum server version__: 5.26
-	 */
-	public function getUsers(
-		?int $page = null,
-		?string $inTeam = null,
-		?string $notInTeam = null,
-		?string $inChannel = null,
-		?string $notInChannel = null,
-		?string $inGroup = null,
-		?bool $groupConstrained = null,
-		?bool $withoutTeam = null,
-		?bool $active = null,
-		?bool $inactive = null,
-		?string $role = null,
-		?string $sort = null,
-		?string $roles = null,
-		?string $channelRoles = null,
-		?string $teamRoles = null,
-	): Response
-	{
-		return $this->connector->send(new GetUsers($page, $inTeam, $notInTeam, $inChannel, $notInChannel, $inGroup, $groupConstrained, $withoutTeam, $active, $inactive, $role, $sort, $roles, $channelRoles, $teamRoles));
-	}
-
-
-	/**
-	 * @param string $t Token id from an email invitation
-	 * @param string $iid Token id from an invitation link
-	 */
-	public function createUser(?string $t = null, ?string $iid = null): Response
-	{
-		return $this->connector->send(new CreateUser($t, $iid));
-	}
-
-
-	public function permanentDeleteAllUsers(): Response
-	{
-		return $this->connector->send(new PermanentDeleteAllUsers());
-	}
-
-
-	/**
-	 * @param string $teamId Team ID
-	 * @param string $channelId Channel ID
-	 * @param string $name Username, nickname first name or last name
-	 * @param int $limit The maximum number of users to return in each subresult
-	 *
-	 * __Available as of server version 5.6. Defaults to `100` if not provided or on an earlier server version.__
-	 */
-	public function autocompleteUsers(
-		?string $teamId = null,
-		?string $channelId = null,
-		string $name,
-		?int $limit = null,
-	): Response
-	{
-		return $this->connector->send(new AutocompleteUsers($teamId, $channelId, $name, $limit));
-	}
-
-
-	public function verifyUserEmail(): Response
-	{
-		return $this->connector->send(new VerifyUserEmail());
-	}
-
-
-	public function sendVerificationEmail(): Response
-	{
-		return $this->connector->send(new SendVerificationEmail());
-	}
-
-
-	/**
-	 * @param string $email User Email
-	 */
-	public function getUserByEmail(string $email): Response
-	{
-		return $this->connector->send(new GetUserByEmail($email));
-	}
-
-
-	public function getUsersByGroupChannelIds(): Response
-	{
-		return $this->connector->send(new GetUsersByGroupChannelIds());
-	}
-
-
-	/**
-	 * @param int $since Only return users that have been modified since the given Unix timestamp (in milliseconds).
-	 *
-	 * __Minimum server version__: 5.14
-	 */
-	public function getUsersByIds(?int $since = null): Response
-	{
-		return $this->connector->send(new GetUsersByIds($since));
-	}
-
-
-	public function getKnownUsers(): Response
-	{
-		return $this->connector->send(new GetKnownUsers());
-	}
-
-
-	public function login(): Response
-	{
-		return $this->connector->send(new Login());
-	}
-
-
-	public function loginByCwsToken(): Response
-	{
-		return $this->connector->send(new LoginByCwsToken());
-	}
-
-
-	public function switchAccountType(): Response
-	{
-		return $this->connector->send(new SwitchAccountType());
-	}
-
-
-	public function logout(): Response
-	{
-		return $this->connector->send(new Logout());
-	}
-
-
-	public function checkUserMfa(): Response
-	{
-		return $this->connector->send(new CheckUserMfa());
-	}
-
-
-	public function migrateAuthToLdap(): Response
-	{
-		return $this->connector->send(new MigrateAuthToLdap());
-	}
-
-
-	public function migrateAuthToSaml(): Response
-	{
-		return $this->connector->send(new MigrateAuthToSaml());
-	}
-
-
-	public function resetPassword(): Response
-	{
-		return $this->connector->send(new ResetPassword());
-	}
-
-
-	public function sendPasswordResetEmail(): Response
-	{
-		return $this->connector->send(new SendPasswordResetEmail());
-	}
-
-
-	public function searchUsers(): Response
-	{
-		return $this->connector->send(new SearchUsers());
-	}
-
-
-	public function attachDeviceId(): Response
-	{
-		return $this->connector->send(new AttachDeviceId());
-	}
-
-
-	public function revokeSessionsFromAllUsers(): Response
-	{
-		return $this->connector->send(new RevokeSessionsFromAllUsers());
-	}
-
-
-	public function getTotalUsersStats(): Response
-	{
-		return $this->connector->send(new GetTotalUsersStats());
-	}
-
-
-	/**
-	 * @param string $inTeam The ID of the team to get user stats for.
-	 * @param string $inChannel The ID of the channel to get user stats for.
-	 * @param bool $includeDeleted If deleted accounts should be included in the count.
-	 * @param bool $includeBots If bot accounts should be included in the count.
-	 * @param string $roles Comma separated string used to filter users based on any of the specified system roles
-	 *
-	 * Example: `?roles=system_admin,system_user` will include users that are either system admins or system users
-	 * @param string $channelRoles Comma separated string used to filter users based on any of the specified channel roles, can only be used in conjunction with `in_channel`
-	 *
-	 * Example: `?in_channel=4eb6axxw7fg3je5iyasnfudc5y&channel_roles=channel_user` will include users that are only channel users and not admins or guests
-	 * @param string $teamRoles Comma separated string used to filter users based on any of the specified team roles, can only be used in conjunction with `in_team`
-	 *
-	 * Example: `?in_team=4eb6axxw7fg3je5iyasnfudc5y&team_roles=team_user` will include users that are only team users and not admins or guests
-	 */
-	public function getTotalUsersStatsFiltered(
-		?string $inTeam = null,
-		?string $inChannel = null,
-		?bool $includeDeleted = null,
-		?bool $includeBots = null,
-		?string $roles = null,
-		?string $channelRoles = null,
-		?string $teamRoles = null,
-	): Response
-	{
-		return $this->connector->send(new GetTotalUsersStatsFiltered($inTeam, $inChannel, $includeDeleted, $includeBots, $roles, $channelRoles, $teamRoles));
-	}
-
-
-	/**
-	 * @param int $page The page to select.
-	 */
-	public function getUserAccessTokens(?int $page = null): Response
-	{
-		return $this->connector->send(new GetUserAccessTokens($page));
-	}
-
-
-	public function disableUserAccessToken(): Response
-	{
-		return $this->connector->send(new DisableUserAccessToken());
-	}
-
-
-	public function enableUserAccessToken(): Response
-	{
-		return $this->connector->send(new EnableUserAccessToken());
-	}
-
-
-	public function revokeUserAccessToken(): Response
-	{
-		return $this->connector->send(new RevokeUserAccessToken());
-	}
-
-
-	public function searchUserAccessTokens(): Response
-	{
-		return $this->connector->send(new SearchUserAccessTokens());
-	}
-
-
-	/**
-	 * @param string $tokenId User access token GUID
-	 */
-	public function getUserAccessToken(string $tokenId): Response
-	{
-		return $this->connector->send(new GetUserAccessToken($tokenId));
-	}
-
-
-	/**
-	 * @param string $username Username
-	 */
-	public function getUserByUsername(string $username): Response
-	{
-		return $this->connector->send(new GetUserByUsername($username));
-	}
-
-
-	public function getUsersByUsernames(): Response
-	{
-		return $this->connector->send(new GetUsersByUsernames());
-	}
-
-
-	/**
-	 * @param string $userId User GUID. This can also be "me" which will point to the current user.
-	 */
-	public function getUser(string $userId): Response
-	{
-		return $this->connector->send(new GetUser($userId));
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function updateUser(string $userId): Response
-	{
-		return $this->connector->send(new UpdateUser($userId));
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function deleteUser(string $userId): Response
-	{
-		return $this->connector->send(new DeleteUser($userId));
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function updateUserActive(string $userId): Response
-	{
-		return $this->connector->send(new UpdateUserActive($userId));
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function getUserAudits(string $userId): Response
-	{
-		return $this->connector->send(new GetUserAudits($userId));
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function updateUserAuth(string $userId): Response
-	{
-		return $this->connector->send(new UpdateUserAuth($userId));
-	}
-
-
-	/**
-	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
-	 * @param int $page Page specifies which part of the results to return, by PageSize.
-	 * @param int $pageSize PageSize specifies the size of the returned chunk of results.
-	 */
-	public function getChannelMembersWithTeamDataForUser(
-		string $userId,
-		?int $page = null,
-		?int $pageSize = null,
-	): Response
-	{
-		return $this->connector->send(new GetChannelMembersWithTeamDataForUser($userId, $page, $pageSize));
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function demoteUserToGuest(string $userId): Response
-	{
-		return $this->connector->send(new DemoteUserToGuest($userId));
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function verifyUserEmailWithoutToken(string $userId): Response
-	{
-		return $this->connector->send(new VerifyUserEmailWithoutToken($userId));
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function updateUserMfa(string $userId): Response
-	{
-		return $this->connector->send(new UpdateUserMfa($userId));
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function generateMfaSecret(string $userId): Response
-	{
-		return $this->connector->send(new GenerateMfaSecret($userId));
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function updateUserPassword(string $userId): Response
-	{
-		return $this->connector->send(new UpdateUserPassword($userId));
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function patchUser(string $userId): Response
-	{
-		return $this->connector->send(new PatchUser($userId));
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function promoteGuestToUser(string $userId): Response
-	{
-		return $this->connector->send(new PromoteGuestToUser($userId));
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function updateUserRoles(string $userId): Response
-	{
-		return $this->connector->send(new UpdateUserRoles($userId));
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function getSessions(string $userId): Response
-	{
-		return $this->connector->send(new GetSessions($userId));
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function revokeSession(string $userId): Response
-	{
-		return $this->connector->send(new RevokeSession($userId));
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function revokeAllSessions(string $userId): Response
-	{
-		return $this->connector->send(new RevokeAllSessions($userId));
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function getUserTermsOfService(string $userId): Response
-	{
-		return $this->connector->send(new GetUserTermsOfService($userId));
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function registerTermsOfServiceAction(string $userId): Response
-	{
-		return $this->connector->send(new RegisterTermsOfServiceAction($userId));
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 * @param int $page The page to select.
-	 */
-	public function getUserAccessTokensForUser(string $userId, ?int $page = null): Response
-	{
-		return $this->connector->send(new GetUserAccessTokensForUser($userId, $page));
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function createUserAccessToken(string $userId): Response
-	{
-		return $this->connector->send(new CreateUserAccessToken($userId));
-	}
-
-
-	/**
-	 * @param string $userId User GUID
-	 */
-	public function publishUserTyping(string $userId): Response
-	{
-		return $this->connector->send(new PublishUserTyping($userId));
-	}
-
-
-	/**
-	 * @param string $userId The ID of the user. This can also be "me" which will point to the current user.
-	 */
-	public function getUploadsForUser(string $userId): Response
-	{
-		return $this->connector->send(new GetUploadsForUser($userId));
-	}
+    /**
+     * @param  int  $page  The page to select.
+     * @param  string  $inTeam  The ID of the team to get users for.
+     * @param  string  $notInTeam  The ID of the team to exclude users for. Must not be used with "in_team" query parameter.
+     * @param  string  $inChannel  The ID of the channel to get users for.
+     * @param  string  $notInChannel  The ID of the channel to exclude users for. Must be used with "in_channel" query parameter.
+     * @param  string  $inGroup  The ID of the group to get users for. Must have `manage_system` permission.
+     * @param  bool  $groupConstrained  When used with `not_in_channel` or `not_in_team`, returns only the users that are allowed to join the channel or team based on its group constrains.
+     * @param  bool  $withoutTeam  Whether or not to list users that are not on any team. This option takes precendence over `in_team`, `in_channel`, and `not_in_channel`.
+     * @param  bool  $active  Whether or not to list only users that are active. This option cannot be used along with the `inactive` option.
+     * @param  bool  $inactive  Whether or not to list only users that are deactivated. This option cannot be used along with the `active` option.
+     * @param  string  $role  Returns users that have this role.
+     * @param  string  $sort  Sort is only available in conjunction with certain options below. The paging parameter is also always available.
+     *
+     * ##### `in_team`
+     * Can be "", "last_activity_at" or "create_at".
+     * When left blank, sorting is done by username.
+     * __Minimum server version__: 4.0
+     * ##### `in_channel`
+     * Can be "", "status".
+     * When left blank, sorting is done by username. `status` will sort by User's current status (Online, Away, DND, Offline), then by Username.
+     * __Minimum server version__: 4.7
+     * ##### `in_group`
+     * Can be "", "display_name".
+     * When left blank, sorting is done by username. `display_name` will sort alphabetically by user's display name.
+     * __Minimum server version__: 7.7
+     * @param  string  $roles  Comma separated string used to filter users based on any of the specified system roles
+     *
+     * Example: `?roles=system_admin,system_user` will return users that are either system admins or system users
+     *
+     * __Minimum server version__: 5.26
+     * @param  string  $channelRoles  Comma separated string used to filter users based on any of the specified channel roles, can only be used in conjunction with `in_channel`
+     *
+     * Example: `?in_channel=4eb6axxw7fg3je5iyasnfudc5y&channel_roles=channel_user` will return users that are only channel users and not admins or guests
+     *
+     * __Minimum server version__: 5.26
+     * @param  string  $teamRoles  Comma separated string used to filter users based on any of the specified team roles, can only be used in conjunction with `in_team`
+     *
+     * Example: `?in_team=4eb6axxw7fg3je5iyasnfudc5y&team_roles=team_user` will return users that are only team users and not admins or guests
+     *
+     * __Minimum server version__: 5.26
+     */
+    public function getUsers(
+        ?int $page = null,
+        ?string $inTeam = null,
+        ?string $notInTeam = null,
+        ?string $inChannel = null,
+        ?string $notInChannel = null,
+        ?string $inGroup = null,
+        ?bool $groupConstrained = null,
+        ?bool $withoutTeam = null,
+        ?bool $active = null,
+        ?bool $inactive = null,
+        ?string $role = null,
+        ?string $sort = null,
+        ?string $roles = null,
+        ?string $channelRoles = null,
+        ?string $teamRoles = null,
+    ): Response {
+        return $this->connector->send(new GetUsers($page, $inTeam, $notInTeam, $inChannel, $notInChannel, $inGroup, $groupConstrained, $withoutTeam, $active, $inactive, $role, $sort, $roles, $channelRoles, $teamRoles));
+    }
+
+    /**
+     * @param  string  $t  Token id from an email invitation
+     * @param  string  $iid  Token id from an invitation link
+     */
+    public function createUser(?string $t = null, ?string $iid = null): Response
+    {
+        return $this->connector->send(new CreateUser($t, $iid));
+    }
+
+    public function permanentDeleteAllUsers(): Response
+    {
+        return $this->connector->send(new PermanentDeleteAllUsers);
+    }
+
+    /**
+     * @param  string  $teamId  Team ID
+     * @param  string  $channelId  Channel ID
+     * @param  string  $name  Username, nickname first name or last name
+     * @param  int  $limit  The maximum number of users to return in each subresult
+     *
+     * __Available as of server version 5.6. Defaults to `100` if not provided or on an earlier server version.__
+     */
+    public function autocompleteUsers(
+        ?string $teamId,
+        ?string $channelId,
+        string $name,
+        ?int $limit = null,
+    ): Response {
+        return $this->connector->send(new AutocompleteUsers($teamId, $channelId, $name, $limit));
+    }
+
+    public function verifyUserEmail(): Response
+    {
+        return $this->connector->send(new VerifyUserEmail);
+    }
+
+    public function sendVerificationEmail(): Response
+    {
+        return $this->connector->send(new SendVerificationEmail);
+    }
+
+    /**
+     * @param  string  $email  User Email
+     */
+    public function getUserByEmail(string $email): Response
+    {
+        return $this->connector->send(new GetUserByEmail($email));
+    }
+
+    public function getUsersByGroupChannelIds(): Response
+    {
+        return $this->connector->send(new GetUsersByGroupChannelIds);
+    }
+
+    /**
+     * @param  int  $since  Only return users that have been modified since the given Unix timestamp (in milliseconds).
+     *
+     * __Minimum server version__: 5.14
+     */
+    public function getUsersByIds(?int $since = null): Response
+    {
+        return $this->connector->send(new GetUsersByIds($since));
+    }
+
+    public function getKnownUsers(): Response
+    {
+        return $this->connector->send(new GetKnownUsers);
+    }
+
+    public function login(): Response
+    {
+        return $this->connector->send(new Login);
+    }
+
+    public function loginByCwsToken(): Response
+    {
+        return $this->connector->send(new LoginByCwsToken);
+    }
+
+    public function switchAccountType(): Response
+    {
+        return $this->connector->send(new SwitchAccountType);
+    }
+
+    public function logout(): Response
+    {
+        return $this->connector->send(new Logout);
+    }
+
+    public function checkUserMfa(): Response
+    {
+        return $this->connector->send(new CheckUserMfa);
+    }
+
+    public function migrateAuthToLdap(): Response
+    {
+        return $this->connector->send(new MigrateAuthToLdap);
+    }
+
+    public function migrateAuthToSaml(): Response
+    {
+        return $this->connector->send(new MigrateAuthToSaml);
+    }
+
+    public function resetPassword(): Response
+    {
+        return $this->connector->send(new ResetPassword);
+    }
+
+    public function sendPasswordResetEmail(): Response
+    {
+        return $this->connector->send(new SendPasswordResetEmail);
+    }
+
+    public function searchUsers(): Response
+    {
+        return $this->connector->send(new SearchUsers);
+    }
+
+    public function attachDeviceId(): Response
+    {
+        return $this->connector->send(new AttachDeviceId);
+    }
+
+    public function revokeSessionsFromAllUsers(): Response
+    {
+        return $this->connector->send(new RevokeSessionsFromAllUsers);
+    }
+
+    public function getTotalUsersStats(): Response
+    {
+        return $this->connector->send(new GetTotalUsersStats);
+    }
+
+    /**
+     * @param  string  $inTeam  The ID of the team to get user stats for.
+     * @param  string  $inChannel  The ID of the channel to get user stats for.
+     * @param  bool  $includeDeleted  If deleted accounts should be included in the count.
+     * @param  bool  $includeBots  If bot accounts should be included in the count.
+     * @param  string  $roles  Comma separated string used to filter users based on any of the specified system roles
+     *
+     * Example: `?roles=system_admin,system_user` will include users that are either system admins or system users
+     * @param  string  $channelRoles  Comma separated string used to filter users based on any of the specified channel roles, can only be used in conjunction with `in_channel`
+     *
+     * Example: `?in_channel=4eb6axxw7fg3je5iyasnfudc5y&channel_roles=channel_user` will include users that are only channel users and not admins or guests
+     * @param  string  $teamRoles  Comma separated string used to filter users based on any of the specified team roles, can only be used in conjunction with `in_team`
+     *
+     * Example: `?in_team=4eb6axxw7fg3je5iyasnfudc5y&team_roles=team_user` will include users that are only team users and not admins or guests
+     */
+    public function getTotalUsersStatsFiltered(
+        ?string $inTeam = null,
+        ?string $inChannel = null,
+        ?bool $includeDeleted = null,
+        ?bool $includeBots = null,
+        ?string $roles = null,
+        ?string $channelRoles = null,
+        ?string $teamRoles = null,
+    ): Response {
+        return $this->connector->send(new GetTotalUsersStatsFiltered($inTeam, $inChannel, $includeDeleted, $includeBots, $roles, $channelRoles, $teamRoles));
+    }
+
+    /**
+     * @param  int  $page  The page to select.
+     */
+    public function getUserAccessTokens(?int $page = null): Response
+    {
+        return $this->connector->send(new GetUserAccessTokens($page));
+    }
+
+    public function disableUserAccessToken(): Response
+    {
+        return $this->connector->send(new DisableUserAccessToken);
+    }
+
+    public function enableUserAccessToken(): Response
+    {
+        return $this->connector->send(new EnableUserAccessToken);
+    }
+
+    public function revokeUserAccessToken(): Response
+    {
+        return $this->connector->send(new RevokeUserAccessToken);
+    }
+
+    public function searchUserAccessTokens(): Response
+    {
+        return $this->connector->send(new SearchUserAccessTokens);
+    }
+
+    /**
+     * @param  string  $tokenId  User access token GUID
+     */
+    public function getUserAccessToken(string $tokenId): Response
+    {
+        return $this->connector->send(new GetUserAccessToken($tokenId));
+    }
+
+    /**
+     * @param  string  $username  Username
+     */
+    public function getUserByUsername(string $username): Response
+    {
+        return $this->connector->send(new GetUserByUsername($username));
+    }
+
+    public function getUsersByUsernames(): Response
+    {
+        return $this->connector->send(new GetUsersByUsernames);
+    }
+
+    /**
+     * @param  string  $userId  User GUID. This can also be "me" which will point to the current user.
+     */
+    public function getUser(string $userId): Response
+    {
+        return $this->connector->send(new GetUser($userId));
+    }
+
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function updateUser(string $userId): Response
+    {
+        return $this->connector->send(new UpdateUser($userId));
+    }
+
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function deleteUser(string $userId): Response
+    {
+        return $this->connector->send(new DeleteUser($userId));
+    }
+
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function updateUserActive(string $userId): Response
+    {
+        return $this->connector->send(new UpdateUserActive($userId));
+    }
+
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function getUserAudits(string $userId): Response
+    {
+        return $this->connector->send(new GetUserAudits($userId));
+    }
+
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function updateUserAuth(string $userId): Response
+    {
+        return $this->connector->send(new UpdateUserAuth($userId));
+    }
+
+    /**
+     * @param  string  $userId  The ID of the user. This can also be "me" which will point to the current user.
+     * @param  int  $page  Page specifies which part of the results to return, by PageSize.
+     * @param  int  $pageSize  PageSize specifies the size of the returned chunk of results.
+     */
+    public function getChannelMembersWithTeamDataForUser(
+        string $userId,
+        ?int $page = null,
+        ?int $pageSize = null,
+    ): Response {
+        return $this->connector->send(new GetChannelMembersWithTeamDataForUser($userId, $page, $pageSize));
+    }
+
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function demoteUserToGuest(string $userId): Response
+    {
+        return $this->connector->send(new DemoteUserToGuest($userId));
+    }
+
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function verifyUserEmailWithoutToken(string $userId): Response
+    {
+        return $this->connector->send(new VerifyUserEmailWithoutToken($userId));
+    }
+
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function updateUserMfa(string $userId): Response
+    {
+        return $this->connector->send(new UpdateUserMfa($userId));
+    }
+
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function generateMfaSecret(string $userId): Response
+    {
+        return $this->connector->send(new GenerateMfaSecret($userId));
+    }
+
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function updateUserPassword(string $userId): Response
+    {
+        return $this->connector->send(new UpdateUserPassword($userId));
+    }
+
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function patchUser(string $userId): Response
+    {
+        return $this->connector->send(new PatchUser($userId));
+    }
+
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function promoteGuestToUser(string $userId): Response
+    {
+        return $this->connector->send(new PromoteGuestToUser($userId));
+    }
+
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function updateUserRoles(string $userId): Response
+    {
+        return $this->connector->send(new UpdateUserRoles($userId));
+    }
+
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function getSessions(string $userId): Response
+    {
+        return $this->connector->send(new GetSessions($userId));
+    }
+
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function revokeSession(string $userId): Response
+    {
+        return $this->connector->send(new RevokeSession($userId));
+    }
+
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function revokeAllSessions(string $userId): Response
+    {
+        return $this->connector->send(new RevokeAllSessions($userId));
+    }
+
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function getUserTermsOfService(string $userId): Response
+    {
+        return $this->connector->send(new GetUserTermsOfService($userId));
+    }
+
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function registerTermsOfServiceAction(string $userId): Response
+    {
+        return $this->connector->send(new RegisterTermsOfServiceAction($userId));
+    }
+
+    /**
+     * @param  string  $userId  User GUID
+     * @param  int  $page  The page to select.
+     */
+    public function getUserAccessTokensForUser(string $userId, ?int $page = null): Response
+    {
+        return $this->connector->send(new GetUserAccessTokensForUser($userId, $page));
+    }
+
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function createUserAccessToken(string $userId): Response
+    {
+        return $this->connector->send(new CreateUserAccessToken($userId));
+    }
+
+    /**
+     * @param  string  $userId  User GUID
+     */
+    public function publishUserTyping(string $userId): Response
+    {
+        return $this->connector->send(new PublishUserTyping($userId));
+    }
+
+    /**
+     * @param  string  $userId  The ID of the user. This can also be "me" which will point to the current user.
+     */
+    public function getUploadsForUser(string $userId): Response
+    {
+        return $this->connector->send(new GetUploadsForUser($userId));
+    }
 }

--- a/src/Client/Resource/Webhooks.php
+++ b/src/Client/Resource/Webhooks.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client\Resource;
 
 use ConduitUI\Mattermost\Client\Requests\Webhooks\CreateIncomingWebhook;
@@ -18,98 +20,88 @@ use Saloon\Http\Response;
 
 class Webhooks extends BaseResource
 {
-	/**
-	 * @param int $page The page to select.
-	 * @param string $teamId The ID of the team to get hooks for.
-	 */
-	public function getIncomingWebhooks(?int $page = null, ?string $teamId = null): Response
-	{
-		return $this->connector->send(new GetIncomingWebhooks($page, $teamId));
-	}
+    /**
+     * @param  int  $page  The page to select.
+     * @param  string  $teamId  The ID of the team to get hooks for.
+     */
+    public function getIncomingWebhooks(?int $page = null, ?string $teamId = null): Response
+    {
+        return $this->connector->send(new GetIncomingWebhooks($page, $teamId));
+    }
 
+    public function createIncomingWebhook(): Response
+    {
+        return $this->connector->send(new CreateIncomingWebhook);
+    }
 
-	public function createIncomingWebhook(): Response
-	{
-		return $this->connector->send(new CreateIncomingWebhook());
-	}
+    /**
+     * @param  string  $hookId  Incoming Webhook GUID
+     */
+    public function getIncomingWebhook(string $hookId): Response
+    {
+        return $this->connector->send(new GetIncomingWebhook($hookId));
+    }
 
+    /**
+     * @param  string  $hookId  Incoming Webhook GUID
+     */
+    public function updateIncomingWebhook(string $hookId): Response
+    {
+        return $this->connector->send(new UpdateIncomingWebhook($hookId));
+    }
 
-	/**
-	 * @param string $hookId Incoming Webhook GUID
-	 */
-	public function getIncomingWebhook(string $hookId): Response
-	{
-		return $this->connector->send(new GetIncomingWebhook($hookId));
-	}
+    /**
+     * @param  string  $hookId  Incoming webhook GUID
+     */
+    public function deleteIncomingWebhook(string $hookId): Response
+    {
+        return $this->connector->send(new DeleteIncomingWebhook($hookId));
+    }
 
+    /**
+     * @param  int  $page  The page to select.
+     * @param  string  $teamId  The ID of the team to get hooks for.
+     * @param  string  $channelId  The ID of the channel to get hooks for.
+     */
+    public function getOutgoingWebhooks(?int $page = null, ?string $teamId = null, ?string $channelId = null): Response
+    {
+        return $this->connector->send(new GetOutgoingWebhooks($page, $teamId, $channelId));
+    }
 
-	/**
-	 * @param string $hookId Incoming Webhook GUID
-	 */
-	public function updateIncomingWebhook(string $hookId): Response
-	{
-		return $this->connector->send(new UpdateIncomingWebhook($hookId));
-	}
+    public function createOutgoingWebhook(): Response
+    {
+        return $this->connector->send(new CreateOutgoingWebhook);
+    }
 
+    /**
+     * @param  string  $hookId  Outgoing webhook GUID
+     */
+    public function getOutgoingWebhook(string $hookId): Response
+    {
+        return $this->connector->send(new GetOutgoingWebhook($hookId));
+    }
 
-	/**
-	 * @param string $hookId Incoming webhook GUID
-	 */
-	public function deleteIncomingWebhook(string $hookId): Response
-	{
-		return $this->connector->send(new DeleteIncomingWebhook($hookId));
-	}
+    /**
+     * @param  string  $hookId  outgoing Webhook GUID
+     */
+    public function updateOutgoingWebhook(string $hookId): Response
+    {
+        return $this->connector->send(new UpdateOutgoingWebhook($hookId));
+    }
 
+    /**
+     * @param  string  $hookId  Outgoing webhook GUID
+     */
+    public function deleteOutgoingWebhook(string $hookId): Response
+    {
+        return $this->connector->send(new DeleteOutgoingWebhook($hookId));
+    }
 
-	/**
-	 * @param int $page The page to select.
-	 * @param string $teamId The ID of the team to get hooks for.
-	 * @param string $channelId The ID of the channel to get hooks for.
-	 */
-	public function getOutgoingWebhooks(?int $page = null, ?string $teamId = null, ?string $channelId = null): Response
-	{
-		return $this->connector->send(new GetOutgoingWebhooks($page, $teamId, $channelId));
-	}
-
-
-	public function createOutgoingWebhook(): Response
-	{
-		return $this->connector->send(new CreateOutgoingWebhook());
-	}
-
-
-	/**
-	 * @param string $hookId Outgoing webhook GUID
-	 */
-	public function getOutgoingWebhook(string $hookId): Response
-	{
-		return $this->connector->send(new GetOutgoingWebhook($hookId));
-	}
-
-
-	/**
-	 * @param string $hookId outgoing Webhook GUID
-	 */
-	public function updateOutgoingWebhook(string $hookId): Response
-	{
-		return $this->connector->send(new UpdateOutgoingWebhook($hookId));
-	}
-
-
-	/**
-	 * @param string $hookId Outgoing webhook GUID
-	 */
-	public function deleteOutgoingWebhook(string $hookId): Response
-	{
-		return $this->connector->send(new DeleteOutgoingWebhook($hookId));
-	}
-
-
-	/**
-	 * @param string $hookId Outgoing webhook GUID
-	 */
-	public function regenOutgoingHookToken(string $hookId): Response
-	{
-		return $this->connector->send(new RegenOutgoingHookToken($hookId));
-	}
+    /**
+     * @param  string  $hookId  Outgoing webhook GUID
+     */
+    public function regenOutgoingHookToken(string $hookId): Response
+    {
+        return $this->connector->send(new RegenOutgoingHookToken($hookId));
+    }
 }

--- a/src/Client/tests/BotsTest.php
+++ b/src/Client/tests/BotsTest.php
@@ -2,159 +2,150 @@
 
 // Generated 2026-04-10 23:46:41
 
-use ConduitUI\Mattermost\Client\Requests\Bots\GetBots;
-use ConduitUI\Mattermost\Client\Requests\Bots\CreateBot;
-use ConduitUI\Mattermost\Client\Requests\Bots\GetBot;
-use ConduitUI\Mattermost\Client\Requests\Bots\PatchBot;
+use ConduitUI\Mattermost\Client\Mattermost;
 use ConduitUI\Mattermost\Client\Requests\Bots\AssignBot;
 use ConduitUI\Mattermost\Client\Requests\Bots\ConvertBotToUser;
+use ConduitUI\Mattermost\Client\Requests\Bots\ConvertUserToBot;
+use ConduitUI\Mattermost\Client\Requests\Bots\CreateBot;
 use ConduitUI\Mattermost\Client\Requests\Bots\DisableBot;
 use ConduitUI\Mattermost\Client\Requests\Bots\EnableBot;
-use ConduitUI\Mattermost\Client\Requests\Bots\ConvertUserToBot;
+use ConduitUI\Mattermost\Client\Requests\Bots\GetBot;
+use ConduitUI\Mattermost\Client\Requests\Bots\GetBots;
+use ConduitUI\Mattermost\Client\Requests\Bots\PatchBot;
 use Saloon\Http\Faking\MockResponse;
 use Saloon\Laravel\Facades\Saloon;
-use Spatie\LaravelData\DataCollection;
 
-beforeEach(function () {
-    $this->mattermost = new ConduitUI\Mattermost\Client\Mattermost(
-		bearerToken: 'replace'
-	);
+beforeEach(function (): void {
+    $this->mattermost = new Mattermost(
+        bearerToken: 'replace'
+    );
 });
 
-
-it('calls the getBots method in the Bots resource', function () {
+it('calls the getBots method in the Bots resource', function (): void {
     Saloon::fake([
         GetBots::class => MockResponse::fixture('bots.getBots'),
     ]);
 
     $response = $this->mattermost->bots()->getBots(
-		page: 123,
-		includeDeleted: true,
-		onlyOrphaned: true
-	);
+        page: 123,
+        includeDeleted: true,
+        onlyOrphaned: true
+    );
 
     Saloon::assertSent(GetBots::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the createBot method in the Bots resource', function () {
+it('calls the createBot method in the Bots resource', function (): void {
     Saloon::fake([
         CreateBot::class => MockResponse::fixture('bots.createBot'),
     ]);
 
     $response = $this->mattermost->bots()->createBot(
-		
-	);
+
+    );
 
     Saloon::assertSent(CreateBot::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getBot method in the Bots resource', function () {
+it('calls the getBot method in the Bots resource', function (): void {
     Saloon::fake([
         GetBot::class => MockResponse::fixture('bots.getBot'),
     ]);
 
     $response = $this->mattermost->bots()->getBot(
-		botUserId: 'test string',
-		includeDeleted: true
-	);
+        botUserId: 'test string',
+        includeDeleted: true
+    );
 
     Saloon::assertSent(GetBot::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the patchBot method in the Bots resource', function () {
+it('calls the patchBot method in the Bots resource', function (): void {
     Saloon::fake([
         PatchBot::class => MockResponse::fixture('bots.patchBot'),
     ]);
 
     $response = $this->mattermost->bots()->patchBot(
-		botUserId: 'test string'
-	);
+        botUserId: 'test string'
+    );
 
     Saloon::assertSent(PatchBot::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the assignBot method in the Bots resource', function () {
+it('calls the assignBot method in the Bots resource', function (): void {
     Saloon::fake([
         AssignBot::class => MockResponse::fixture('bots.assignBot'),
     ]);
 
     $response = $this->mattermost->bots()->assignBot(
-		botUserId: 'test string',
-		userId: 'test string'
-	);
+        botUserId: 'test string',
+        userId: 'test string'
+    );
 
     Saloon::assertSent(AssignBot::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the convertBotToUser method in the Bots resource', function () {
+it('calls the convertBotToUser method in the Bots resource', function (): void {
     Saloon::fake([
         ConvertBotToUser::class => MockResponse::fixture('bots.convertBotToUser'),
     ]);
 
     $response = $this->mattermost->bots()->convertBotToUser(
-		botUserId: 'test string',
-		setSystemAdmin: true
-	);
+        botUserId: 'test string',
+        setSystemAdmin: true
+    );
 
     Saloon::assertSent(ConvertBotToUser::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the disableBot method in the Bots resource', function () {
+it('calls the disableBot method in the Bots resource', function (): void {
     Saloon::fake([
         DisableBot::class => MockResponse::fixture('bots.disableBot'),
     ]);
 
     $response = $this->mattermost->bots()->disableBot(
-		botUserId: 'test string'
-	);
+        botUserId: 'test string'
+    );
 
     Saloon::assertSent(DisableBot::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the enableBot method in the Bots resource', function () {
+it('calls the enableBot method in the Bots resource', function (): void {
     Saloon::fake([
         EnableBot::class => MockResponse::fixture('bots.enableBot'),
     ]);
 
     $response = $this->mattermost->bots()->enableBot(
-		botUserId: 'test string'
-	);
+        botUserId: 'test string'
+    );
 
     Saloon::assertSent(EnableBot::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the convertUserToBot method in the Bots resource', function () {
+it('calls the convertUserToBot method in the Bots resource', function (): void {
     Saloon::fake([
         ConvertUserToBot::class => MockResponse::fixture('bots.convertUserToBot'),
     ]);
 
     $response = $this->mattermost->bots()->convertUserToBot(
-		userId: 'test string'
-	);
+        userId: 'test string'
+    );
 
     Saloon::assertSent(ConvertUserToBot::class);
 

--- a/src/Client/tests/ChannelsTest.php
+++ b/src/Client/tests/ChannelsTest.php
@@ -2,883 +2,831 @@
 
 // Generated 2026-04-10 23:46:41
 
-use ConduitUI\Mattermost\Client\Requests\Channels\GetAllChannels;
+use ConduitUI\Mattermost\Client\Mattermost;
+use ConduitUI\Mattermost\Client\Requests\Channels\AddChannelMember;
+use ConduitUI\Mattermost\Client\Requests\Channels\AutocompleteChannelsForTeam;
+use ConduitUI\Mattermost\Client\Requests\Channels\AutocompleteChannelsForTeamForSearch;
+use ConduitUI\Mattermost\Client\Requests\Channels\ChannelMembersMinusGroupMembers;
 use ConduitUI\Mattermost\Client\Requests\Channels\CreateChannel;
 use ConduitUI\Mattermost\Client\Requests\Channels\CreateDirectChannel;
 use ConduitUI\Mattermost\Client\Requests\Channels\CreateGroupChannel;
-use ConduitUI\Mattermost\Client\Requests\Channels\SearchGroupChannels;
-use ConduitUI\Mattermost\Client\Requests\Channels\ViewChannel;
-use ConduitUI\Mattermost\Client\Requests\Channels\SearchAllChannels;
-use ConduitUI\Mattermost\Client\Requests\Channels\GetChannel;
-use ConduitUI\Mattermost\Client\Requests\Channels\UpdateChannel;
+use ConduitUI\Mattermost\Client\Requests\Channels\CreateSidebarCategoryForTeamForUser;
 use ConduitUI\Mattermost\Client\Requests\Channels\DeleteChannel;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetAllChannels;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetChannel;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelByName;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelByNameForTeamName;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelMember;
 use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelMemberCountsByGroup;
 use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelMembers;
-use ConduitUI\Mattermost\Client\Requests\Channels\AddChannelMember;
 use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelMembersByIds;
-use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelMember;
-use ConduitUI\Mattermost\Client\Requests\Channels\RemoveUserFromChannel;
-use ConduitUI\Mattermost\Client\Requests\Channels\UpdateChannelNotifyProps;
-use ConduitUI\Mattermost\Client\Requests\Channels\UpdateChannelRoles;
-use ConduitUI\Mattermost\Client\Requests\Channels\UpdateChannelMemberSchemeRoles;
-use ConduitUI\Mattermost\Client\Requests\Channels\ChannelMembersMinusGroupMembers;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelMembersForUser;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelMembersTimezones;
 use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelModerations;
-use ConduitUI\Mattermost\Client\Requests\Channels\PatchChannelModerations;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelsForTeamForUser;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelsForUser;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelStats;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelUnread;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetDeletedChannelsForTeam;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetPinnedPosts;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetPrivateChannelsForTeam;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetPublicChannelsByIdsForTeam;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetPublicChannelsForTeam;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetSidebarCategoriesForTeamForUser;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetSidebarCategoryForTeamForUser;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetSidebarCategoryOrderForTeamForUser;
 use ConduitUI\Mattermost\Client\Requests\Channels\MoveChannel;
 use ConduitUI\Mattermost\Client\Requests\Channels\PatchChannel;
-use ConduitUI\Mattermost\Client\Requests\Channels\GetPinnedPosts;
-use ConduitUI\Mattermost\Client\Requests\Channels\UpdateChannelPrivacy;
-use ConduitUI\Mattermost\Client\Requests\Channels\RestoreChannel;
-use ConduitUI\Mattermost\Client\Requests\Channels\UpdateChannelScheme;
-use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelStats;
-use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelMembersTimezones;
-use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelByNameForTeamName;
-use ConduitUI\Mattermost\Client\Requests\Channels\GetPublicChannelsForTeam;
-use ConduitUI\Mattermost\Client\Requests\Channels\AutocompleteChannelsForTeam;
-use ConduitUI\Mattermost\Client\Requests\Channels\GetDeletedChannelsForTeam;
-use ConduitUI\Mattermost\Client\Requests\Channels\GetPublicChannelsByIdsForTeam;
-use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelByName;
-use ConduitUI\Mattermost\Client\Requests\Channels\GetPrivateChannelsForTeam;
-use ConduitUI\Mattermost\Client\Requests\Channels\SearchChannels;
-use ConduitUI\Mattermost\Client\Requests\Channels\SearchArchivedChannels;
-use ConduitUI\Mattermost\Client\Requests\Channels\AutocompleteChannelsForTeamForSearch;
-use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelsForUser;
-use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelUnread;
-use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelsForTeamForUser;
-use ConduitUI\Mattermost\Client\Requests\Channels\GetSidebarCategoriesForTeamForUser;
-use ConduitUI\Mattermost\Client\Requests\Channels\UpdateSidebarCategoriesForTeamForUser;
-use ConduitUI\Mattermost\Client\Requests\Channels\CreateSidebarCategoryForTeamForUser;
-use ConduitUI\Mattermost\Client\Requests\Channels\GetSidebarCategoryOrderForTeamForUser;
-use ConduitUI\Mattermost\Client\Requests\Channels\UpdateSidebarCategoryOrderForTeamForUser;
-use ConduitUI\Mattermost\Client\Requests\Channels\GetSidebarCategoryForTeamForUser;
-use ConduitUI\Mattermost\Client\Requests\Channels\UpdateSidebarCategoryForTeamForUser;
+use ConduitUI\Mattermost\Client\Requests\Channels\PatchChannelModerations;
 use ConduitUI\Mattermost\Client\Requests\Channels\RemoveSidebarCategoryForTeamForUser;
-use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelMembersForUser;
+use ConduitUI\Mattermost\Client\Requests\Channels\RemoveUserFromChannel;
+use ConduitUI\Mattermost\Client\Requests\Channels\RestoreChannel;
+use ConduitUI\Mattermost\Client\Requests\Channels\SearchAllChannels;
+use ConduitUI\Mattermost\Client\Requests\Channels\SearchArchivedChannels;
+use ConduitUI\Mattermost\Client\Requests\Channels\SearchChannels;
+use ConduitUI\Mattermost\Client\Requests\Channels\SearchGroupChannels;
+use ConduitUI\Mattermost\Client\Requests\Channels\UpdateChannel;
+use ConduitUI\Mattermost\Client\Requests\Channels\UpdateChannelMemberSchemeRoles;
+use ConduitUI\Mattermost\Client\Requests\Channels\UpdateChannelNotifyProps;
+use ConduitUI\Mattermost\Client\Requests\Channels\UpdateChannelPrivacy;
+use ConduitUI\Mattermost\Client\Requests\Channels\UpdateChannelRoles;
+use ConduitUI\Mattermost\Client\Requests\Channels\UpdateChannelScheme;
+use ConduitUI\Mattermost\Client\Requests\Channels\UpdateSidebarCategoriesForTeamForUser;
+use ConduitUI\Mattermost\Client\Requests\Channels\UpdateSidebarCategoryForTeamForUser;
+use ConduitUI\Mattermost\Client\Requests\Channels\UpdateSidebarCategoryOrderForTeamForUser;
+use ConduitUI\Mattermost\Client\Requests\Channels\ViewChannel;
 use Saloon\Http\Faking\MockResponse;
 use Saloon\Laravel\Facades\Saloon;
-use Spatie\LaravelData\DataCollection;
 
-beforeEach(function () {
-    $this->mattermost = new ConduitUI\Mattermost\Client\Mattermost(
-		bearerToken: 'replace'
-	);
+beforeEach(function (): void {
+    $this->mattermost = new Mattermost(
+        bearerToken: 'replace'
+    );
 });
 
-
-it('calls the getAllChannels method in the Channels resource', function () {
+it('calls the getAllChannels method in the Channels resource', function (): void {
     Saloon::fake([
         GetAllChannels::class => MockResponse::fixture('channels.getAllChannels'),
     ]);
 
     $response = $this->mattermost->channels()->getAllChannels(
-		notAssociatedToGroup: 'test string',
-		page: 123,
-		excludeDefaultChannels: true,
-		includeDeleted: true,
-		includeTotalCount: true,
-		excludePolicyConstrained: true
-	);
+        notAssociatedToGroup: 'test string',
+        page: 123,
+        excludeDefaultChannels: true,
+        includeDeleted: true,
+        includeTotalCount: true,
+        excludePolicyConstrained: true
+    );
 
     Saloon::assertSent(GetAllChannels::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the createChannel method in the Channels resource', function () {
+it('calls the createChannel method in the Channels resource', function (): void {
     Saloon::fake([
         CreateChannel::class => MockResponse::fixture('channels.createChannel'),
     ]);
 
     $response = $this->mattermost->channels()->createChannel(
-		
-	);
+
+    );
 
     Saloon::assertSent(CreateChannel::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the createDirectChannel method in the Channels resource', function () {
+it('calls the createDirectChannel method in the Channels resource', function (): void {
     Saloon::fake([
         CreateDirectChannel::class => MockResponse::fixture('channels.createDirectChannel'),
     ]);
 
     $response = $this->mattermost->channels()->createDirectChannel(
-		
-	);
+
+    );
 
     Saloon::assertSent(CreateDirectChannel::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the createGroupChannel method in the Channels resource', function () {
+it('calls the createGroupChannel method in the Channels resource', function (): void {
     Saloon::fake([
         CreateGroupChannel::class => MockResponse::fixture('channels.createGroupChannel'),
     ]);
 
     $response = $this->mattermost->channels()->createGroupChannel(
-		
-	);
+
+    );
 
     Saloon::assertSent(CreateGroupChannel::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the searchGroupChannels method in the Channels resource', function () {
+it('calls the searchGroupChannels method in the Channels resource', function (): void {
     Saloon::fake([
         SearchGroupChannels::class => MockResponse::fixture('channels.searchGroupChannels'),
     ]);
 
     $response = $this->mattermost->channels()->searchGroupChannels(
-		
-	);
+
+    );
 
     Saloon::assertSent(SearchGroupChannels::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the viewChannel method in the Channels resource', function () {
+it('calls the viewChannel method in the Channels resource', function (): void {
     Saloon::fake([
         ViewChannel::class => MockResponse::fixture('channels.viewChannel'),
     ]);
 
     $response = $this->mattermost->channels()->viewChannel(
-		userId: 'test string'
-	);
+        userId: 'test string'
+    );
 
     Saloon::assertSent(ViewChannel::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the searchAllChannels method in the Channels resource', function () {
+it('calls the searchAllChannels method in the Channels resource', function (): void {
     Saloon::fake([
         SearchAllChannels::class => MockResponse::fixture('channels.searchAllChannels'),
     ]);
 
     $response = $this->mattermost->channels()->searchAllChannels(
-		systemConsole: true
-	);
+        systemConsole: true
+    );
 
     Saloon::assertSent(SearchAllChannels::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getChannel method in the Channels resource', function () {
+it('calls the getChannel method in the Channels resource', function (): void {
     Saloon::fake([
         GetChannel::class => MockResponse::fixture('channels.getChannel'),
     ]);
 
     $response = $this->mattermost->channels()->getChannel(
-		channelId: 'test string'
-	);
+        channelId: 'test string'
+    );
 
     Saloon::assertSent(GetChannel::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the updateChannel method in the Channels resource', function () {
+it('calls the updateChannel method in the Channels resource', function (): void {
     Saloon::fake([
         UpdateChannel::class => MockResponse::fixture('channels.updateChannel'),
     ]);
 
     $response = $this->mattermost->channels()->updateChannel(
-		channelId: 'test string'
-	);
+        channelId: 'test string'
+    );
 
     Saloon::assertSent(UpdateChannel::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the deleteChannel method in the Channels resource', function () {
+it('calls the deleteChannel method in the Channels resource', function (): void {
     Saloon::fake([
         DeleteChannel::class => MockResponse::fixture('channels.deleteChannel'),
     ]);
 
     $response = $this->mattermost->channels()->deleteChannel(
-		channelId: 'test string'
-	);
+        channelId: 'test string'
+    );
 
     Saloon::assertSent(DeleteChannel::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getChannelMemberCountsByGroup method in the Channels resource', function () {
+it('calls the getChannelMemberCountsByGroup method in the Channels resource', function (): void {
     Saloon::fake([
         GetChannelMemberCountsByGroup::class => MockResponse::fixture('channels.getChannelMemberCountsByGroup'),
     ]);
 
     $response = $this->mattermost->channels()->getChannelMemberCountsByGroup(
-		channelId: 'test string',
-		includeTimezones: true
-	);
+        channelId: 'test string',
+        includeTimezones: true
+    );
 
     Saloon::assertSent(GetChannelMemberCountsByGroup::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getChannelMembers method in the Channels resource', function () {
+it('calls the getChannelMembers method in the Channels resource', function (): void {
     Saloon::fake([
         GetChannelMembers::class => MockResponse::fixture('channels.getChannelMembers'),
     ]);
 
     $response = $this->mattermost->channels()->getChannelMembers(
-		channelId: 'test string',
-		page: 123
-	);
+        channelId: 'test string',
+        page: 123
+    );
 
     Saloon::assertSent(GetChannelMembers::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the addChannelMember method in the Channels resource', function () {
+it('calls the addChannelMember method in the Channels resource', function (): void {
     Saloon::fake([
         AddChannelMember::class => MockResponse::fixture('channels.addChannelMember'),
     ]);
 
     $response = $this->mattermost->channels()->addChannelMember(
-		channelId: 'test string'
-	);
+        channelId: 'test string'
+    );
 
     Saloon::assertSent(AddChannelMember::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getChannelMembersByIds method in the Channels resource', function () {
+it('calls the getChannelMembersByIds method in the Channels resource', function (): void {
     Saloon::fake([
         GetChannelMembersByIds::class => MockResponse::fixture('channels.getChannelMembersByIds'),
     ]);
 
     $response = $this->mattermost->channels()->getChannelMembersByIds(
-		channelId: 'test string'
-	);
+        channelId: 'test string'
+    );
 
     Saloon::assertSent(GetChannelMembersByIds::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getChannelMember method in the Channels resource', function () {
+it('calls the getChannelMember method in the Channels resource', function (): void {
     Saloon::fake([
         GetChannelMember::class => MockResponse::fixture('channels.getChannelMember'),
     ]);
 
     $response = $this->mattermost->channels()->getChannelMember(
-		channelId: 'test string',
-		userId: 'test string'
-	);
+        channelId: 'test string',
+        userId: 'test string'
+    );
 
     Saloon::assertSent(GetChannelMember::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the removeUserFromChannel method in the Channels resource', function () {
+it('calls the removeUserFromChannel method in the Channels resource', function (): void {
     Saloon::fake([
         RemoveUserFromChannel::class => MockResponse::fixture('channels.removeUserFromChannel'),
     ]);
 
     $response = $this->mattermost->channels()->removeUserFromChannel(
-		channelId: 'test string',
-		userId: 'test string'
-	);
+        channelId: 'test string',
+        userId: 'test string'
+    );
 
     Saloon::assertSent(RemoveUserFromChannel::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the updateChannelNotifyProps method in the Channels resource', function () {
+it('calls the updateChannelNotifyProps method in the Channels resource', function (): void {
     Saloon::fake([
         UpdateChannelNotifyProps::class => MockResponse::fixture('channels.updateChannelNotifyProps'),
     ]);
 
     $response = $this->mattermost->channels()->updateChannelNotifyProps(
-		channelId: 'test string',
-		userId: 'test string'
-	);
+        channelId: 'test string',
+        userId: 'test string'
+    );
 
     Saloon::assertSent(UpdateChannelNotifyProps::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the updateChannelRoles method in the Channels resource', function () {
+it('calls the updateChannelRoles method in the Channels resource', function (): void {
     Saloon::fake([
         UpdateChannelRoles::class => MockResponse::fixture('channels.updateChannelRoles'),
     ]);
 
     $response = $this->mattermost->channels()->updateChannelRoles(
-		channelId: 'test string',
-		userId: 'test string'
-	);
+        channelId: 'test string',
+        userId: 'test string'
+    );
 
     Saloon::assertSent(UpdateChannelRoles::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the updateChannelMemberSchemeRoles method in the Channels resource', function () {
+it('calls the updateChannelMemberSchemeRoles method in the Channels resource', function (): void {
     Saloon::fake([
         UpdateChannelMemberSchemeRoles::class => MockResponse::fixture('channels.updateChannelMemberSchemeRoles'),
     ]);
 
     $response = $this->mattermost->channels()->updateChannelMemberSchemeRoles(
-		channelId: 'test string',
-		userId: 'test string'
-	);
+        channelId: 'test string',
+        userId: 'test string'
+    );
 
     Saloon::assertSent(UpdateChannelMemberSchemeRoles::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the channelMembersMinusGroupMembers method in the Channels resource', function () {
+it('calls the channelMembersMinusGroupMembers method in the Channels resource', function (): void {
     Saloon::fake([
         ChannelMembersMinusGroupMembers::class => MockResponse::fixture('channels.channelMembersMinusGroupMembers'),
     ]);
 
     $response = $this->mattermost->channels()->channelMembersMinusGroupMembers(
-		channelId: 'test string',
-		groupIds: 'test string',
-		page: 123
-	);
+        channelId: 'test string',
+        groupIds: 'test string',
+        page: 123
+    );
 
     Saloon::assertSent(ChannelMembersMinusGroupMembers::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getChannelModerations method in the Channels resource', function () {
+it('calls the getChannelModerations method in the Channels resource', function (): void {
     Saloon::fake([
         GetChannelModerations::class => MockResponse::fixture('channels.getChannelModerations'),
     ]);
 
     $response = $this->mattermost->channels()->getChannelModerations(
-		channelId: 'test string'
-	);
+        channelId: 'test string'
+    );
 
     Saloon::assertSent(GetChannelModerations::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the patchChannelModerations method in the Channels resource', function () {
+it('calls the patchChannelModerations method in the Channels resource', function (): void {
     Saloon::fake([
         PatchChannelModerations::class => MockResponse::fixture('channels.patchChannelModerations'),
     ]);
 
     $response = $this->mattermost->channels()->patchChannelModerations(
-		channelId: 'test string'
-	);
+        channelId: 'test string'
+    );
 
     Saloon::assertSent(PatchChannelModerations::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the moveChannel method in the Channels resource', function () {
+it('calls the moveChannel method in the Channels resource', function (): void {
     Saloon::fake([
         MoveChannel::class => MockResponse::fixture('channels.moveChannel'),
     ]);
 
     $response = $this->mattermost->channels()->moveChannel(
-		channelId: 'test string'
-	);
+        channelId: 'test string'
+    );
 
     Saloon::assertSent(MoveChannel::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the patchChannel method in the Channels resource', function () {
+it('calls the patchChannel method in the Channels resource', function (): void {
     Saloon::fake([
         PatchChannel::class => MockResponse::fixture('channels.patchChannel'),
     ]);
 
     $response = $this->mattermost->channels()->patchChannel(
-		channelId: 'test string'
-	);
+        channelId: 'test string'
+    );
 
     Saloon::assertSent(PatchChannel::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getPinnedPosts method in the Channels resource', function () {
+it('calls the getPinnedPosts method in the Channels resource', function (): void {
     Saloon::fake([
         GetPinnedPosts::class => MockResponse::fixture('channels.getPinnedPosts'),
     ]);
 
     $response = $this->mattermost->channels()->getPinnedPosts(
-		channelId: 'test string'
-	);
+        channelId: 'test string'
+    );
 
     Saloon::assertSent(GetPinnedPosts::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the updateChannelPrivacy method in the Channels resource', function () {
+it('calls the updateChannelPrivacy method in the Channels resource', function (): void {
     Saloon::fake([
         UpdateChannelPrivacy::class => MockResponse::fixture('channels.updateChannelPrivacy'),
     ]);
 
     $response = $this->mattermost->channels()->updateChannelPrivacy(
-		channelId: 'test string'
-	);
+        channelId: 'test string'
+    );
 
     Saloon::assertSent(UpdateChannelPrivacy::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the restoreChannel method in the Channels resource', function () {
+it('calls the restoreChannel method in the Channels resource', function (): void {
     Saloon::fake([
         RestoreChannel::class => MockResponse::fixture('channels.restoreChannel'),
     ]);
 
     $response = $this->mattermost->channels()->restoreChannel(
-		channelId: 'test string'
-	);
+        channelId: 'test string'
+    );
 
     Saloon::assertSent(RestoreChannel::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the updateChannelScheme method in the Channels resource', function () {
+it('calls the updateChannelScheme method in the Channels resource', function (): void {
     Saloon::fake([
         UpdateChannelScheme::class => MockResponse::fixture('channels.updateChannelScheme'),
     ]);
 
     $response = $this->mattermost->channels()->updateChannelScheme(
-		channelId: 'test string'
-	);
+        channelId: 'test string'
+    );
 
     Saloon::assertSent(UpdateChannelScheme::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getChannelStats method in the Channels resource', function () {
+it('calls the getChannelStats method in the Channels resource', function (): void {
     Saloon::fake([
         GetChannelStats::class => MockResponse::fixture('channels.getChannelStats'),
     ]);
 
     $response = $this->mattermost->channels()->getChannelStats(
-		channelId: 'test string'
-	);
+        channelId: 'test string'
+    );
 
     Saloon::assertSent(GetChannelStats::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getChannelMembersTimezones method in the Channels resource', function () {
+it('calls the getChannelMembersTimezones method in the Channels resource', function (): void {
     Saloon::fake([
         GetChannelMembersTimezones::class => MockResponse::fixture('channels.getChannelMembersTimezones'),
     ]);
 
     $response = $this->mattermost->channels()->getChannelMembersTimezones(
-		channelId: 'test string'
-	);
+        channelId: 'test string'
+    );
 
     Saloon::assertSent(GetChannelMembersTimezones::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getChannelByNameForTeamName method in the Channels resource', function () {
+it('calls the getChannelByNameForTeamName method in the Channels resource', function (): void {
     Saloon::fake([
         GetChannelByNameForTeamName::class => MockResponse::fixture('channels.getChannelByNameForTeamName'),
     ]);
 
     $response = $this->mattermost->channels()->getChannelByNameForTeamName(
-		teamName: 'test string',
-		channelName: 'test string',
-		includeDeleted: true
-	);
+        teamName: 'test string',
+        channelName: 'test string',
+        includeDeleted: true
+    );
 
     Saloon::assertSent(GetChannelByNameForTeamName::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getPublicChannelsForTeam method in the Channels resource', function () {
+it('calls the getPublicChannelsForTeam method in the Channels resource', function (): void {
     Saloon::fake([
         GetPublicChannelsForTeam::class => MockResponse::fixture('channels.getPublicChannelsForTeam'),
     ]);
 
     $response = $this->mattermost->channels()->getPublicChannelsForTeam(
-		teamId: 'test string',
-		page: 123
-	);
+        teamId: 'test string',
+        page: 123
+    );
 
     Saloon::assertSent(GetPublicChannelsForTeam::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the autocompleteChannelsForTeam method in the Channels resource', function () {
+it('calls the autocompleteChannelsForTeam method in the Channels resource', function (): void {
     Saloon::fake([
         AutocompleteChannelsForTeam::class => MockResponse::fixture('channels.autocompleteChannelsForTeam'),
     ]);
 
     $response = $this->mattermost->channels()->autocompleteChannelsForTeam(
-		teamId: 'test string',
-		name: 'test string'
-	);
+        teamId: 'test string',
+        name: 'test string'
+    );
 
     Saloon::assertSent(AutocompleteChannelsForTeam::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getDeletedChannelsForTeam method in the Channels resource', function () {
+it('calls the getDeletedChannelsForTeam method in the Channels resource', function (): void {
     Saloon::fake([
         GetDeletedChannelsForTeam::class => MockResponse::fixture('channels.getDeletedChannelsForTeam'),
     ]);
 
     $response = $this->mattermost->channels()->getDeletedChannelsForTeam(
-		teamId: 'test string',
-		page: 123
-	);
+        teamId: 'test string',
+        page: 123
+    );
 
     Saloon::assertSent(GetDeletedChannelsForTeam::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getPublicChannelsByIdsForTeam method in the Channels resource', function () {
+it('calls the getPublicChannelsByIdsForTeam method in the Channels resource', function (): void {
     Saloon::fake([
         GetPublicChannelsByIdsForTeam::class => MockResponse::fixture('channels.getPublicChannelsByIdsForTeam'),
     ]);
 
     $response = $this->mattermost->channels()->getPublicChannelsByIdsForTeam(
-		teamId: 'test string'
-	);
+        teamId: 'test string'
+    );
 
     Saloon::assertSent(GetPublicChannelsByIdsForTeam::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getChannelByName method in the Channels resource', function () {
+it('calls the getChannelByName method in the Channels resource', function (): void {
     Saloon::fake([
         GetChannelByName::class => MockResponse::fixture('channels.getChannelByName'),
     ]);
 
     $response = $this->mattermost->channels()->getChannelByName(
-		teamId: 'test string',
-		channelName: 'test string',
-		includeDeleted: true
-	);
+        teamId: 'test string',
+        channelName: 'test string',
+        includeDeleted: true
+    );
 
     Saloon::assertSent(GetChannelByName::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getPrivateChannelsForTeam method in the Channels resource', function () {
+it('calls the getPrivateChannelsForTeam method in the Channels resource', function (): void {
     Saloon::fake([
         GetPrivateChannelsForTeam::class => MockResponse::fixture('channels.getPrivateChannelsForTeam'),
     ]);
 
     $response = $this->mattermost->channels()->getPrivateChannelsForTeam(
-		teamId: 'test string',
-		page: 123
-	);
+        teamId: 'test string',
+        page: 123
+    );
 
     Saloon::assertSent(GetPrivateChannelsForTeam::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the searchChannels method in the Channels resource', function () {
+it('calls the searchChannels method in the Channels resource', function (): void {
     Saloon::fake([
         SearchChannels::class => MockResponse::fixture('channels.searchChannels'),
     ]);
 
     $response = $this->mattermost->channels()->searchChannels(
-		teamId: 'test string'
-	);
+        teamId: 'test string'
+    );
 
     Saloon::assertSent(SearchChannels::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the searchArchivedChannels method in the Channels resource', function () {
+it('calls the searchArchivedChannels method in the Channels resource', function (): void {
     Saloon::fake([
         SearchArchivedChannels::class => MockResponse::fixture('channels.searchArchivedChannels'),
     ]);
 
     $response = $this->mattermost->channels()->searchArchivedChannels(
-		teamId: 'test string'
-	);
+        teamId: 'test string'
+    );
 
     Saloon::assertSent(SearchArchivedChannels::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the autocompleteChannelsForTeamForSearch method in the Channels resource', function () {
+it('calls the autocompleteChannelsForTeamForSearch method in the Channels resource', function (): void {
     Saloon::fake([
         AutocompleteChannelsForTeamForSearch::class => MockResponse::fixture('channels.autocompleteChannelsForTeamForSearch'),
     ]);
 
     $response = $this->mattermost->channels()->autocompleteChannelsForTeamForSearch(
-		teamId: 'test string',
-		name: 'test string'
-	);
+        teamId: 'test string',
+        name: 'test string'
+    );
 
     Saloon::assertSent(AutocompleteChannelsForTeamForSearch::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getChannelsForUser method in the Channels resource', function () {
+it('calls the getChannelsForUser method in the Channels resource', function (): void {
     Saloon::fake([
         GetChannelsForUser::class => MockResponse::fixture('channels.getChannelsForUser'),
     ]);
 
     $response = $this->mattermost->channels()->getChannelsForUser(
-		userId: 'test string',
-		lastDeleteAt: 123,
-		includeDeleted: true
-	);
+        userId: 'test string',
+        lastDeleteAt: 123,
+        includeDeleted: true
+    );
 
     Saloon::assertSent(GetChannelsForUser::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getChannelUnread method in the Channels resource', function () {
+it('calls the getChannelUnread method in the Channels resource', function (): void {
     Saloon::fake([
         GetChannelUnread::class => MockResponse::fixture('channels.getChannelUnread'),
     ]);
 
     $response = $this->mattermost->channels()->getChannelUnread(
-		userId: 'test string',
-		channelId: 'test string'
-	);
+        userId: 'test string',
+        channelId: 'test string'
+    );
 
     Saloon::assertSent(GetChannelUnread::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getChannelsForTeamForUser method in the Channels resource', function () {
+it('calls the getChannelsForTeamForUser method in the Channels resource', function (): void {
     Saloon::fake([
         GetChannelsForTeamForUser::class => MockResponse::fixture('channels.getChannelsForTeamForUser'),
     ]);
 
     $response = $this->mattermost->channels()->getChannelsForTeamForUser(
-		userId: 'test string',
-		teamId: 'test string',
-		includeDeleted: true,
-		lastDeleteAt: 123
-	);
+        userId: 'test string',
+        teamId: 'test string',
+        includeDeleted: true,
+        lastDeleteAt: 123
+    );
 
     Saloon::assertSent(GetChannelsForTeamForUser::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getSidebarCategoriesForTeamForUser method in the Channels resource', function () {
+it('calls the getSidebarCategoriesForTeamForUser method in the Channels resource', function (): void {
     Saloon::fake([
         GetSidebarCategoriesForTeamForUser::class => MockResponse::fixture('channels.getSidebarCategoriesForTeamForUser'),
     ]);
 
     $response = $this->mattermost->channels()->getSidebarCategoriesForTeamForUser(
-		teamId: 'test string',
-		userId: 'test string'
-	);
+        teamId: 'test string',
+        userId: 'test string'
+    );
 
     Saloon::assertSent(GetSidebarCategoriesForTeamForUser::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the updateSidebarCategoriesForTeamForUser method in the Channels resource', function () {
+it('calls the updateSidebarCategoriesForTeamForUser method in the Channels resource', function (): void {
     Saloon::fake([
         UpdateSidebarCategoriesForTeamForUser::class => MockResponse::fixture('channels.updateSidebarCategoriesForTeamForUser'),
     ]);
 
     $response = $this->mattermost->channels()->updateSidebarCategoriesForTeamForUser(
-		teamId: 'test string',
-		userId: 'test string'
-	);
+        teamId: 'test string',
+        userId: 'test string'
+    );
 
     Saloon::assertSent(UpdateSidebarCategoriesForTeamForUser::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the createSidebarCategoryForTeamForUser method in the Channels resource', function () {
+it('calls the createSidebarCategoryForTeamForUser method in the Channels resource', function (): void {
     Saloon::fake([
         CreateSidebarCategoryForTeamForUser::class => MockResponse::fixture('channels.createSidebarCategoryForTeamForUser'),
     ]);
 
     $response = $this->mattermost->channels()->createSidebarCategoryForTeamForUser(
-		teamId: 'test string',
-		userId: 'test string'
-	);
+        teamId: 'test string',
+        userId: 'test string'
+    );
 
     Saloon::assertSent(CreateSidebarCategoryForTeamForUser::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getSidebarCategoryOrderForTeamForUser method in the Channels resource', function () {
+it('calls the getSidebarCategoryOrderForTeamForUser method in the Channels resource', function (): void {
     Saloon::fake([
         GetSidebarCategoryOrderForTeamForUser::class => MockResponse::fixture('channels.getSidebarCategoryOrderForTeamForUser'),
     ]);
 
     $response = $this->mattermost->channels()->getSidebarCategoryOrderForTeamForUser(
-		teamId: 'test string',
-		userId: 'test string'
-	);
+        teamId: 'test string',
+        userId: 'test string'
+    );
 
     Saloon::assertSent(GetSidebarCategoryOrderForTeamForUser::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the updateSidebarCategoryOrderForTeamForUser method in the Channels resource', function () {
+it('calls the updateSidebarCategoryOrderForTeamForUser method in the Channels resource', function (): void {
     Saloon::fake([
         UpdateSidebarCategoryOrderForTeamForUser::class => MockResponse::fixture('channels.updateSidebarCategoryOrderForTeamForUser'),
     ]);
 
     $response = $this->mattermost->channels()->updateSidebarCategoryOrderForTeamForUser(
-		teamId: 'test string',
-		userId: 'test string'
-	);
+        teamId: 'test string',
+        userId: 'test string'
+    );
 
     Saloon::assertSent(UpdateSidebarCategoryOrderForTeamForUser::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getSidebarCategoryForTeamForUser method in the Channels resource', function () {
+it('calls the getSidebarCategoryForTeamForUser method in the Channels resource', function (): void {
     Saloon::fake([
         GetSidebarCategoryForTeamForUser::class => MockResponse::fixture('channels.getSidebarCategoryForTeamForUser'),
     ]);
 
     $response = $this->mattermost->channels()->getSidebarCategoryForTeamForUser(
-		teamId: 'test string',
-		userId: 'test string',
-		categoryId: 'test string'
-	);
+        teamId: 'test string',
+        userId: 'test string',
+        categoryId: 'test string'
+    );
 
     Saloon::assertSent(GetSidebarCategoryForTeamForUser::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the updateSidebarCategoryForTeamForUser method in the Channels resource', function () {
+it('calls the updateSidebarCategoryForTeamForUser method in the Channels resource', function (): void {
     Saloon::fake([
         UpdateSidebarCategoryForTeamForUser::class => MockResponse::fixture('channels.updateSidebarCategoryForTeamForUser'),
     ]);
 
     $response = $this->mattermost->channels()->updateSidebarCategoryForTeamForUser(
-		teamId: 'test string',
-		userId: 'test string',
-		categoryId: 'test string'
-	);
+        teamId: 'test string',
+        userId: 'test string',
+        categoryId: 'test string'
+    );
 
     Saloon::assertSent(UpdateSidebarCategoryForTeamForUser::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the removeSidebarCategoryForTeamForUser method in the Channels resource', function () {
+it('calls the removeSidebarCategoryForTeamForUser method in the Channels resource', function (): void {
     Saloon::fake([
         RemoveSidebarCategoryForTeamForUser::class => MockResponse::fixture('channels.removeSidebarCategoryForTeamForUser'),
     ]);
 
     $response = $this->mattermost->channels()->removeSidebarCategoryForTeamForUser(
-		teamId: 'test string',
-		userId: 'test string',
-		categoryId: 'test string'
-	);
+        teamId: 'test string',
+        userId: 'test string',
+        categoryId: 'test string'
+    );
 
     Saloon::assertSent(RemoveSidebarCategoryForTeamForUser::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getChannelMembersForUser method in the Channels resource', function () {
+it('calls the getChannelMembersForUser method in the Channels resource', function (): void {
     Saloon::fake([
         GetChannelMembersForUser::class => MockResponse::fixture('channels.getChannelMembersForUser'),
     ]);
 
     $response = $this->mattermost->channels()->getChannelMembersForUser(
-		userId: 'test string',
-		teamId: 'test string'
-	);
+        userId: 'test string',
+        teamId: 'test string'
+    );
 
     Saloon::assertSent(GetChannelMembersForUser::class);
 

--- a/src/Client/tests/CommandsTest.php
+++ b/src/Client/tests/CommandsTest.php
@@ -2,155 +2,146 @@
 
 // Generated 2026-04-10 23:46:41
 
-use ConduitUI\Mattermost\Client\Requests\Commands\ListCommands;
+use ConduitUI\Mattermost\Client\Mattermost;
 use ConduitUI\Mattermost\Client\Requests\Commands\CreateCommand;
+use ConduitUI\Mattermost\Client\Requests\Commands\DeleteCommand;
 use ConduitUI\Mattermost\Client\Requests\Commands\ExecuteCommand;
 use ConduitUI\Mattermost\Client\Requests\Commands\GetCommandById;
-use ConduitUI\Mattermost\Client\Requests\Commands\UpdateCommand;
-use ConduitUI\Mattermost\Client\Requests\Commands\DeleteCommand;
+use ConduitUI\Mattermost\Client\Requests\Commands\ListAutocompleteCommands;
+use ConduitUI\Mattermost\Client\Requests\Commands\ListCommands;
 use ConduitUI\Mattermost\Client\Requests\Commands\MoveCommand;
 use ConduitUI\Mattermost\Client\Requests\Commands\RegenCommandToken;
-use ConduitUI\Mattermost\Client\Requests\Commands\ListAutocompleteCommands;
+use ConduitUI\Mattermost\Client\Requests\Commands\UpdateCommand;
 use Saloon\Http\Faking\MockResponse;
 use Saloon\Laravel\Facades\Saloon;
-use Spatie\LaravelData\DataCollection;
 
-beforeEach(function () {
-    $this->mattermost = new ConduitUI\Mattermost\Client\Mattermost(
-		bearerToken: 'replace'
-	);
+beforeEach(function (): void {
+    $this->mattermost = new Mattermost(
+        bearerToken: 'replace'
+    );
 });
 
-
-it('calls the listCommands method in the Commands resource', function () {
+it('calls the listCommands method in the Commands resource', function (): void {
     Saloon::fake([
         ListCommands::class => MockResponse::fixture('commands.listCommands'),
     ]);
 
     $response = $this->mattermost->commands()->listCommands(
-		teamId: 'test string',
-		customOnly: true
-	);
+        teamId: 'test string',
+        customOnly: true
+    );
 
     Saloon::assertSent(ListCommands::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the createCommand method in the Commands resource', function () {
+it('calls the createCommand method in the Commands resource', function (): void {
     Saloon::fake([
         CreateCommand::class => MockResponse::fixture('commands.createCommand'),
     ]);
 
     $response = $this->mattermost->commands()->createCommand(
-		
-	);
+
+    );
 
     Saloon::assertSent(CreateCommand::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the executeCommand method in the Commands resource', function () {
+it('calls the executeCommand method in the Commands resource', function (): void {
     Saloon::fake([
         ExecuteCommand::class => MockResponse::fixture('commands.executeCommand'),
     ]);
 
     $response = $this->mattermost->commands()->executeCommand(
-		
-	);
+
+    );
 
     Saloon::assertSent(ExecuteCommand::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getCommandById method in the Commands resource', function () {
+it('calls the getCommandById method in the Commands resource', function (): void {
     Saloon::fake([
         GetCommandById::class => MockResponse::fixture('commands.getCommandById'),
     ]);
 
     $response = $this->mattermost->commands()->getCommandById(
-		commandId: 'test string'
-	);
+        commandId: 'test string'
+    );
 
     Saloon::assertSent(GetCommandById::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the updateCommand method in the Commands resource', function () {
+it('calls the updateCommand method in the Commands resource', function (): void {
     Saloon::fake([
         UpdateCommand::class => MockResponse::fixture('commands.updateCommand'),
     ]);
 
     $response = $this->mattermost->commands()->updateCommand(
-		commandId: 'test string'
-	);
+        commandId: 'test string'
+    );
 
     Saloon::assertSent(UpdateCommand::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the deleteCommand method in the Commands resource', function () {
+it('calls the deleteCommand method in the Commands resource', function (): void {
     Saloon::fake([
         DeleteCommand::class => MockResponse::fixture('commands.deleteCommand'),
     ]);
 
     $response = $this->mattermost->commands()->deleteCommand(
-		commandId: 'test string'
-	);
+        commandId: 'test string'
+    );
 
     Saloon::assertSent(DeleteCommand::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the moveCommand method in the Commands resource', function () {
+it('calls the moveCommand method in the Commands resource', function (): void {
     Saloon::fake([
         MoveCommand::class => MockResponse::fixture('commands.moveCommand'),
     ]);
 
     $response = $this->mattermost->commands()->moveCommand(
-		commandId: 'test string'
-	);
+        commandId: 'test string'
+    );
 
     Saloon::assertSent(MoveCommand::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the regenCommandToken method in the Commands resource', function () {
+it('calls the regenCommandToken method in the Commands resource', function (): void {
     Saloon::fake([
         RegenCommandToken::class => MockResponse::fixture('commands.regenCommandToken'),
     ]);
 
     $response = $this->mattermost->commands()->regenCommandToken(
-		commandId: 'test string'
-	);
+        commandId: 'test string'
+    );
 
     Saloon::assertSent(RegenCommandToken::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the listAutocompleteCommands method in the Commands resource', function () {
+it('calls the listAutocompleteCommands method in the Commands resource', function (): void {
     Saloon::fake([
         ListAutocompleteCommands::class => MockResponse::fixture('commands.listAutocompleteCommands'),
     ]);
 
     $response = $this->mattermost->commands()->listAutocompleteCommands(
-		teamId: 'test string'
-	);
+        teamId: 'test string'
+    );
 
     Saloon::assertSent(ListAutocompleteCommands::class);
 

--- a/src/Client/tests/DataRetentionTest.php
+++ b/src/Client/tests/DataRetentionTest.php
@@ -2,44 +2,42 @@
 
 // Generated 2026-04-10 23:46:41
 
+use ConduitUI\Mattermost\Client\Mattermost;
 use ConduitUI\Mattermost\Client\Requests\DataRetention\GetChannelPoliciesForUser;
 use ConduitUI\Mattermost\Client\Requests\DataRetention\GetTeamPoliciesForUser;
 use Saloon\Http\Faking\MockResponse;
 use Saloon\Laravel\Facades\Saloon;
-use Spatie\LaravelData\DataCollection;
 
-beforeEach(function () {
-    $this->mattermost = new ConduitUI\Mattermost\Client\Mattermost(
-		bearerToken: 'replace'
-	);
+beforeEach(function (): void {
+    $this->mattermost = new Mattermost(
+        bearerToken: 'replace'
+    );
 });
 
-
-it('calls the getChannelPoliciesForUser method in the DataRetention resource', function () {
+it('calls the getChannelPoliciesForUser method in the DataRetention resource', function (): void {
     Saloon::fake([
         GetChannelPoliciesForUser::class => MockResponse::fixture('dataRetention.getChannelPoliciesForUser'),
     ]);
 
     $response = $this->mattermost->dataRetention()->getChannelPoliciesForUser(
-		userId: 'test string',
-		page: 123
-	);
+        userId: 'test string',
+        page: 123
+    );
 
     Saloon::assertSent(GetChannelPoliciesForUser::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getTeamPoliciesForUser method in the DataRetention resource', function () {
+it('calls the getTeamPoliciesForUser method in the DataRetention resource', function (): void {
     Saloon::fake([
         GetTeamPoliciesForUser::class => MockResponse::fixture('dataRetention.getTeamPoliciesForUser'),
     ]);
 
     $response = $this->mattermost->dataRetention()->getTeamPoliciesForUser(
-		userId: 'test string',
-		page: 123
-	);
+        userId: 'test string',
+        page: 123
+    );
 
     Saloon::assertSent(GetTeamPoliciesForUser::class);
 

--- a/src/Client/tests/EmojiTest.php
+++ b/src/Client/tests/EmojiTest.php
@@ -2,139 +2,131 @@
 
 // Generated 2026-04-10 23:46:41
 
-use ConduitUI\Mattermost\Client\Requests\Emoji\GetEmojiList;
-use ConduitUI\Mattermost\Client\Requests\Emoji\CreateEmoji;
+use ConduitUI\Mattermost\Client\Mattermost;
 use ConduitUI\Mattermost\Client\Requests\Emoji\AutocompleteEmoji;
-use ConduitUI\Mattermost\Client\Requests\Emoji\GetEmojiByName;
-use ConduitUI\Mattermost\Client\Requests\Emoji\SearchEmoji;
-use ConduitUI\Mattermost\Client\Requests\Emoji\GetEmoji;
+use ConduitUI\Mattermost\Client\Requests\Emoji\CreateEmoji;
 use ConduitUI\Mattermost\Client\Requests\Emoji\DeleteEmoji;
+use ConduitUI\Mattermost\Client\Requests\Emoji\GetEmoji;
+use ConduitUI\Mattermost\Client\Requests\Emoji\GetEmojiByName;
 use ConduitUI\Mattermost\Client\Requests\Emoji\GetEmojiImage;
+use ConduitUI\Mattermost\Client\Requests\Emoji\GetEmojiList;
+use ConduitUI\Mattermost\Client\Requests\Emoji\SearchEmoji;
 use Saloon\Http\Faking\MockResponse;
 use Saloon\Laravel\Facades\Saloon;
-use Spatie\LaravelData\DataCollection;
 
-beforeEach(function () {
-    $this->mattermost = new ConduitUI\Mattermost\Client\Mattermost(
-		bearerToken: 'replace'
-	);
+beforeEach(function (): void {
+    $this->mattermost = new Mattermost(
+        bearerToken: 'replace'
+    );
 });
 
-
-it('calls the getEmojiList method in the Emoji resource', function () {
+it('calls the getEmojiList method in the Emoji resource', function (): void {
     Saloon::fake([
         GetEmojiList::class => MockResponse::fixture('emoji.getEmojiList'),
     ]);
 
     $response = $this->mattermost->emoji()->getEmojiList(
-		page: 123,
-		sort: 'test string'
-	);
+        page: 123,
+        sort: 'test string'
+    );
 
     Saloon::assertSent(GetEmojiList::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the createEmoji method in the Emoji resource', function () {
+it('calls the createEmoji method in the Emoji resource', function (): void {
     Saloon::fake([
         CreateEmoji::class => MockResponse::fixture('emoji.createEmoji'),
     ]);
 
     $response = $this->mattermost->emoji()->createEmoji(
-		
-	);
+
+    );
 
     Saloon::assertSent(CreateEmoji::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the autocompleteEmoji method in the Emoji resource', function () {
+it('calls the autocompleteEmoji method in the Emoji resource', function (): void {
     Saloon::fake([
         AutocompleteEmoji::class => MockResponse::fixture('emoji.autocompleteEmoji'),
     ]);
 
     $response = $this->mattermost->emoji()->autocompleteEmoji(
-		name: 'test string'
-	);
+        name: 'test string'
+    );
 
     Saloon::assertSent(AutocompleteEmoji::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getEmojiByName method in the Emoji resource', function () {
+it('calls the getEmojiByName method in the Emoji resource', function (): void {
     Saloon::fake([
         GetEmojiByName::class => MockResponse::fixture('emoji.getEmojiByName'),
     ]);
 
     $response = $this->mattermost->emoji()->getEmojiByName(
-		emojiName: 'test string'
-	);
+        emojiName: 'test string'
+    );
 
     Saloon::assertSent(GetEmojiByName::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the searchEmoji method in the Emoji resource', function () {
+it('calls the searchEmoji method in the Emoji resource', function (): void {
     Saloon::fake([
         SearchEmoji::class => MockResponse::fixture('emoji.searchEmoji'),
     ]);
 
     $response = $this->mattermost->emoji()->searchEmoji(
-		
-	);
+
+    );
 
     Saloon::assertSent(SearchEmoji::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getEmoji method in the Emoji resource', function () {
+it('calls the getEmoji method in the Emoji resource', function (): void {
     Saloon::fake([
         GetEmoji::class => MockResponse::fixture('emoji.getEmoji'),
     ]);
 
     $response = $this->mattermost->emoji()->getEmoji(
-		emojiId: 'test string'
-	);
+        emojiId: 'test string'
+    );
 
     Saloon::assertSent(GetEmoji::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the deleteEmoji method in the Emoji resource', function () {
+it('calls the deleteEmoji method in the Emoji resource', function (): void {
     Saloon::fake([
         DeleteEmoji::class => MockResponse::fixture('emoji.deleteEmoji'),
     ]);
 
     $response = $this->mattermost->emoji()->deleteEmoji(
-		emojiId: 'test string'
-	);
+        emojiId: 'test string'
+    );
 
     Saloon::assertSent(DeleteEmoji::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getEmojiImage method in the Emoji resource', function () {
+it('calls the getEmojiImage method in the Emoji resource', function (): void {
     Saloon::fake([
         GetEmojiImage::class => MockResponse::fixture('emoji.getEmojiImage'),
     ]);
 
     $response = $this->mattermost->emoji()->getEmojiImage(
-		emojiId: 'test string'
-	);
+        emojiId: 'test string'
+    );
 
     Saloon::assertSent(GetEmojiImage::class);
 

--- a/src/Client/tests/FilesTest.php
+++ b/src/Client/tests/FilesTest.php
@@ -2,124 +2,117 @@
 
 // Generated 2026-04-10 23:46:41
 
-use ConduitUI\Mattermost\Client\Requests\Files\UploadFile;
+use ConduitUI\Mattermost\Client\Mattermost;
 use ConduitUI\Mattermost\Client\Requests\Files\GetFile;
 use ConduitUI\Mattermost\Client\Requests\Files\GetFileInfo;
 use ConduitUI\Mattermost\Client\Requests\Files\GetFileLink;
 use ConduitUI\Mattermost\Client\Requests\Files\GetFilePreview;
 use ConduitUI\Mattermost\Client\Requests\Files\GetFilePublic;
 use ConduitUI\Mattermost\Client\Requests\Files\GetFileThumbnail;
+use ConduitUI\Mattermost\Client\Requests\Files\UploadFile;
 use Saloon\Http\Faking\MockResponse;
 use Saloon\Laravel\Facades\Saloon;
-use Spatie\LaravelData\DataCollection;
 
-beforeEach(function () {
-    $this->mattermost = new ConduitUI\Mattermost\Client\Mattermost(
-		bearerToken: 'replace'
-	);
+beforeEach(function (): void {
+    $this->mattermost = new Mattermost(
+        bearerToken: 'replace'
+    );
 });
 
-
-it('calls the uploadFile method in the Files resource', function () {
+it('calls the uploadFile method in the Files resource', function (): void {
     Saloon::fake([
         UploadFile::class => MockResponse::fixture('files.uploadFile'),
     ]);
 
     $response = $this->mattermost->files()->uploadFile(
-		channelId: 'test string',
-		filename: 'test string'
-	);
+        channelId: 'test string',
+        filename: 'test string'
+    );
 
     Saloon::assertSent(UploadFile::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getFile method in the Files resource', function () {
+it('calls the getFile method in the Files resource', function (): void {
     Saloon::fake([
         GetFile::class => MockResponse::fixture('files.getFile'),
     ]);
 
     $response = $this->mattermost->files()->getFile(
-		fileId: 'test string'
-	);
+        fileId: 'test string'
+    );
 
     Saloon::assertSent(GetFile::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getFileInfo method in the Files resource', function () {
+it('calls the getFileInfo method in the Files resource', function (): void {
     Saloon::fake([
         GetFileInfo::class => MockResponse::fixture('files.getFileInfo'),
     ]);
 
     $response = $this->mattermost->files()->getFileInfo(
-		fileId: 'test string'
-	);
+        fileId: 'test string'
+    );
 
     Saloon::assertSent(GetFileInfo::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getFileLink method in the Files resource', function () {
+it('calls the getFileLink method in the Files resource', function (): void {
     Saloon::fake([
         GetFileLink::class => MockResponse::fixture('files.getFileLink'),
     ]);
 
     $response = $this->mattermost->files()->getFileLink(
-		fileId: 'test string'
-	);
+        fileId: 'test string'
+    );
 
     Saloon::assertSent(GetFileLink::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getFilePreview method in the Files resource', function () {
+it('calls the getFilePreview method in the Files resource', function (): void {
     Saloon::fake([
         GetFilePreview::class => MockResponse::fixture('files.getFilePreview'),
     ]);
 
     $response = $this->mattermost->files()->getFilePreview(
-		fileId: 'test string'
-	);
+        fileId: 'test string'
+    );
 
     Saloon::assertSent(GetFilePreview::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getFilePublic method in the Files resource', function () {
+it('calls the getFilePublic method in the Files resource', function (): void {
     Saloon::fake([
         GetFilePublic::class => MockResponse::fixture('files.getFilePublic'),
     ]);
 
     $response = $this->mattermost->files()->getFilePublic(
-		fileId: 'test string',
-		h: 'test string'
-	);
+        fileId: 'test string',
+        h: 'test string'
+    );
 
     Saloon::assertSent(GetFilePublic::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getFileThumbnail method in the Files resource', function () {
+it('calls the getFileThumbnail method in the Files resource', function (): void {
     Saloon::fake([
         GetFileThumbnail::class => MockResponse::fixture('files.getFileThumbnail'),
     ]);
 
     $response = $this->mattermost->files()->getFileThumbnail(
-		fileId: 'test string'
-	);
+        fileId: 'test string'
+    );
 
     Saloon::assertSent(GetFileThumbnail::class);
 

--- a/src/Client/tests/GroupsTest.php
+++ b/src/Client/tests/GroupsTest.php
@@ -2,81 +2,77 @@
 
 // Generated 2026-04-10 23:46:41
 
+use ConduitUI\Mattermost\Client\Mattermost;
+use ConduitUI\Mattermost\Client\Requests\Groups\GetGroupsAssociatedToChannelsByTeam;
 use ConduitUI\Mattermost\Client\Requests\Groups\GetGroupsByChannel;
 use ConduitUI\Mattermost\Client\Requests\Groups\GetGroupsByTeam;
-use ConduitUI\Mattermost\Client\Requests\Groups\GetGroupsAssociatedToChannelsByTeam;
 use ConduitUI\Mattermost\Client\Requests\Groups\GetGroupsByUserId;
 use Saloon\Http\Faking\MockResponse;
 use Saloon\Laravel\Facades\Saloon;
-use Spatie\LaravelData\DataCollection;
 
-beforeEach(function () {
-    $this->mattermost = new ConduitUI\Mattermost\Client\Mattermost(
-		bearerToken: 'replace'
-	);
+beforeEach(function (): void {
+    $this->mattermost = new Mattermost(
+        bearerToken: 'replace'
+    );
 });
 
-
-it('calls the getGroupsByChannel method in the Groups resource', function () {
+it('calls the getGroupsByChannel method in the Groups resource', function (): void {
     Saloon::fake([
         GetGroupsByChannel::class => MockResponse::fixture('groups.getGroupsByChannel'),
     ]);
 
     $response = $this->mattermost->groups()->getGroupsByChannel(
-		channelId: 'test string',
-		page: 123,
-		filterAllowReference: true
-	);
+        channelId: 'test string',
+        page: 123,
+        filterAllowReference: true
+    );
 
     Saloon::assertSent(GetGroupsByChannel::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getGroupsByTeam method in the Groups resource', function () {
+it('calls the getGroupsByTeam method in the Groups resource', function (): void {
     Saloon::fake([
         GetGroupsByTeam::class => MockResponse::fixture('groups.getGroupsByTeam'),
     ]);
 
     $response = $this->mattermost->groups()->getGroupsByTeam(
-		teamId: 'test string',
-		page: 123,
-		filterAllowReference: true
-	);
+        teamId: 'test string',
+        page: 123,
+        filterAllowReference: true
+    );
 
     Saloon::assertSent(GetGroupsByTeam::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getGroupsAssociatedToChannelsByTeam method in the Groups resource', function () {
+it('calls the getGroupsAssociatedToChannelsByTeam method in the Groups resource', function (): void {
     Saloon::fake([
         GetGroupsAssociatedToChannelsByTeam::class => MockResponse::fixture('groups.getGroupsAssociatedToChannelsByTeam'),
     ]);
 
     $response = $this->mattermost->groups()->getGroupsAssociatedToChannelsByTeam(
-		teamId: 'test string',
-		page: 123,
-		filterAllowReference: true,
-		paginate: true
-	);
+        teamId: 'test string',
+        page: 123,
+        filterAllowReference: true,
+        paginate: true
+    );
 
     Saloon::assertSent(GetGroupsAssociatedToChannelsByTeam::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getGroupsByUserId method in the Groups resource', function () {
+it('calls the getGroupsByUserId method in the Groups resource', function (): void {
     Saloon::fake([
         GetGroupsByUserId::class => MockResponse::fixture('groups.getGroupsByUserId'),
     ]);
 
     $response = $this->mattermost->groups()->getGroupsByUserId(
-		userId: 'test string'
-	);
+        userId: 'test string'
+    );
 
     Saloon::assertSent(GetGroupsByUserId::class);
 

--- a/src/Client/tests/InsightsTest.php
+++ b/src/Client/tests/InsightsTest.php
@@ -2,153 +2,145 @@
 
 // Generated 2026-04-10 23:46:41
 
-use ConduitUI\Mattermost\Client\Requests\Insights\GetTopChannelsForTeam;
-use ConduitUI\Mattermost\Client\Requests\Insights\GetTopReactionsForTeam;
+use ConduitUI\Mattermost\Client\Mattermost;
 use ConduitUI\Mattermost\Client\Requests\Insights\GetNewTeamMembers;
-use ConduitUI\Mattermost\Client\Requests\Insights\GetTopThreadsForTeam;
+use ConduitUI\Mattermost\Client\Requests\Insights\GetTopChannelsForTeam;
 use ConduitUI\Mattermost\Client\Requests\Insights\GetTopChannelsForUser;
 use ConduitUI\Mattermost\Client\Requests\Insights\GetTopDmsForUser;
+use ConduitUI\Mattermost\Client\Requests\Insights\GetTopReactionsForTeam;
 use ConduitUI\Mattermost\Client\Requests\Insights\GetTopReactionsForUser;
+use ConduitUI\Mattermost\Client\Requests\Insights\GetTopThreadsForTeam;
 use ConduitUI\Mattermost\Client\Requests\Insights\GetTopThreadsForUser;
 use Saloon\Http\Faking\MockResponse;
 use Saloon\Laravel\Facades\Saloon;
-use Spatie\LaravelData\DataCollection;
 
-beforeEach(function () {
-    $this->mattermost = new ConduitUI\Mattermost\Client\Mattermost(
-		bearerToken: 'replace'
-	);
+beforeEach(function (): void {
+    $this->mattermost = new Mattermost(
+        bearerToken: 'replace'
+    );
 });
 
-
-it('calls the getTopChannelsForTeam method in the Insights resource', function () {
+it('calls the getTopChannelsForTeam method in the Insights resource', function (): void {
     Saloon::fake([
         GetTopChannelsForTeam::class => MockResponse::fixture('insights.getTopChannelsForTeam'),
     ]);
 
     $response = $this->mattermost->insights()->getTopChannelsForTeam(
-		teamId: 'test string',
-		timeRange: 'test string',
-		page: 123
-	);
+        teamId: 'test string',
+        timeRange: 'test string',
+        page: 123
+    );
 
     Saloon::assertSent(GetTopChannelsForTeam::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getTopReactionsForTeam method in the Insights resource', function () {
+it('calls the getTopReactionsForTeam method in the Insights resource', function (): void {
     Saloon::fake([
         GetTopReactionsForTeam::class => MockResponse::fixture('insights.getTopReactionsForTeam'),
     ]);
 
     $response = $this->mattermost->insights()->getTopReactionsForTeam(
-		teamId: 'test string',
-		timeRange: 'test string',
-		page: 123
-	);
+        teamId: 'test string',
+        timeRange: 'test string',
+        page: 123
+    );
 
     Saloon::assertSent(GetTopReactionsForTeam::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getNewTeamMembers method in the Insights resource', function () {
+it('calls the getNewTeamMembers method in the Insights resource', function (): void {
     Saloon::fake([
         GetNewTeamMembers::class => MockResponse::fixture('insights.getNewTeamMembers'),
     ]);
 
     $response = $this->mattermost->insights()->getNewTeamMembers(
-		teamId: 'test string',
-		timeRange: 'test string',
-		page: 123
-	);
+        teamId: 'test string',
+        timeRange: 'test string',
+        page: 123
+    );
 
     Saloon::assertSent(GetNewTeamMembers::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getTopThreadsForTeam method in the Insights resource', function () {
+it('calls the getTopThreadsForTeam method in the Insights resource', function (): void {
     Saloon::fake([
         GetTopThreadsForTeam::class => MockResponse::fixture('insights.getTopThreadsForTeam'),
     ]);
 
     $response = $this->mattermost->insights()->getTopThreadsForTeam(
-		teamId: 'test string',
-		timeRange: 'test string',
-		page: 123
-	);
+        teamId: 'test string',
+        timeRange: 'test string',
+        page: 123
+    );
 
     Saloon::assertSent(GetTopThreadsForTeam::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getTopChannelsForUser method in the Insights resource', function () {
+it('calls the getTopChannelsForUser method in the Insights resource', function (): void {
     Saloon::fake([
         GetTopChannelsForUser::class => MockResponse::fixture('insights.getTopChannelsForUser'),
     ]);
 
     $response = $this->mattermost->insights()->getTopChannelsForUser(
-		timeRange: 'test string',
-		page: 123,
-		teamId: 'test string'
-	);
+        timeRange: 'test string',
+        page: 123,
+        teamId: 'test string'
+    );
 
     Saloon::assertSent(GetTopChannelsForUser::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getTopDmsForUser method in the Insights resource', function () {
+it('calls the getTopDmsForUser method in the Insights resource', function (): void {
     Saloon::fake([
         GetTopDmsForUser::class => MockResponse::fixture('insights.getTopDmsForUser'),
     ]);
 
     $response = $this->mattermost->insights()->getTopDmsForUser(
-		timeRange: 'test string',
-		page: 123
-	);
+        timeRange: 'test string',
+        page: 123
+    );
 
     Saloon::assertSent(GetTopDmsForUser::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getTopReactionsForUser method in the Insights resource', function () {
+it('calls the getTopReactionsForUser method in the Insights resource', function (): void {
     Saloon::fake([
         GetTopReactionsForUser::class => MockResponse::fixture('insights.getTopReactionsForUser'),
     ]);
 
     $response = $this->mattermost->insights()->getTopReactionsForUser(
-		timeRange: 'test string',
-		page: 123,
-		teamId: 'test string'
-	);
+        timeRange: 'test string',
+        page: 123,
+        teamId: 'test string'
+    );
 
     Saloon::assertSent(GetTopReactionsForUser::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getTopThreadsForUser method in the Insights resource', function () {
+it('calls the getTopThreadsForUser method in the Insights resource', function (): void {
     Saloon::fake([
         GetTopThreadsForUser::class => MockResponse::fixture('insights.getTopThreadsForUser'),
     ]);
 
     $response = $this->mattermost->insights()->getTopThreadsForUser(
-		timeRange: 'test string',
-		page: 123,
-		teamId: 'test string'
-	);
+        timeRange: 'test string',
+        page: 123,
+        teamId: 'test string'
+    );
 
     Saloon::assertSent(GetTopThreadsForUser::class);
 

--- a/src/Client/tests/OauthTest.php
+++ b/src/Client/tests/OauthTest.php
@@ -2,27 +2,26 @@
 
 // Generated 2026-04-10 23:46:41
 
+use ConduitUI\Mattermost\Client\Mattermost;
 use ConduitUI\Mattermost\Client\Requests\Oauth\GetAuthorizedOauthAppsForUser;
 use Saloon\Http\Faking\MockResponse;
 use Saloon\Laravel\Facades\Saloon;
-use Spatie\LaravelData\DataCollection;
 
-beforeEach(function () {
-    $this->mattermost = new ConduitUI\Mattermost\Client\Mattermost(
-		bearerToken: 'replace'
-	);
+beforeEach(function (): void {
+    $this->mattermost = new Mattermost(
+        bearerToken: 'replace'
+    );
 });
 
-
-it('calls the getAuthorizedOauthAppsForUser method in the Oauth resource', function () {
+it('calls the getAuthorizedOauthAppsForUser method in the Oauth resource', function (): void {
     Saloon::fake([
         GetAuthorizedOauthAppsForUser::class => MockResponse::fixture('oauth.getAuthorizedOauthAppsForUser'),
     ]);
 
     $response = $this->mattermost->oauth()->getAuthorizedOauthAppsForUser(
-		userId: 'test string',
-		page: 123
-	);
+        userId: 'test string',
+        page: 123
+    );
 
     Saloon::assertSent(GetAuthorizedOauthAppsForUser::class);
 

--- a/src/Client/tests/Pest.php
+++ b/src/Client/tests/Pest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use ConduitUI\Mattermost\Client\Tests\TestCase;
 
 uses(TestCase::class)->in(__DIR__);

--- a/src/Client/tests/PostsTest.php
+++ b/src/Client/tests/PostsTest.php
@@ -2,357 +2,336 @@
 
 // Generated 2026-04-10 23:46:41
 
-use ConduitUI\Mattermost\Client\Requests\Posts\GetPostsForChannel;
+use ConduitUI\Mattermost\Client\Mattermost;
 use ConduitUI\Mattermost\Client\Requests\Posts\CreatePost;
 use ConduitUI\Mattermost\Client\Requests\Posts\CreatePostEphemeral;
-use ConduitUI\Mattermost\Client\Requests\Posts\GetPostsByIds;
-use ConduitUI\Mattermost\Client\Requests\Posts\GetPost;
-use ConduitUI\Mattermost\Client\Requests\Posts\UpdatePost;
 use ConduitUI\Mattermost\Client\Requests\Posts\DeletePost;
 use ConduitUI\Mattermost\Client\Requests\Posts\DoPostAction;
 use ConduitUI\Mattermost\Client\Requests\Posts\GetFileInfosForPost;
+use ConduitUI\Mattermost\Client\Requests\Posts\GetFlaggedPostsForUser;
+use ConduitUI\Mattermost\Client\Requests\Posts\GetPost;
+use ConduitUI\Mattermost\Client\Requests\Posts\GetPostsAroundLastUnread;
+use ConduitUI\Mattermost\Client\Requests\Posts\GetPostsByIds;
+use ConduitUI\Mattermost\Client\Requests\Posts\GetPostsForChannel;
+use ConduitUI\Mattermost\Client\Requests\Posts\GetPostThread;
 use ConduitUI\Mattermost\Client\Requests\Posts\PatchPost;
 use ConduitUI\Mattermost\Client\Requests\Posts\PinPost;
-use ConduitUI\Mattermost\Client\Requests\Posts\GetPostThread;
-use ConduitUI\Mattermost\Client\Requests\Posts\UnpinPost;
+use ConduitUI\Mattermost\Client\Requests\Posts\SaveAcknowledgementForPost;
 use ConduitUI\Mattermost\Client\Requests\Posts\SearchPosts;
-use ConduitUI\Mattermost\Client\Requests\Posts\GetPostsAroundLastUnread;
-use ConduitUI\Mattermost\Client\Requests\Posts\GetFlaggedPostsForUser;
-use ConduitUI\Mattermost\Client\Requests\Posts\SaveAcknowledgementForPost;
-use ConduitUI\Mattermost\Client\Requests\Posts\SaveAcknowledgementForPost;
 use ConduitUI\Mattermost\Client\Requests\Posts\SetPostReminder;
 use ConduitUI\Mattermost\Client\Requests\Posts\SetPostUnread;
+use ConduitUI\Mattermost\Client\Requests\Posts\UnpinPost;
+use ConduitUI\Mattermost\Client\Requests\Posts\UpdatePost;
 use Saloon\Http\Faking\MockResponse;
 use Saloon\Laravel\Facades\Saloon;
-use Spatie\LaravelData\DataCollection;
 
-beforeEach(function () {
-    $this->mattermost = new ConduitUI\Mattermost\Client\Mattermost(
-		bearerToken: 'replace'
-	);
+beforeEach(function (): void {
+    $this->mattermost = new Mattermost(
+        bearerToken: 'replace'
+    );
 });
 
-
-it('calls the getPostsForChannel method in the Posts resource', function () {
+it('calls the getPostsForChannel method in the Posts resource', function (): void {
     Saloon::fake([
         GetPostsForChannel::class => MockResponse::fixture('posts.getPostsForChannel'),
     ]);
 
     $response = $this->mattermost->posts()->getPostsForChannel(
-		channelId: 'test string',
-		page: 123,
-		since: 123,
-		before: 'test string',
-		includeDeleted: true
-	);
+        channelId: 'test string',
+        page: 123,
+        since: 123,
+        before: 'test string',
+        includeDeleted: true
+    );
 
     Saloon::assertSent(GetPostsForChannel::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the createPost method in the Posts resource', function () {
+it('calls the createPost method in the Posts resource', function (): void {
     Saloon::fake([
         CreatePost::class => MockResponse::fixture('posts.createPost'),
     ]);
 
     $response = $this->mattermost->posts()->createPost(
-		setOnline: true
-	);
+        setOnline: true
+    );
 
     Saloon::assertSent(CreatePost::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the createPostEphemeral method in the Posts resource', function () {
+it('calls the createPostEphemeral method in the Posts resource', function (): void {
     Saloon::fake([
         CreatePostEphemeral::class => MockResponse::fixture('posts.createPostEphemeral'),
     ]);
 
     $response = $this->mattermost->posts()->createPostEphemeral(
-		
-	);
+
+    );
 
     Saloon::assertSent(CreatePostEphemeral::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getPostsByIds method in the Posts resource', function () {
+it('calls the getPostsByIds method in the Posts resource', function (): void {
     Saloon::fake([
         GetPostsByIds::class => MockResponse::fixture('posts.getPostsByIds'),
     ]);
 
     $response = $this->mattermost->posts()->getPostsByIds(
-		
-	);
+
+    );
 
     Saloon::assertSent(GetPostsByIds::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getPost method in the Posts resource', function () {
+it('calls the getPost method in the Posts resource', function (): void {
     Saloon::fake([
         GetPost::class => MockResponse::fixture('posts.getPost'),
     ]);
 
     $response = $this->mattermost->posts()->getPost(
-		postId: 'test string',
-		includeDeleted: true
-	);
+        postId: 'test string',
+        includeDeleted: true
+    );
 
     Saloon::assertSent(GetPost::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the updatePost method in the Posts resource', function () {
+it('calls the updatePost method in the Posts resource', function (): void {
     Saloon::fake([
         UpdatePost::class => MockResponse::fixture('posts.updatePost'),
     ]);
 
     $response = $this->mattermost->posts()->updatePost(
-		postId: 'test string'
-	);
+        postId: 'test string'
+    );
 
     Saloon::assertSent(UpdatePost::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the deletePost method in the Posts resource', function () {
+it('calls the deletePost method in the Posts resource', function (): void {
     Saloon::fake([
         DeletePost::class => MockResponse::fixture('posts.deletePost'),
     ]);
 
     $response = $this->mattermost->posts()->deletePost(
-		postId: 'test string'
-	);
+        postId: 'test string'
+    );
 
     Saloon::assertSent(DeletePost::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the doPostAction method in the Posts resource', function () {
+it('calls the doPostAction method in the Posts resource', function (): void {
     Saloon::fake([
         DoPostAction::class => MockResponse::fixture('posts.doPostAction'),
     ]);
 
     $response = $this->mattermost->posts()->doPostAction(
-		postId: 'test string',
-		actionId: 'test string'
-	);
+        postId: 'test string',
+        actionId: 'test string'
+    );
 
     Saloon::assertSent(DoPostAction::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getFileInfosForPost method in the Posts resource', function () {
+it('calls the getFileInfosForPost method in the Posts resource', function (): void {
     Saloon::fake([
         GetFileInfosForPost::class => MockResponse::fixture('posts.getFileInfosForPost'),
     ]);
 
     $response = $this->mattermost->posts()->getFileInfosForPost(
-		postId: 'test string',
-		includeDeleted: true
-	);
+        postId: 'test string',
+        includeDeleted: true
+    );
 
     Saloon::assertSent(GetFileInfosForPost::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the patchPost method in the Posts resource', function () {
+it('calls the patchPost method in the Posts resource', function (): void {
     Saloon::fake([
         PatchPost::class => MockResponse::fixture('posts.patchPost'),
     ]);
 
     $response = $this->mattermost->posts()->patchPost(
-		postId: 'test string'
-	);
+        postId: 'test string'
+    );
 
     Saloon::assertSent(PatchPost::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the pinPost method in the Posts resource', function () {
+it('calls the pinPost method in the Posts resource', function (): void {
     Saloon::fake([
         PinPost::class => MockResponse::fixture('posts.pinPost'),
     ]);
 
     $response = $this->mattermost->posts()->pinPost(
-		postId: 'test string'
-	);
+        postId: 'test string'
+    );
 
     Saloon::assertSent(PinPost::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getPostThread method in the Posts resource', function () {
+it('calls the getPostThread method in the Posts resource', function (): void {
     Saloon::fake([
         GetPostThread::class => MockResponse::fixture('posts.getPostThread'),
     ]);
 
     $response = $this->mattermost->posts()->getPostThread(
-		postId: 'test string',
-		perPage: 123,
-		fromPost: 'test string',
-		fromCreateAt: 123,
-		direction: 'test string',
-		skipFetchThreads: true,
-		collapsedThreads: true,
-		collapsedThreadsExtended: true
-	);
+        postId: 'test string',
+        perPage: 123,
+        fromPost: 'test string',
+        fromCreateAt: 123,
+        direction: 'test string',
+        skipFetchThreads: true,
+        collapsedThreads: true,
+        collapsedThreadsExtended: true
+    );
 
     Saloon::assertSent(GetPostThread::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the unpinPost method in the Posts resource', function () {
+it('calls the unpinPost method in the Posts resource', function (): void {
     Saloon::fake([
         UnpinPost::class => MockResponse::fixture('posts.unpinPost'),
     ]);
 
     $response = $this->mattermost->posts()->unpinPost(
-		postId: 'test string'
-	);
+        postId: 'test string'
+    );
 
     Saloon::assertSent(UnpinPost::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the searchPosts method in the Posts resource', function () {
+it('calls the searchPosts method in the Posts resource', function (): void {
     Saloon::fake([
         SearchPosts::class => MockResponse::fixture('posts.searchPosts'),
     ]);
 
     $response = $this->mattermost->posts()->searchPosts(
-		teamId: 'test string'
-	);
+        teamId: 'test string'
+    );
 
     Saloon::assertSent(SearchPosts::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getPostsAroundLastUnread method in the Posts resource', function () {
+it('calls the getPostsAroundLastUnread method in the Posts resource', function (): void {
     Saloon::fake([
         GetPostsAroundLastUnread::class => MockResponse::fixture('posts.getPostsAroundLastUnread'),
     ]);
 
     $response = $this->mattermost->posts()->getPostsAroundLastUnread(
-		userId: 'test string',
-		channelId: 'test string',
-		limitBefore: 123,
-		limitAfter: 123,
-		skipFetchThreads: true,
-		collapsedThreads: true,
-		collapsedThreadsExtended: true
-	);
+        userId: 'test string',
+        channelId: 'test string',
+        limitBefore: 123,
+        limitAfter: 123,
+        skipFetchThreads: true,
+        collapsedThreads: true,
+        collapsedThreadsExtended: true
+    );
 
     Saloon::assertSent(GetPostsAroundLastUnread::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getFlaggedPostsForUser method in the Posts resource', function () {
+it('calls the getFlaggedPostsForUser method in the Posts resource', function (): void {
     Saloon::fake([
         GetFlaggedPostsForUser::class => MockResponse::fixture('posts.getFlaggedPostsForUser'),
     ]);
 
     $response = $this->mattermost->posts()->getFlaggedPostsForUser(
-		userId: 'test string',
-		teamId: 'test string',
-		channelId: 'test string',
-		page: 123
-	);
+        userId: 'test string',
+        teamId: 'test string',
+        channelId: 'test string',
+        page: 123
+    );
 
     Saloon::assertSent(GetFlaggedPostsForUser::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the saveAcknowledgementForPost method in the Posts resource', function () {
+it('calls the saveAcknowledgementForPost method in the Posts resource', function (): void {
     Saloon::fake([
         SaveAcknowledgementForPost::class => MockResponse::fixture('posts.saveAcknowledgementForPost'),
     ]);
 
     $response = $this->mattermost->posts()->saveAcknowledgementForPost(
-		userId: 'test string',
-		postId: 'test string'
-	);
+        userId: 'test string',
+        postId: 'test string'
+    );
 
     Saloon::assertSent(SaveAcknowledgementForPost::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the saveAcknowledgementForPost method in the Posts resource', function () {
+it('calls the saveAcknowledgementForPost method in the Posts resource', function (): void {
     Saloon::fake([
         SaveAcknowledgementForPost::class => MockResponse::fixture('posts.saveAcknowledgementForPost'),
     ]);
 
     $response = $this->mattermost->posts()->saveAcknowledgementForPost(
-		userId: 'test string',
-		postId: 'test string'
-	);
+        userId: 'test string',
+        postId: 'test string'
+    );
 
     Saloon::assertSent(SaveAcknowledgementForPost::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the setPostReminder method in the Posts resource', function () {
+it('calls the setPostReminder method in the Posts resource', function (): void {
     Saloon::fake([
         SetPostReminder::class => MockResponse::fixture('posts.setPostReminder'),
     ]);
 
     $response = $this->mattermost->posts()->setPostReminder(
-		userId: 'test string',
-		postId: 'test string'
-	);
+        userId: 'test string',
+        postId: 'test string'
+    );
 
     Saloon::assertSent(SetPostReminder::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the setPostUnread method in the Posts resource', function () {
+it('calls the setPostUnread method in the Posts resource', function (): void {
     Saloon::fake([
         SetPostUnread::class => MockResponse::fixture('posts.setPostUnread'),
     ]);
 
     $response = $this->mattermost->posts()->setPostUnread(
-		userId: 'test string',
-		postId: 'test string'
-	);
+        userId: 'test string',
+        postId: 'test string'
+    );
 
     Saloon::assertSent(SetPostUnread::class);
 

--- a/src/Client/tests/PreferencesTest.php
+++ b/src/Client/tests/PreferencesTest.php
@@ -2,93 +2,88 @@
 
 // Generated 2026-04-10 23:46:41
 
-use ConduitUI\Mattermost\Client\Requests\Preferences\GetPreferences;
-use ConduitUI\Mattermost\Client\Requests\Preferences\UpdatePreferences;
+use ConduitUI\Mattermost\Client\Mattermost;
 use ConduitUI\Mattermost\Client\Requests\Preferences\DeletePreferences;
+use ConduitUI\Mattermost\Client\Requests\Preferences\GetPreferences;
 use ConduitUI\Mattermost\Client\Requests\Preferences\GetPreferencesByCategory;
 use ConduitUI\Mattermost\Client\Requests\Preferences\GetPreferencesByCategoryByName;
+use ConduitUI\Mattermost\Client\Requests\Preferences\UpdatePreferences;
 use Saloon\Http\Faking\MockResponse;
 use Saloon\Laravel\Facades\Saloon;
-use Spatie\LaravelData\DataCollection;
 
-beforeEach(function () {
-    $this->mattermost = new ConduitUI\Mattermost\Client\Mattermost(
-		bearerToken: 'replace'
-	);
+beforeEach(function (): void {
+    $this->mattermost = new Mattermost(
+        bearerToken: 'replace'
+    );
 });
 
-
-it('calls the getPreferences method in the Preferences resource', function () {
+it('calls the getPreferences method in the Preferences resource', function (): void {
     Saloon::fake([
         GetPreferences::class => MockResponse::fixture('preferences.getPreferences'),
     ]);
 
     $response = $this->mattermost->preferences()->getPreferences(
-		userId: 'test string'
-	);
+        userId: 'test string'
+    );
 
     Saloon::assertSent(GetPreferences::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the updatePreferences method in the Preferences resource', function () {
+it('calls the updatePreferences method in the Preferences resource', function (): void {
     Saloon::fake([
         UpdatePreferences::class => MockResponse::fixture('preferences.updatePreferences'),
     ]);
 
     $response = $this->mattermost->preferences()->updatePreferences(
-		userId: 'test string'
-	);
+        userId: 'test string'
+    );
 
     Saloon::assertSent(UpdatePreferences::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the deletePreferences method in the Preferences resource', function () {
+it('calls the deletePreferences method in the Preferences resource', function (): void {
     Saloon::fake([
         DeletePreferences::class => MockResponse::fixture('preferences.deletePreferences'),
     ]);
 
     $response = $this->mattermost->preferences()->deletePreferences(
-		userId: 'test string'
-	);
+        userId: 'test string'
+    );
 
     Saloon::assertSent(DeletePreferences::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getPreferencesByCategory method in the Preferences resource', function () {
+it('calls the getPreferencesByCategory method in the Preferences resource', function (): void {
     Saloon::fake([
         GetPreferencesByCategory::class => MockResponse::fixture('preferences.getPreferencesByCategory'),
     ]);
 
     $response = $this->mattermost->preferences()->getPreferencesByCategory(
-		userId: 'test string',
-		category: 'test string'
-	);
+        userId: 'test string',
+        category: 'test string'
+    );
 
     Saloon::assertSent(GetPreferencesByCategory::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getPreferencesByCategoryByName method in the Preferences resource', function () {
+it('calls the getPreferencesByCategoryByName method in the Preferences resource', function (): void {
     Saloon::fake([
         GetPreferencesByCategoryByName::class => MockResponse::fixture('preferences.getPreferencesByCategoryByName'),
     ]);
 
     $response = $this->mattermost->preferences()->getPreferencesByCategoryByName(
-		userId: 'test string',
-		category: 'test string',
-		preferenceName: 'test string'
-	);
+        userId: 'test string',
+        category: 'test string',
+        preferenceName: 'test string'
+    );
 
     Saloon::assertSent(GetPreferencesByCategoryByName::class);
 

--- a/src/Client/tests/ReactionsTest.php
+++ b/src/Client/tests/ReactionsTest.php
@@ -2,76 +2,72 @@
 
 // Generated 2026-04-10 23:46:41
 
+use ConduitUI\Mattermost\Client\Mattermost;
+use ConduitUI\Mattermost\Client\Requests\Reactions\DeleteReaction;
 use ConduitUI\Mattermost\Client\Requests\Reactions\GetBulkReactions;
 use ConduitUI\Mattermost\Client\Requests\Reactions\GetReactions;
 use ConduitUI\Mattermost\Client\Requests\Reactions\SaveReaction;
-use ConduitUI\Mattermost\Client\Requests\Reactions\DeleteReaction;
 use Saloon\Http\Faking\MockResponse;
 use Saloon\Laravel\Facades\Saloon;
-use Spatie\LaravelData\DataCollection;
 
-beforeEach(function () {
-    $this->mattermost = new ConduitUI\Mattermost\Client\Mattermost(
-		bearerToken: 'replace'
-	);
+beforeEach(function (): void {
+    $this->mattermost = new Mattermost(
+        bearerToken: 'replace'
+    );
 });
 
-
-it('calls the getBulkReactions method in the Reactions resource', function () {
+it('calls the getBulkReactions method in the Reactions resource', function (): void {
     Saloon::fake([
         GetBulkReactions::class => MockResponse::fixture('reactions.getBulkReactions'),
     ]);
 
     $response = $this->mattermost->reactions()->getBulkReactions(
-		
-	);
+
+    );
 
     Saloon::assertSent(GetBulkReactions::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getReactions method in the Reactions resource', function () {
+it('calls the getReactions method in the Reactions resource', function (): void {
     Saloon::fake([
         GetReactions::class => MockResponse::fixture('reactions.getReactions'),
     ]);
 
     $response = $this->mattermost->reactions()->getReactions(
-		postId: 'test string'
-	);
+        postId: 'test string'
+    );
 
     Saloon::assertSent(GetReactions::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the saveReaction method in the Reactions resource', function () {
+it('calls the saveReaction method in the Reactions resource', function (): void {
     Saloon::fake([
         SaveReaction::class => MockResponse::fixture('reactions.saveReaction'),
     ]);
 
     $response = $this->mattermost->reactions()->saveReaction(
-		
-	);
+
+    );
 
     Saloon::assertSent(SaveReaction::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the deleteReaction method in the Reactions resource', function () {
+it('calls the deleteReaction method in the Reactions resource', function (): void {
     Saloon::fake([
         DeleteReaction::class => MockResponse::fixture('reactions.deleteReaction'),
     ]);
 
     $response = $this->mattermost->reactions()->deleteReaction(
-		userId: 'test string',
-		postId: 'test string',
-		emojiName: 'test string'
-	);
+        userId: 'test string',
+        postId: 'test string',
+        emojiName: 'test string'
+    );
 
     Saloon::assertSent(DeleteReaction::class);
 

--- a/src/Client/tests/StatusTest.php
+++ b/src/Client/tests/StatusTest.php
@@ -2,122 +2,115 @@
 
 // Generated 2026-04-10 23:46:41
 
+use ConduitUI\Mattermost\Client\Mattermost;
 use ConduitUI\Mattermost\Client\Requests\Status\GetUsersStatusesByIds;
 use ConduitUI\Mattermost\Client\Requests\Status\GetUserStatus;
-use ConduitUI\Mattermost\Client\Requests\Status\UpdateUserStatus;
-use ConduitUI\Mattermost\Client\Requests\Status\UpdateUserCustomStatus;
-use ConduitUI\Mattermost\Client\Requests\Status\UnsetUserCustomStatus;
-use ConduitUI\Mattermost\Client\Requests\Status\RemoveRecentCustomStatus;
 use ConduitUI\Mattermost\Client\Requests\Status\PostUserRecentCustomStatusDelete;
+use ConduitUI\Mattermost\Client\Requests\Status\RemoveRecentCustomStatus;
+use ConduitUI\Mattermost\Client\Requests\Status\UnsetUserCustomStatus;
+use ConduitUI\Mattermost\Client\Requests\Status\UpdateUserCustomStatus;
+use ConduitUI\Mattermost\Client\Requests\Status\UpdateUserStatus;
 use Saloon\Http\Faking\MockResponse;
 use Saloon\Laravel\Facades\Saloon;
-use Spatie\LaravelData\DataCollection;
 
-beforeEach(function () {
-    $this->mattermost = new ConduitUI\Mattermost\Client\Mattermost(
-		bearerToken: 'replace'
-	);
+beforeEach(function (): void {
+    $this->mattermost = new Mattermost(
+        bearerToken: 'replace'
+    );
 });
 
-
-it('calls the getUsersStatusesByIds method in the Status resource', function () {
+it('calls the getUsersStatusesByIds method in the Status resource', function (): void {
     Saloon::fake([
         GetUsersStatusesByIds::class => MockResponse::fixture('status.getUsersStatusesByIds'),
     ]);
 
     $response = $this->mattermost->status()->getUsersStatusesByIds(
-		
-	);
+
+    );
 
     Saloon::assertSent(GetUsersStatusesByIds::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getUserStatus method in the Status resource', function () {
+it('calls the getUserStatus method in the Status resource', function (): void {
     Saloon::fake([
         GetUserStatus::class => MockResponse::fixture('status.getUserStatus'),
     ]);
 
     $response = $this->mattermost->status()->getUserStatus(
-		userId: 'test string'
-	);
+        userId: 'test string'
+    );
 
     Saloon::assertSent(GetUserStatus::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the updateUserStatus method in the Status resource', function () {
+it('calls the updateUserStatus method in the Status resource', function (): void {
     Saloon::fake([
         UpdateUserStatus::class => MockResponse::fixture('status.updateUserStatus'),
     ]);
 
     $response = $this->mattermost->status()->updateUserStatus(
-		userId: 'test string'
-	);
+        userId: 'test string'
+    );
 
     Saloon::assertSent(UpdateUserStatus::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the updateUserCustomStatus method in the Status resource', function () {
+it('calls the updateUserCustomStatus method in the Status resource', function (): void {
     Saloon::fake([
         UpdateUserCustomStatus::class => MockResponse::fixture('status.updateUserCustomStatus'),
     ]);
 
     $response = $this->mattermost->status()->updateUserCustomStatus(
-		userId: 'test string'
-	);
+        userId: 'test string'
+    );
 
     Saloon::assertSent(UpdateUserCustomStatus::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the unsetUserCustomStatus method in the Status resource', function () {
+it('calls the unsetUserCustomStatus method in the Status resource', function (): void {
     Saloon::fake([
         UnsetUserCustomStatus::class => MockResponse::fixture('status.unsetUserCustomStatus'),
     ]);
 
     $response = $this->mattermost->status()->unsetUserCustomStatus(
-		userId: 'test string'
-	);
+        userId: 'test string'
+    );
 
     Saloon::assertSent(UnsetUserCustomStatus::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the removeRecentCustomStatus method in the Status resource', function () {
+it('calls the removeRecentCustomStatus method in the Status resource', function (): void {
     Saloon::fake([
         RemoveRecentCustomStatus::class => MockResponse::fixture('status.removeRecentCustomStatus'),
     ]);
 
     $response = $this->mattermost->status()->removeRecentCustomStatus(
-		userId: 'test string'
-	);
+        userId: 'test string'
+    );
 
     Saloon::assertSent(RemoveRecentCustomStatus::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the postUserRecentCustomStatusDelete method in the Status resource', function () {
+it('calls the postUserRecentCustomStatusDelete method in the Status resource', function (): void {
     Saloon::fake([
         PostUserRecentCustomStatusDelete::class => MockResponse::fixture('status.postUserRecentCustomStatusDelete'),
     ]);
 
     $response = $this->mattermost->status()->postUserRecentCustomStatusDelete(
-		userId: 'test string'
-	);
+        userId: 'test string'
+    );
 
     Saloon::assertSent(PostUserRecentCustomStatusDelete::class);
 

--- a/src/Client/tests/SystemTest.php
+++ b/src/Client/tests/SystemTest.php
@@ -2,94 +2,89 @@
 
 // Generated 2026-04-10 23:46:41
 
-use ConduitUI\Mattermost\Client\Requests\System\MarkNoticesViewed;
+use ConduitUI\Mattermost\Client\Mattermost;
+use ConduitUI\Mattermost\Client\Requests\System\GenerateSupportPacket;
 use ConduitUI\Mattermost\Client\Requests\System\GetNotices;
 use ConduitUI\Mattermost\Client\Requests\System\GetPing;
-use ConduitUI\Mattermost\Client\Requests\System\GenerateSupportPacket;
 use ConduitUI\Mattermost\Client\Requests\System\GetSupportedTimezone;
+use ConduitUI\Mattermost\Client\Requests\System\MarkNoticesViewed;
 use Saloon\Http\Faking\MockResponse;
 use Saloon\Laravel\Facades\Saloon;
-use Spatie\LaravelData\DataCollection;
 
-beforeEach(function () {
-    $this->mattermost = new ConduitUI\Mattermost\Client\Mattermost(
-		bearerToken: 'replace'
-	);
+beforeEach(function (): void {
+    $this->mattermost = new Mattermost(
+        bearerToken: 'replace'
+    );
 });
 
-
-it('calls the markNoticesViewed method in the System resource', function () {
+it('calls the markNoticesViewed method in the System resource', function (): void {
     Saloon::fake([
         MarkNoticesViewed::class => MockResponse::fixture('system.markNoticesViewed'),
     ]);
 
     $response = $this->mattermost->system()->markNoticesViewed(
-		
-	);
+
+    );
 
     Saloon::assertSent(MarkNoticesViewed::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getNotices method in the System resource', function () {
+it('calls the getNotices method in the System resource', function (): void {
     Saloon::fake([
         GetNotices::class => MockResponse::fixture('system.getNotices'),
     ]);
 
     $response = $this->mattermost->system()->getNotices(
-		teamId: 'test string',
-		clientVersion: 'test string',
-		locale: 'test string',
-		client: 'test string'
-	);
+        teamId: 'test string',
+        clientVersion: 'test string',
+        locale: 'test string',
+        client: 'test string'
+    );
 
     Saloon::assertSent(GetNotices::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getPing method in the System resource', function () {
+it('calls the getPing method in the System resource', function (): void {
     Saloon::fake([
         GetPing::class => MockResponse::fixture('system.getPing'),
     ]);
 
     $response = $this->mattermost->system()->getPing(
-		getServerStatus: true,
-		deviceId: 'test string'
-	);
+        getServerStatus: true,
+        deviceId: 'test string'
+    );
 
     Saloon::assertSent(GetPing::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the generateSupportPacket method in the System resource', function () {
+it('calls the generateSupportPacket method in the System resource', function (): void {
     Saloon::fake([
         GenerateSupportPacket::class => MockResponse::fixture('system.generateSupportPacket'),
     ]);
 
     $response = $this->mattermost->system()->generateSupportPacket(
-		
-	);
+
+    );
 
     Saloon::assertSent(GenerateSupportPacket::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getSupportedTimezone method in the System resource', function () {
+it('calls the getSupportedTimezone method in the System resource', function (): void {
     Saloon::fake([
         GetSupportedTimezone::class => MockResponse::fixture('system.getSupportedTimezone'),
     ]);
 
     $response = $this->mattermost->system()->getSupportedTimezone(
-		
-	);
+
+    );
 
     Saloon::assertSent(GetSupportedTimezone::class);
 

--- a/src/Client/tests/TeamsTest.php
+++ b/src/Client/tests/TeamsTest.php
@@ -2,616 +2,579 @@
 
 // Generated 2026-04-10 23:46:41
 
-use ConduitUI\Mattermost\Client\Requests\Teams\GetAllTeams;
-use ConduitUI\Mattermost\Client\Requests\Teams\CreateTeam;
-use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamInviteInfo;
-use ConduitUI\Mattermost\Client\Requests\Teams\InvalidateEmailInvites;
-use ConduitUI\Mattermost\Client\Requests\Teams\AddTeamMemberFromInvite;
-use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamByName;
-use ConduitUI\Mattermost\Client\Requests\Teams\TeamExists;
-use ConduitUI\Mattermost\Client\Requests\Teams\SearchTeams;
-use ConduitUI\Mattermost\Client\Requests\Teams\GetTeam;
-use ConduitUI\Mattermost\Client\Requests\Teams\UpdateTeam;
-use ConduitUI\Mattermost\Client\Requests\Teams\SoftDeleteTeam;
-use ConduitUI\Mattermost\Client\Requests\Teams\SearchFiles;
-use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamIcon;
-use ConduitUI\Mattermost\Client\Requests\Teams\SetTeamIcon;
-use ConduitUI\Mattermost\Client\Requests\Teams\RemoveTeamIcon;
-use ConduitUI\Mattermost\Client\Requests\Teams\ImportTeam;
-use ConduitUI\Mattermost\Client\Requests\Teams\InviteGuestsToTeam;
-use ConduitUI\Mattermost\Client\Requests\Teams\InviteUsersToTeam;
-use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamMembers;
+use ConduitUI\Mattermost\Client\Mattermost;
 use ConduitUI\Mattermost\Client\Requests\Teams\AddTeamMember;
+use ConduitUI\Mattermost\Client\Requests\Teams\AddTeamMemberFromInvite;
 use ConduitUI\Mattermost\Client\Requests\Teams\AddTeamMembers;
-use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamMembersByIds;
+use ConduitUI\Mattermost\Client\Requests\Teams\CreateTeam;
+use ConduitUI\Mattermost\Client\Requests\Teams\GetAllTeams;
+use ConduitUI\Mattermost\Client\Requests\Teams\GetTeam;
+use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamByName;
+use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamIcon;
+use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamInviteInfo;
 use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamMember;
-use ConduitUI\Mattermost\Client\Requests\Teams\RemoveTeamMember;
-use ConduitUI\Mattermost\Client\Requests\Teams\UpdateTeamMemberRoles;
-use ConduitUI\Mattermost\Client\Requests\Teams\UpdateTeamMemberSchemeRoles;
-use ConduitUI\Mattermost\Client\Requests\Teams\TeamMembersMinusGroupMembers;
-use ConduitUI\Mattermost\Client\Requests\Teams\PatchTeam;
-use ConduitUI\Mattermost\Client\Requests\Teams\UpdateTeamPrivacy;
-use ConduitUI\Mattermost\Client\Requests\Teams\RegenerateTeamInviteId;
-use ConduitUI\Mattermost\Client\Requests\Teams\RestoreTeam;
-use ConduitUI\Mattermost\Client\Requests\Teams\UpdateTeamScheme;
-use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamStats;
-use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamsForUser;
+use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamMembers;
+use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamMembersByIds;
 use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamMembersForUser;
+use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamsForUser;
+use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamStats;
 use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamsUnreadForUser;
 use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamUnread;
+use ConduitUI\Mattermost\Client\Requests\Teams\ImportTeam;
+use ConduitUI\Mattermost\Client\Requests\Teams\InvalidateEmailInvites;
+use ConduitUI\Mattermost\Client\Requests\Teams\InviteGuestsToTeam;
+use ConduitUI\Mattermost\Client\Requests\Teams\InviteUsersToTeam;
+use ConduitUI\Mattermost\Client\Requests\Teams\PatchTeam;
+use ConduitUI\Mattermost\Client\Requests\Teams\RegenerateTeamInviteId;
+use ConduitUI\Mattermost\Client\Requests\Teams\RemoveTeamIcon;
+use ConduitUI\Mattermost\Client\Requests\Teams\RemoveTeamMember;
+use ConduitUI\Mattermost\Client\Requests\Teams\RestoreTeam;
+use ConduitUI\Mattermost\Client\Requests\Teams\SearchFiles;
+use ConduitUI\Mattermost\Client\Requests\Teams\SearchTeams;
+use ConduitUI\Mattermost\Client\Requests\Teams\SetTeamIcon;
+use ConduitUI\Mattermost\Client\Requests\Teams\SoftDeleteTeam;
+use ConduitUI\Mattermost\Client\Requests\Teams\TeamExists;
+use ConduitUI\Mattermost\Client\Requests\Teams\TeamMembersMinusGroupMembers;
+use ConduitUI\Mattermost\Client\Requests\Teams\UpdateTeam;
+use ConduitUI\Mattermost\Client\Requests\Teams\UpdateTeamMemberRoles;
+use ConduitUI\Mattermost\Client\Requests\Teams\UpdateTeamMemberSchemeRoles;
+use ConduitUI\Mattermost\Client\Requests\Teams\UpdateTeamPrivacy;
+use ConduitUI\Mattermost\Client\Requests\Teams\UpdateTeamScheme;
 use Saloon\Http\Faking\MockResponse;
 use Saloon\Laravel\Facades\Saloon;
-use Spatie\LaravelData\DataCollection;
 
-beforeEach(function () {
-    $this->mattermost = new ConduitUI\Mattermost\Client\Mattermost(
-		bearerToken: 'replace'
-	);
+beforeEach(function (): void {
+    $this->mattermost = new Mattermost(
+        bearerToken: 'replace'
+    );
 });
 
-
-it('calls the getAllTeams method in the Teams resource', function () {
+it('calls the getAllTeams method in the Teams resource', function (): void {
     Saloon::fake([
         GetAllTeams::class => MockResponse::fixture('teams.getAllTeams'),
     ]);
 
     $response = $this->mattermost->teams()->getAllTeams(
-		page: 123,
-		includeTotalCount: true,
-		excludePolicyConstrained: true
-	);
+        page: 123,
+        includeTotalCount: true,
+        excludePolicyConstrained: true
+    );
 
     Saloon::assertSent(GetAllTeams::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the createTeam method in the Teams resource', function () {
+it('calls the createTeam method in the Teams resource', function (): void {
     Saloon::fake([
         CreateTeam::class => MockResponse::fixture('teams.createTeam'),
     ]);
 
     $response = $this->mattermost->teams()->createTeam(
-		
-	);
+
+    );
 
     Saloon::assertSent(CreateTeam::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getTeamInviteInfo method in the Teams resource', function () {
+it('calls the getTeamInviteInfo method in the Teams resource', function (): void {
     Saloon::fake([
         GetTeamInviteInfo::class => MockResponse::fixture('teams.getTeamInviteInfo'),
     ]);
 
     $response = $this->mattermost->teams()->getTeamInviteInfo(
-		inviteId: 'test string'
-	);
+        inviteId: 'test string'
+    );
 
     Saloon::assertSent(GetTeamInviteInfo::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the invalidateEmailInvites method in the Teams resource', function () {
+it('calls the invalidateEmailInvites method in the Teams resource', function (): void {
     Saloon::fake([
         InvalidateEmailInvites::class => MockResponse::fixture('teams.invalidateEmailInvites'),
     ]);
 
     $response = $this->mattermost->teams()->invalidateEmailInvites(
-		
-	);
+
+    );
 
     Saloon::assertSent(InvalidateEmailInvites::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the addTeamMemberFromInvite method in the Teams resource', function () {
+it('calls the addTeamMemberFromInvite method in the Teams resource', function (): void {
     Saloon::fake([
         AddTeamMemberFromInvite::class => MockResponse::fixture('teams.addTeamMemberFromInvite'),
     ]);
 
     $response = $this->mattermost->teams()->addTeamMemberFromInvite(
-		token: 'test string'
-	);
+        token: 'test string'
+    );
 
     Saloon::assertSent(AddTeamMemberFromInvite::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getTeamByName method in the Teams resource', function () {
+it('calls the getTeamByName method in the Teams resource', function (): void {
     Saloon::fake([
         GetTeamByName::class => MockResponse::fixture('teams.getTeamByName'),
     ]);
 
     $response = $this->mattermost->teams()->getTeamByName(
-		name: 'test string'
-	);
+        name: 'test string'
+    );
 
     Saloon::assertSent(GetTeamByName::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the teamExists method in the Teams resource', function () {
+it('calls the teamExists method in the Teams resource', function (): void {
     Saloon::fake([
         TeamExists::class => MockResponse::fixture('teams.teamExists'),
     ]);
 
     $response = $this->mattermost->teams()->teamExists(
-		name: 'test string'
-	);
+        name: 'test string'
+    );
 
     Saloon::assertSent(TeamExists::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the searchTeams method in the Teams resource', function () {
+it('calls the searchTeams method in the Teams resource', function (): void {
     Saloon::fake([
         SearchTeams::class => MockResponse::fixture('teams.searchTeams'),
     ]);
 
     $response = $this->mattermost->teams()->searchTeams(
-		
-	);
+
+    );
 
     Saloon::assertSent(SearchTeams::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getTeam method in the Teams resource', function () {
+it('calls the getTeam method in the Teams resource', function (): void {
     Saloon::fake([
         GetTeam::class => MockResponse::fixture('teams.getTeam'),
     ]);
 
     $response = $this->mattermost->teams()->getTeam(
-		teamId: 'test string'
-	);
+        teamId: 'test string'
+    );
 
     Saloon::assertSent(GetTeam::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the updateTeam method in the Teams resource', function () {
+it('calls the updateTeam method in the Teams resource', function (): void {
     Saloon::fake([
         UpdateTeam::class => MockResponse::fixture('teams.updateTeam'),
     ]);
 
     $response = $this->mattermost->teams()->updateTeam(
-		teamId: 'test string'
-	);
+        teamId: 'test string'
+    );
 
     Saloon::assertSent(UpdateTeam::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the softDeleteTeam method in the Teams resource', function () {
+it('calls the softDeleteTeam method in the Teams resource', function (): void {
     Saloon::fake([
         SoftDeleteTeam::class => MockResponse::fixture('teams.softDeleteTeam'),
     ]);
 
     $response = $this->mattermost->teams()->softDeleteTeam(
-		teamId: 'test string',
-		permanent: true
-	);
+        teamId: 'test string',
+        permanent: true
+    );
 
     Saloon::assertSent(SoftDeleteTeam::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the searchFiles method in the Teams resource', function () {
+it('calls the searchFiles method in the Teams resource', function (): void {
     Saloon::fake([
         SearchFiles::class => MockResponse::fixture('teams.searchFiles'),
     ]);
 
     $response = $this->mattermost->teams()->searchFiles(
-		teamId: 'test string'
-	);
+        teamId: 'test string'
+    );
 
     Saloon::assertSent(SearchFiles::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getTeamIcon method in the Teams resource', function () {
+it('calls the getTeamIcon method in the Teams resource', function (): void {
     Saloon::fake([
         GetTeamIcon::class => MockResponse::fixture('teams.getTeamIcon'),
     ]);
 
     $response = $this->mattermost->teams()->getTeamIcon(
-		teamId: 'test string'
-	);
+        teamId: 'test string'
+    );
 
     Saloon::assertSent(GetTeamIcon::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the setTeamIcon method in the Teams resource', function () {
+it('calls the setTeamIcon method in the Teams resource', function (): void {
     Saloon::fake([
         SetTeamIcon::class => MockResponse::fixture('teams.setTeamIcon'),
     ]);
 
     $response = $this->mattermost->teams()->setTeamIcon(
-		teamId: 'test string'
-	);
+        teamId: 'test string'
+    );
 
     Saloon::assertSent(SetTeamIcon::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the removeTeamIcon method in the Teams resource', function () {
+it('calls the removeTeamIcon method in the Teams resource', function (): void {
     Saloon::fake([
         RemoveTeamIcon::class => MockResponse::fixture('teams.removeTeamIcon'),
     ]);
 
     $response = $this->mattermost->teams()->removeTeamIcon(
-		teamId: 'test string'
-	);
+        teamId: 'test string'
+    );
 
     Saloon::assertSent(RemoveTeamIcon::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the importTeam method in the Teams resource', function () {
+it('calls the importTeam method in the Teams resource', function (): void {
     Saloon::fake([
         ImportTeam::class => MockResponse::fixture('teams.importTeam'),
     ]);
 
     $response = $this->mattermost->teams()->importTeam(
-		teamId: 'test string'
-	);
+        teamId: 'test string'
+    );
 
     Saloon::assertSent(ImportTeam::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the inviteGuestsToTeam method in the Teams resource', function () {
+it('calls the inviteGuestsToTeam method in the Teams resource', function (): void {
     Saloon::fake([
         InviteGuestsToTeam::class => MockResponse::fixture('teams.inviteGuestsToTeam'),
     ]);
 
     $response = $this->mattermost->teams()->inviteGuestsToTeam(
-		teamId: 'test string'
-	);
+        teamId: 'test string'
+    );
 
     Saloon::assertSent(InviteGuestsToTeam::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the inviteUsersToTeam method in the Teams resource', function () {
+it('calls the inviteUsersToTeam method in the Teams resource', function (): void {
     Saloon::fake([
         InviteUsersToTeam::class => MockResponse::fixture('teams.inviteUsersToTeam'),
     ]);
 
     $response = $this->mattermost->teams()->inviteUsersToTeam(
-		teamId: 'test string'
-	);
+        teamId: 'test string'
+    );
 
     Saloon::assertSent(InviteUsersToTeam::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getTeamMembers method in the Teams resource', function () {
+it('calls the getTeamMembers method in the Teams resource', function (): void {
     Saloon::fake([
         GetTeamMembers::class => MockResponse::fixture('teams.getTeamMembers'),
     ]);
 
     $response = $this->mattermost->teams()->getTeamMembers(
-		teamId: 'test string',
-		page: 123
-	);
+        teamId: 'test string',
+        page: 123
+    );
 
     Saloon::assertSent(GetTeamMembers::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the addTeamMember method in the Teams resource', function () {
+it('calls the addTeamMember method in the Teams resource', function (): void {
     Saloon::fake([
         AddTeamMember::class => MockResponse::fixture('teams.addTeamMember'),
     ]);
 
     $response = $this->mattermost->teams()->addTeamMember(
-		teamId: 'test string'
-	);
+        teamId: 'test string'
+    );
 
     Saloon::assertSent(AddTeamMember::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the addTeamMembers method in the Teams resource', function () {
+it('calls the addTeamMembers method in the Teams resource', function (): void {
     Saloon::fake([
         AddTeamMembers::class => MockResponse::fixture('teams.addTeamMembers'),
     ]);
 
     $response = $this->mattermost->teams()->addTeamMembers(
-		teamId: 'test string',
-		graceful: true
-	);
+        teamId: 'test string',
+        graceful: true
+    );
 
     Saloon::assertSent(AddTeamMembers::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getTeamMembersByIds method in the Teams resource', function () {
+it('calls the getTeamMembersByIds method in the Teams resource', function (): void {
     Saloon::fake([
         GetTeamMembersByIds::class => MockResponse::fixture('teams.getTeamMembersByIds'),
     ]);
 
     $response = $this->mattermost->teams()->getTeamMembersByIds(
-		teamId: 'test string'
-	);
+        teamId: 'test string'
+    );
 
     Saloon::assertSent(GetTeamMembersByIds::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getTeamMember method in the Teams resource', function () {
+it('calls the getTeamMember method in the Teams resource', function (): void {
     Saloon::fake([
         GetTeamMember::class => MockResponse::fixture('teams.getTeamMember'),
     ]);
 
     $response = $this->mattermost->teams()->getTeamMember(
-		teamId: 'test string',
-		userId: 'test string'
-	);
+        teamId: 'test string',
+        userId: 'test string'
+    );
 
     Saloon::assertSent(GetTeamMember::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the removeTeamMember method in the Teams resource', function () {
+it('calls the removeTeamMember method in the Teams resource', function (): void {
     Saloon::fake([
         RemoveTeamMember::class => MockResponse::fixture('teams.removeTeamMember'),
     ]);
 
     $response = $this->mattermost->teams()->removeTeamMember(
-		teamId: 'test string',
-		userId: 'test string'
-	);
+        teamId: 'test string',
+        userId: 'test string'
+    );
 
     Saloon::assertSent(RemoveTeamMember::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the updateTeamMemberRoles method in the Teams resource', function () {
+it('calls the updateTeamMemberRoles method in the Teams resource', function (): void {
     Saloon::fake([
         UpdateTeamMemberRoles::class => MockResponse::fixture('teams.updateTeamMemberRoles'),
     ]);
 
     $response = $this->mattermost->teams()->updateTeamMemberRoles(
-		teamId: 'test string',
-		userId: 'test string'
-	);
+        teamId: 'test string',
+        userId: 'test string'
+    );
 
     Saloon::assertSent(UpdateTeamMemberRoles::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the updateTeamMemberSchemeRoles method in the Teams resource', function () {
+it('calls the updateTeamMemberSchemeRoles method in the Teams resource', function (): void {
     Saloon::fake([
         UpdateTeamMemberSchemeRoles::class => MockResponse::fixture('teams.updateTeamMemberSchemeRoles'),
     ]);
 
     $response = $this->mattermost->teams()->updateTeamMemberSchemeRoles(
-		teamId: 'test string',
-		userId: 'test string'
-	);
+        teamId: 'test string',
+        userId: 'test string'
+    );
 
     Saloon::assertSent(UpdateTeamMemberSchemeRoles::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the teamMembersMinusGroupMembers method in the Teams resource', function () {
+it('calls the teamMembersMinusGroupMembers method in the Teams resource', function (): void {
     Saloon::fake([
         TeamMembersMinusGroupMembers::class => MockResponse::fixture('teams.teamMembersMinusGroupMembers'),
     ]);
 
     $response = $this->mattermost->teams()->teamMembersMinusGroupMembers(
-		teamId: 'test string',
-		groupIds: 'test string',
-		page: 123
-	);
+        teamId: 'test string',
+        groupIds: 'test string',
+        page: 123
+    );
 
     Saloon::assertSent(TeamMembersMinusGroupMembers::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the patchTeam method in the Teams resource', function () {
+it('calls the patchTeam method in the Teams resource', function (): void {
     Saloon::fake([
         PatchTeam::class => MockResponse::fixture('teams.patchTeam'),
     ]);
 
     $response = $this->mattermost->teams()->patchTeam(
-		teamId: 'test string'
-	);
+        teamId: 'test string'
+    );
 
     Saloon::assertSent(PatchTeam::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the updateTeamPrivacy method in the Teams resource', function () {
+it('calls the updateTeamPrivacy method in the Teams resource', function (): void {
     Saloon::fake([
         UpdateTeamPrivacy::class => MockResponse::fixture('teams.updateTeamPrivacy'),
     ]);
 
     $response = $this->mattermost->teams()->updateTeamPrivacy(
-		teamId: 'test string'
-	);
+        teamId: 'test string'
+    );
 
     Saloon::assertSent(UpdateTeamPrivacy::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the regenerateTeamInviteId method in the Teams resource', function () {
+it('calls the regenerateTeamInviteId method in the Teams resource', function (): void {
     Saloon::fake([
         RegenerateTeamInviteId::class => MockResponse::fixture('teams.regenerateTeamInviteId'),
     ]);
 
     $response = $this->mattermost->teams()->regenerateTeamInviteId(
-		teamId: 'test string'
-	);
+        teamId: 'test string'
+    );
 
     Saloon::assertSent(RegenerateTeamInviteId::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the restoreTeam method in the Teams resource', function () {
+it('calls the restoreTeam method in the Teams resource', function (): void {
     Saloon::fake([
         RestoreTeam::class => MockResponse::fixture('teams.restoreTeam'),
     ]);
 
     $response = $this->mattermost->teams()->restoreTeam(
-		teamId: 'test string'
-	);
+        teamId: 'test string'
+    );
 
     Saloon::assertSent(RestoreTeam::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the updateTeamScheme method in the Teams resource', function () {
+it('calls the updateTeamScheme method in the Teams resource', function (): void {
     Saloon::fake([
         UpdateTeamScheme::class => MockResponse::fixture('teams.updateTeamScheme'),
     ]);
 
     $response = $this->mattermost->teams()->updateTeamScheme(
-		teamId: 'test string'
-	);
+        teamId: 'test string'
+    );
 
     Saloon::assertSent(UpdateTeamScheme::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getTeamStats method in the Teams resource', function () {
+it('calls the getTeamStats method in the Teams resource', function (): void {
     Saloon::fake([
         GetTeamStats::class => MockResponse::fixture('teams.getTeamStats'),
     ]);
 
     $response = $this->mattermost->teams()->getTeamStats(
-		teamId: 'test string'
-	);
+        teamId: 'test string'
+    );
 
     Saloon::assertSent(GetTeamStats::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getTeamsForUser method in the Teams resource', function () {
+it('calls the getTeamsForUser method in the Teams resource', function (): void {
     Saloon::fake([
         GetTeamsForUser::class => MockResponse::fixture('teams.getTeamsForUser'),
     ]);
 
     $response = $this->mattermost->teams()->getTeamsForUser(
-		userId: 'test string'
-	);
+        userId: 'test string'
+    );
 
     Saloon::assertSent(GetTeamsForUser::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getTeamMembersForUser method in the Teams resource', function () {
+it('calls the getTeamMembersForUser method in the Teams resource', function (): void {
     Saloon::fake([
         GetTeamMembersForUser::class => MockResponse::fixture('teams.getTeamMembersForUser'),
     ]);
 
     $response = $this->mattermost->teams()->getTeamMembersForUser(
-		userId: 'test string'
-	);
+        userId: 'test string'
+    );
 
     Saloon::assertSent(GetTeamMembersForUser::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getTeamsUnreadForUser method in the Teams resource', function () {
+it('calls the getTeamsUnreadForUser method in the Teams resource', function (): void {
     Saloon::fake([
         GetTeamsUnreadForUser::class => MockResponse::fixture('teams.getTeamsUnreadForUser'),
     ]);
 
     $response = $this->mattermost->teams()->getTeamsUnreadForUser(
-		userId: 'test string',
-		excludeTeam: 'test string',
-		includeCollapsedThreads: true
-	);
+        userId: 'test string',
+        excludeTeam: 'test string',
+        includeCollapsedThreads: true
+    );
 
     Saloon::assertSent(GetTeamsUnreadForUser::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getTeamUnread method in the Teams resource', function () {
+it('calls the getTeamUnread method in the Teams resource', function (): void {
     Saloon::fake([
         GetTeamUnread::class => MockResponse::fixture('teams.getTeamUnread'),
     ]);
 
     $response = $this->mattermost->teams()->getTeamUnread(
-		userId: 'test string',
-		teamId: 'test string'
-	);
+        userId: 'test string',
+        teamId: 'test string'
+    );
 
     Saloon::assertSent(GetTeamUnread::class);
 

--- a/src/Client/tests/TestCase.php
+++ b/src/Client/tests/TestCase.php
@@ -1,12 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ConduitUI\Mattermost\Client;
 
 use Dotenv\Dotenv;
 use Orchestra\Testbench\TestCase as Orchestra;
 use Saloon\Laravel\SaloonServiceProvider;
 use Spatie\LaravelData\LaravelDataServiceProvider;
-use ConduitUI\Mattermost\Client\MattermostServiceProvider;
 
 class TestCase extends Orchestra
 {
@@ -19,7 +20,7 @@ class TestCase extends Orchestra
         ];
     }
 
-    public function getEnvironmentSetUp($app)
+    public function getEnvironmentSetUp($app): void
     {
         // Load .env.test into the environment.
         if (file_exists(dirname(__DIR__).'/.env')) {

--- a/src/Client/tests/ThreadsTest.php
+++ b/src/Client/tests/ThreadsTest.php
@@ -2,160 +2,152 @@
 
 // Generated 2026-04-10 23:46:41
 
-use ConduitUI\Mattermost\Client\Requests\Threads\GetUserThreads;
+use ConduitUI\Mattermost\Client\Mattermost;
 use ConduitUI\Mattermost\Client\Requests\Threads\GetThreadMentionCountsByChannel;
-use ConduitUI\Mattermost\Client\Requests\Threads\UpdateThreadsReadForUser;
 use ConduitUI\Mattermost\Client\Requests\Threads\GetUserThread;
+use ConduitUI\Mattermost\Client\Requests\Threads\GetUserThreads;
+use ConduitUI\Mattermost\Client\Requests\Threads\SetThreadUnreadByPostId;
 use ConduitUI\Mattermost\Client\Requests\Threads\StartFollowingThread;
 use ConduitUI\Mattermost\Client\Requests\Threads\StopFollowingThread;
 use ConduitUI\Mattermost\Client\Requests\Threads\UpdateThreadReadForUser;
-use ConduitUI\Mattermost\Client\Requests\Threads\SetThreadUnreadByPostId;
+use ConduitUI\Mattermost\Client\Requests\Threads\UpdateThreadsReadForUser;
 use Saloon\Http\Faking\MockResponse;
 use Saloon\Laravel\Facades\Saloon;
-use Spatie\LaravelData\DataCollection;
 
-beforeEach(function () {
-    $this->mattermost = new ConduitUI\Mattermost\Client\Mattermost(
-		bearerToken: 'replace'
-	);
+beforeEach(function (): void {
+    $this->mattermost = new Mattermost(
+        bearerToken: 'replace'
+    );
 });
 
-
-it('calls the getUserThreads method in the Threads resource', function () {
+it('calls the getUserThreads method in the Threads resource', function (): void {
     Saloon::fake([
         GetUserThreads::class => MockResponse::fixture('threads.getUserThreads'),
     ]);
 
     $response = $this->mattermost->threads()->getUserThreads(
-		userId: 'test string',
-		teamId: 'test string',
-		since: 123,
-		deleted: true,
-		extended: true,
-		page: 123,
-		pageSize: 123,
-		totalsOnly: true,
-		threadsOnly: true
-	);
+        userId: 'test string',
+        teamId: 'test string',
+        since: 123,
+        deleted: true,
+        extended: true,
+        page: 123,
+        pageSize: 123,
+        totalsOnly: true,
+        threadsOnly: true
+    );
 
     Saloon::assertSent(GetUserThreads::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getThreadMentionCountsByChannel method in the Threads resource', function () {
+it('calls the getThreadMentionCountsByChannel method in the Threads resource', function (): void {
     Saloon::fake([
         GetThreadMentionCountsByChannel::class => MockResponse::fixture('threads.getThreadMentionCountsByChannel'),
     ]);
 
     $response = $this->mattermost->threads()->getThreadMentionCountsByChannel(
-		userId: 'test string',
-		teamId: 'test string'
-	);
+        userId: 'test string',
+        teamId: 'test string'
+    );
 
     Saloon::assertSent(GetThreadMentionCountsByChannel::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the updateThreadsReadForUser method in the Threads resource', function () {
+it('calls the updateThreadsReadForUser method in the Threads resource', function (): void {
     Saloon::fake([
         UpdateThreadsReadForUser::class => MockResponse::fixture('threads.updateThreadsReadForUser'),
     ]);
 
     $response = $this->mattermost->threads()->updateThreadsReadForUser(
-		userId: 'test string',
-		teamId: 'test string'
-	);
+        userId: 'test string',
+        teamId: 'test string'
+    );
 
     Saloon::assertSent(UpdateThreadsReadForUser::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getUserThread method in the Threads resource', function () {
+it('calls the getUserThread method in the Threads resource', function (): void {
     Saloon::fake([
         GetUserThread::class => MockResponse::fixture('threads.getUserThread'),
     ]);
 
     $response = $this->mattermost->threads()->getUserThread(
-		userId: 'test string',
-		teamId: 'test string',
-		threadId: 'test string'
-	);
+        userId: 'test string',
+        teamId: 'test string',
+        threadId: 'test string'
+    );
 
     Saloon::assertSent(GetUserThread::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the startFollowingThread method in the Threads resource', function () {
+it('calls the startFollowingThread method in the Threads resource', function (): void {
     Saloon::fake([
         StartFollowingThread::class => MockResponse::fixture('threads.startFollowingThread'),
     ]);
 
     $response = $this->mattermost->threads()->startFollowingThread(
-		userId: 'test string',
-		teamId: 'test string',
-		threadId: 'test string'
-	);
+        userId: 'test string',
+        teamId: 'test string',
+        threadId: 'test string'
+    );
 
     Saloon::assertSent(StartFollowingThread::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the stopFollowingThread method in the Threads resource', function () {
+it('calls the stopFollowingThread method in the Threads resource', function (): void {
     Saloon::fake([
         StopFollowingThread::class => MockResponse::fixture('threads.stopFollowingThread'),
     ]);
 
     $response = $this->mattermost->threads()->stopFollowingThread(
-		userId: 'test string',
-		teamId: 'test string',
-		threadId: 'test string'
-	);
+        userId: 'test string',
+        teamId: 'test string',
+        threadId: 'test string'
+    );
 
     Saloon::assertSent(StopFollowingThread::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the updateThreadReadForUser method in the Threads resource', function () {
+it('calls the updateThreadReadForUser method in the Threads resource', function (): void {
     Saloon::fake([
         UpdateThreadReadForUser::class => MockResponse::fixture('threads.updateThreadReadForUser'),
     ]);
 
     $response = $this->mattermost->threads()->updateThreadReadForUser(
-		userId: 'test string',
-		teamId: 'test string',
-		threadId: 'test string',
-		timestamp: 'test string'
-	);
+        userId: 'test string',
+        teamId: 'test string',
+        threadId: 'test string',
+        timestamp: 'test string'
+    );
 
     Saloon::assertSent(UpdateThreadReadForUser::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the setThreadUnreadByPostId method in the Threads resource', function () {
+it('calls the setThreadUnreadByPostId method in the Threads resource', function (): void {
     Saloon::fake([
         SetThreadUnreadByPostId::class => MockResponse::fixture('threads.setThreadUnreadByPostId'),
     ]);
 
     $response = $this->mattermost->threads()->setThreadUnreadByPostId(
-		userId: 'test string',
-		teamId: 'test string',
-		threadId: 'test string',
-		postId: 'test string'
-	);
+        userId: 'test string',
+        teamId: 'test string',
+        threadId: 'test string',
+        postId: 'test string'
+    );
 
     Saloon::assertSent(SetThreadUnreadByPostId::class);
 

--- a/src/Client/tests/UsersTest.php
+++ b/src/Client/tests/UsersTest.php
@@ -2,933 +2,877 @@
 
 // Generated 2026-04-10 23:46:41
 
-use ConduitUI\Mattermost\Client\Requests\Users\GetUsers;
-use ConduitUI\Mattermost\Client\Requests\Users\CreateUser;
-use ConduitUI\Mattermost\Client\Requests\Users\PermanentDeleteAllUsers;
-use ConduitUI\Mattermost\Client\Requests\Users\AutocompleteUsers;
-use ConduitUI\Mattermost\Client\Requests\Users\VerifyUserEmail;
-use ConduitUI\Mattermost\Client\Requests\Users\SendVerificationEmail;
-use ConduitUI\Mattermost\Client\Requests\Users\GetUserByEmail;
-use ConduitUI\Mattermost\Client\Requests\Users\GetUsersByGroupChannelIds;
-use ConduitUI\Mattermost\Client\Requests\Users\GetUsersByIds;
-use ConduitUI\Mattermost\Client\Requests\Users\GetKnownUsers;
-use ConduitUI\Mattermost\Client\Requests\Users\Login;
-use ConduitUI\Mattermost\Client\Requests\Users\LoginByCwsToken;
-use ConduitUI\Mattermost\Client\Requests\Users\SwitchAccountType;
-use ConduitUI\Mattermost\Client\Requests\Users\Logout;
-use ConduitUI\Mattermost\Client\Requests\Users\CheckUserMfa;
-use ConduitUI\Mattermost\Client\Requests\Users\MigrateAuthToLdap;
-use ConduitUI\Mattermost\Client\Requests\Users\MigrateAuthToSaml;
-use ConduitUI\Mattermost\Client\Requests\Users\ResetPassword;
-use ConduitUI\Mattermost\Client\Requests\Users\SendPasswordResetEmail;
-use ConduitUI\Mattermost\Client\Requests\Users\SearchUsers;
+use ConduitUI\Mattermost\Client\Mattermost;
 use ConduitUI\Mattermost\Client\Requests\Users\AttachDeviceId;
-use ConduitUI\Mattermost\Client\Requests\Users\RevokeSessionsFromAllUsers;
-use ConduitUI\Mattermost\Client\Requests\Users\GetTotalUsersStats;
-use ConduitUI\Mattermost\Client\Requests\Users\GetTotalUsersStatsFiltered;
-use ConduitUI\Mattermost\Client\Requests\Users\GetUserAccessTokens;
+use ConduitUI\Mattermost\Client\Requests\Users\AutocompleteUsers;
+use ConduitUI\Mattermost\Client\Requests\Users\CheckUserMfa;
+use ConduitUI\Mattermost\Client\Requests\Users\CreateUser;
+use ConduitUI\Mattermost\Client\Requests\Users\CreateUserAccessToken;
+use ConduitUI\Mattermost\Client\Requests\Users\DeleteUser;
+use ConduitUI\Mattermost\Client\Requests\Users\DemoteUserToGuest;
 use ConduitUI\Mattermost\Client\Requests\Users\DisableUserAccessToken;
 use ConduitUI\Mattermost\Client\Requests\Users\EnableUserAccessToken;
+use ConduitUI\Mattermost\Client\Requests\Users\GenerateMfaSecret;
+use ConduitUI\Mattermost\Client\Requests\Users\GetChannelMembersWithTeamDataForUser;
+use ConduitUI\Mattermost\Client\Requests\Users\GetKnownUsers;
+use ConduitUI\Mattermost\Client\Requests\Users\GetSessions;
+use ConduitUI\Mattermost\Client\Requests\Users\GetTotalUsersStats;
+use ConduitUI\Mattermost\Client\Requests\Users\GetTotalUsersStatsFiltered;
+use ConduitUI\Mattermost\Client\Requests\Users\GetUploadsForUser;
+use ConduitUI\Mattermost\Client\Requests\Users\GetUser;
+use ConduitUI\Mattermost\Client\Requests\Users\GetUserAccessToken;
+use ConduitUI\Mattermost\Client\Requests\Users\GetUserAccessTokens;
+use ConduitUI\Mattermost\Client\Requests\Users\GetUserAccessTokensForUser;
+use ConduitUI\Mattermost\Client\Requests\Users\GetUserAudits;
+use ConduitUI\Mattermost\Client\Requests\Users\GetUserByEmail;
+use ConduitUI\Mattermost\Client\Requests\Users\GetUserByUsername;
+use ConduitUI\Mattermost\Client\Requests\Users\GetUsers;
+use ConduitUI\Mattermost\Client\Requests\Users\GetUsersByGroupChannelIds;
+use ConduitUI\Mattermost\Client\Requests\Users\GetUsersByIds;
+use ConduitUI\Mattermost\Client\Requests\Users\GetUsersByUsernames;
+use ConduitUI\Mattermost\Client\Requests\Users\GetUserTermsOfService;
+use ConduitUI\Mattermost\Client\Requests\Users\Login;
+use ConduitUI\Mattermost\Client\Requests\Users\LoginByCwsToken;
+use ConduitUI\Mattermost\Client\Requests\Users\Logout;
+use ConduitUI\Mattermost\Client\Requests\Users\MigrateAuthToLdap;
+use ConduitUI\Mattermost\Client\Requests\Users\MigrateAuthToSaml;
+use ConduitUI\Mattermost\Client\Requests\Users\PatchUser;
+use ConduitUI\Mattermost\Client\Requests\Users\PermanentDeleteAllUsers;
+use ConduitUI\Mattermost\Client\Requests\Users\PromoteGuestToUser;
+use ConduitUI\Mattermost\Client\Requests\Users\PublishUserTyping;
+use ConduitUI\Mattermost\Client\Requests\Users\RegisterTermsOfServiceAction;
+use ConduitUI\Mattermost\Client\Requests\Users\ResetPassword;
+use ConduitUI\Mattermost\Client\Requests\Users\RevokeAllSessions;
+use ConduitUI\Mattermost\Client\Requests\Users\RevokeSession;
+use ConduitUI\Mattermost\Client\Requests\Users\RevokeSessionsFromAllUsers;
 use ConduitUI\Mattermost\Client\Requests\Users\RevokeUserAccessToken;
 use ConduitUI\Mattermost\Client\Requests\Users\SearchUserAccessTokens;
-use ConduitUI\Mattermost\Client\Requests\Users\GetUserAccessToken;
-use ConduitUI\Mattermost\Client\Requests\Users\GetUserByUsername;
-use ConduitUI\Mattermost\Client\Requests\Users\GetUsersByUsernames;
-use ConduitUI\Mattermost\Client\Requests\Users\GetUser;
+use ConduitUI\Mattermost\Client\Requests\Users\SearchUsers;
+use ConduitUI\Mattermost\Client\Requests\Users\SendPasswordResetEmail;
+use ConduitUI\Mattermost\Client\Requests\Users\SendVerificationEmail;
+use ConduitUI\Mattermost\Client\Requests\Users\SwitchAccountType;
 use ConduitUI\Mattermost\Client\Requests\Users\UpdateUser;
-use ConduitUI\Mattermost\Client\Requests\Users\DeleteUser;
 use ConduitUI\Mattermost\Client\Requests\Users\UpdateUserActive;
-use ConduitUI\Mattermost\Client\Requests\Users\GetUserAudits;
 use ConduitUI\Mattermost\Client\Requests\Users\UpdateUserAuth;
-use ConduitUI\Mattermost\Client\Requests\Users\GetChannelMembersWithTeamDataForUser;
-use ConduitUI\Mattermost\Client\Requests\Users\DemoteUserToGuest;
-use ConduitUI\Mattermost\Client\Requests\Users\VerifyUserEmailWithoutToken;
 use ConduitUI\Mattermost\Client\Requests\Users\UpdateUserMfa;
-use ConduitUI\Mattermost\Client\Requests\Users\GenerateMfaSecret;
 use ConduitUI\Mattermost\Client\Requests\Users\UpdateUserPassword;
-use ConduitUI\Mattermost\Client\Requests\Users\PatchUser;
-use ConduitUI\Mattermost\Client\Requests\Users\PromoteGuestToUser;
 use ConduitUI\Mattermost\Client\Requests\Users\UpdateUserRoles;
-use ConduitUI\Mattermost\Client\Requests\Users\GetSessions;
-use ConduitUI\Mattermost\Client\Requests\Users\RevokeSession;
-use ConduitUI\Mattermost\Client\Requests\Users\RevokeAllSessions;
-use ConduitUI\Mattermost\Client\Requests\Users\GetUserTermsOfService;
-use ConduitUI\Mattermost\Client\Requests\Users\RegisterTermsOfServiceAction;
-use ConduitUI\Mattermost\Client\Requests\Users\GetUserAccessTokensForUser;
-use ConduitUI\Mattermost\Client\Requests\Users\CreateUserAccessToken;
-use ConduitUI\Mattermost\Client\Requests\Users\PublishUserTyping;
-use ConduitUI\Mattermost\Client\Requests\Users\GetUploadsForUser;
+use ConduitUI\Mattermost\Client\Requests\Users\VerifyUserEmail;
+use ConduitUI\Mattermost\Client\Requests\Users\VerifyUserEmailWithoutToken;
 use Saloon\Http\Faking\MockResponse;
 use Saloon\Laravel\Facades\Saloon;
-use Spatie\LaravelData\DataCollection;
 
-beforeEach(function () {
-    $this->mattermost = new ConduitUI\Mattermost\Client\Mattermost(
-		bearerToken: 'replace'
-	);
+beforeEach(function (): void {
+    $this->mattermost = new Mattermost(
+        bearerToken: 'replace'
+    );
 });
 
-
-it('calls the getUsers method in the Users resource', function () {
+it('calls the getUsers method in the Users resource', function (): void {
     Saloon::fake([
         GetUsers::class => MockResponse::fixture('users.getUsers'),
     ]);
 
     $response = $this->mattermost->users()->getUsers(
-		page: 123,
-		inTeam: 'test string',
-		notInTeam: 'test string',
-		inChannel: 'test string',
-		notInChannel: 'test string',
-		inGroup: 'test string',
-		groupConstrained: true,
-		withoutTeam: true,
-		active: true,
-		inactive: true,
-		role: 'test string',
-		sort: 'test string',
-		roles: 'test string',
-		channelRoles: 'test string',
-		teamRoles: 'test string'
-	);
+        page: 123,
+        inTeam: 'test string',
+        notInTeam: 'test string',
+        inChannel: 'test string',
+        notInChannel: 'test string',
+        inGroup: 'test string',
+        groupConstrained: true,
+        withoutTeam: true,
+        active: true,
+        inactive: true,
+        role: 'test string',
+        sort: 'test string',
+        roles: 'test string',
+        channelRoles: 'test string',
+        teamRoles: 'test string'
+    );
 
     Saloon::assertSent(GetUsers::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the createUser method in the Users resource', function () {
+it('calls the createUser method in the Users resource', function (): void {
     Saloon::fake([
         CreateUser::class => MockResponse::fixture('users.createUser'),
     ]);
 
     $response = $this->mattermost->users()->createUser(
-		t: 'test string',
-		iid: 'test string'
-	);
+        t: 'test string',
+        iid: 'test string'
+    );
 
     Saloon::assertSent(CreateUser::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the permanentDeleteAllUsers method in the Users resource', function () {
+it('calls the permanentDeleteAllUsers method in the Users resource', function (): void {
     Saloon::fake([
         PermanentDeleteAllUsers::class => MockResponse::fixture('users.permanentDeleteAllUsers'),
     ]);
 
     $response = $this->mattermost->users()->permanentDeleteAllUsers(
-		
-	);
+
+    );
 
     Saloon::assertSent(PermanentDeleteAllUsers::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the autocompleteUsers method in the Users resource', function () {
+it('calls the autocompleteUsers method in the Users resource', function (): void {
     Saloon::fake([
         AutocompleteUsers::class => MockResponse::fixture('users.autocompleteUsers'),
     ]);
 
     $response = $this->mattermost->users()->autocompleteUsers(
-		teamId: 'test string',
-		channelId: 'test string',
-		name: 'test string',
-		limit: 123
-	);
+        teamId: 'test string',
+        channelId: 'test string',
+        name: 'test string',
+        limit: 123
+    );
 
     Saloon::assertSent(AutocompleteUsers::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the verifyUserEmail method in the Users resource', function () {
+it('calls the verifyUserEmail method in the Users resource', function (): void {
     Saloon::fake([
         VerifyUserEmail::class => MockResponse::fixture('users.verifyUserEmail'),
     ]);
 
     $response = $this->mattermost->users()->verifyUserEmail(
-		
-	);
+
+    );
 
     Saloon::assertSent(VerifyUserEmail::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the sendVerificationEmail method in the Users resource', function () {
+it('calls the sendVerificationEmail method in the Users resource', function (): void {
     Saloon::fake([
         SendVerificationEmail::class => MockResponse::fixture('users.sendVerificationEmail'),
     ]);
 
     $response = $this->mattermost->users()->sendVerificationEmail(
-		
-	);
+
+    );
 
     Saloon::assertSent(SendVerificationEmail::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getUserByEmail method in the Users resource', function () {
+it('calls the getUserByEmail method in the Users resource', function (): void {
     Saloon::fake([
         GetUserByEmail::class => MockResponse::fixture('users.getUserByEmail'),
     ]);
 
     $response = $this->mattermost->users()->getUserByEmail(
-		email: 'test string'
-	);
+        email: 'test string'
+    );
 
     Saloon::assertSent(GetUserByEmail::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getUsersByGroupChannelIds method in the Users resource', function () {
+it('calls the getUsersByGroupChannelIds method in the Users resource', function (): void {
     Saloon::fake([
         GetUsersByGroupChannelIds::class => MockResponse::fixture('users.getUsersByGroupChannelIds'),
     ]);
 
     $response = $this->mattermost->users()->getUsersByGroupChannelIds(
-		
-	);
+
+    );
 
     Saloon::assertSent(GetUsersByGroupChannelIds::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getUsersByIds method in the Users resource', function () {
+it('calls the getUsersByIds method in the Users resource', function (): void {
     Saloon::fake([
         GetUsersByIds::class => MockResponse::fixture('users.getUsersByIds'),
     ]);
 
     $response = $this->mattermost->users()->getUsersByIds(
-		since: 123
-	);
+        since: 123
+    );
 
     Saloon::assertSent(GetUsersByIds::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getKnownUsers method in the Users resource', function () {
+it('calls the getKnownUsers method in the Users resource', function (): void {
     Saloon::fake([
         GetKnownUsers::class => MockResponse::fixture('users.getKnownUsers'),
     ]);
 
     $response = $this->mattermost->users()->getKnownUsers(
-		
-	);
+
+    );
 
     Saloon::assertSent(GetKnownUsers::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the login method in the Users resource', function () {
+it('calls the login method in the Users resource', function (): void {
     Saloon::fake([
         Login::class => MockResponse::fixture('users.login'),
     ]);
 
     $response = $this->mattermost->users()->login(
-		
-	);
+
+    );
 
     Saloon::assertSent(Login::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the loginByCwsToken method in the Users resource', function () {
+it('calls the loginByCwsToken method in the Users resource', function (): void {
     Saloon::fake([
         LoginByCwsToken::class => MockResponse::fixture('users.loginByCwsToken'),
     ]);
 
     $response = $this->mattermost->users()->loginByCwsToken(
-		
-	);
+
+    );
 
     Saloon::assertSent(LoginByCwsToken::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the switchAccountType method in the Users resource', function () {
+it('calls the switchAccountType method in the Users resource', function (): void {
     Saloon::fake([
         SwitchAccountType::class => MockResponse::fixture('users.switchAccountType'),
     ]);
 
     $response = $this->mattermost->users()->switchAccountType(
-		
-	);
+
+    );
 
     Saloon::assertSent(SwitchAccountType::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the logout method in the Users resource', function () {
+it('calls the logout method in the Users resource', function (): void {
     Saloon::fake([
         Logout::class => MockResponse::fixture('users.logout'),
     ]);
 
     $response = $this->mattermost->users()->logout(
-		
-	);
+
+    );
 
     Saloon::assertSent(Logout::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the checkUserMfa method in the Users resource', function () {
+it('calls the checkUserMfa method in the Users resource', function (): void {
     Saloon::fake([
         CheckUserMfa::class => MockResponse::fixture('users.checkUserMfa'),
     ]);
 
     $response = $this->mattermost->users()->checkUserMfa(
-		
-	);
+
+    );
 
     Saloon::assertSent(CheckUserMfa::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the migrateAuthToLdap method in the Users resource', function () {
+it('calls the migrateAuthToLdap method in the Users resource', function (): void {
     Saloon::fake([
         MigrateAuthToLdap::class => MockResponse::fixture('users.migrateAuthToLdap'),
     ]);
 
     $response = $this->mattermost->users()->migrateAuthToLdap(
-		
-	);
+
+    );
 
     Saloon::assertSent(MigrateAuthToLdap::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the migrateAuthToSaml method in the Users resource', function () {
+it('calls the migrateAuthToSaml method in the Users resource', function (): void {
     Saloon::fake([
         MigrateAuthToSaml::class => MockResponse::fixture('users.migrateAuthToSaml'),
     ]);
 
     $response = $this->mattermost->users()->migrateAuthToSaml(
-		
-	);
+
+    );
 
     Saloon::assertSent(MigrateAuthToSaml::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the resetPassword method in the Users resource', function () {
+it('calls the resetPassword method in the Users resource', function (): void {
     Saloon::fake([
         ResetPassword::class => MockResponse::fixture('users.resetPassword'),
     ]);
 
     $response = $this->mattermost->users()->resetPassword(
-		
-	);
+
+    );
 
     Saloon::assertSent(ResetPassword::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the sendPasswordResetEmail method in the Users resource', function () {
+it('calls the sendPasswordResetEmail method in the Users resource', function (): void {
     Saloon::fake([
         SendPasswordResetEmail::class => MockResponse::fixture('users.sendPasswordResetEmail'),
     ]);
 
     $response = $this->mattermost->users()->sendPasswordResetEmail(
-		
-	);
+
+    );
 
     Saloon::assertSent(SendPasswordResetEmail::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the searchUsers method in the Users resource', function () {
+it('calls the searchUsers method in the Users resource', function (): void {
     Saloon::fake([
         SearchUsers::class => MockResponse::fixture('users.searchUsers'),
     ]);
 
     $response = $this->mattermost->users()->searchUsers(
-		
-	);
+
+    );
 
     Saloon::assertSent(SearchUsers::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the attachDeviceId method in the Users resource', function () {
+it('calls the attachDeviceId method in the Users resource', function (): void {
     Saloon::fake([
         AttachDeviceId::class => MockResponse::fixture('users.attachDeviceId'),
     ]);
 
     $response = $this->mattermost->users()->attachDeviceId(
-		
-	);
+
+    );
 
     Saloon::assertSent(AttachDeviceId::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the revokeSessionsFromAllUsers method in the Users resource', function () {
+it('calls the revokeSessionsFromAllUsers method in the Users resource', function (): void {
     Saloon::fake([
         RevokeSessionsFromAllUsers::class => MockResponse::fixture('users.revokeSessionsFromAllUsers'),
     ]);
 
     $response = $this->mattermost->users()->revokeSessionsFromAllUsers(
-		
-	);
+
+    );
 
     Saloon::assertSent(RevokeSessionsFromAllUsers::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getTotalUsersStats method in the Users resource', function () {
+it('calls the getTotalUsersStats method in the Users resource', function (): void {
     Saloon::fake([
         GetTotalUsersStats::class => MockResponse::fixture('users.getTotalUsersStats'),
     ]);
 
     $response = $this->mattermost->users()->getTotalUsersStats(
-		
-	);
+
+    );
 
     Saloon::assertSent(GetTotalUsersStats::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getTotalUsersStatsFiltered method in the Users resource', function () {
+it('calls the getTotalUsersStatsFiltered method in the Users resource', function (): void {
     Saloon::fake([
         GetTotalUsersStatsFiltered::class => MockResponse::fixture('users.getTotalUsersStatsFiltered'),
     ]);
 
     $response = $this->mattermost->users()->getTotalUsersStatsFiltered(
-		inTeam: 'test string',
-		inChannel: 'test string',
-		includeDeleted: true,
-		includeBots: true,
-		roles: 'test string',
-		channelRoles: 'test string',
-		teamRoles: 'test string'
-	);
+        inTeam: 'test string',
+        inChannel: 'test string',
+        includeDeleted: true,
+        includeBots: true,
+        roles: 'test string',
+        channelRoles: 'test string',
+        teamRoles: 'test string'
+    );
 
     Saloon::assertSent(GetTotalUsersStatsFiltered::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getUserAccessTokens method in the Users resource', function () {
+it('calls the getUserAccessTokens method in the Users resource', function (): void {
     Saloon::fake([
         GetUserAccessTokens::class => MockResponse::fixture('users.getUserAccessTokens'),
     ]);
 
     $response = $this->mattermost->users()->getUserAccessTokens(
-		page: 123
-	);
+        page: 123
+    );
 
     Saloon::assertSent(GetUserAccessTokens::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the disableUserAccessToken method in the Users resource', function () {
+it('calls the disableUserAccessToken method in the Users resource', function (): void {
     Saloon::fake([
         DisableUserAccessToken::class => MockResponse::fixture('users.disableUserAccessToken'),
     ]);
 
     $response = $this->mattermost->users()->disableUserAccessToken(
-		
-	);
+
+    );
 
     Saloon::assertSent(DisableUserAccessToken::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the enableUserAccessToken method in the Users resource', function () {
+it('calls the enableUserAccessToken method in the Users resource', function (): void {
     Saloon::fake([
         EnableUserAccessToken::class => MockResponse::fixture('users.enableUserAccessToken'),
     ]);
 
     $response = $this->mattermost->users()->enableUserAccessToken(
-		
-	);
+
+    );
 
     Saloon::assertSent(EnableUserAccessToken::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the revokeUserAccessToken method in the Users resource', function () {
+it('calls the revokeUserAccessToken method in the Users resource', function (): void {
     Saloon::fake([
         RevokeUserAccessToken::class => MockResponse::fixture('users.revokeUserAccessToken'),
     ]);
 
     $response = $this->mattermost->users()->revokeUserAccessToken(
-		
-	);
+
+    );
 
     Saloon::assertSent(RevokeUserAccessToken::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the searchUserAccessTokens method in the Users resource', function () {
+it('calls the searchUserAccessTokens method in the Users resource', function (): void {
     Saloon::fake([
         SearchUserAccessTokens::class => MockResponse::fixture('users.searchUserAccessTokens'),
     ]);
 
     $response = $this->mattermost->users()->searchUserAccessTokens(
-		
-	);
+
+    );
 
     Saloon::assertSent(SearchUserAccessTokens::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getUserAccessToken method in the Users resource', function () {
+it('calls the getUserAccessToken method in the Users resource', function (): void {
     Saloon::fake([
         GetUserAccessToken::class => MockResponse::fixture('users.getUserAccessToken'),
     ]);
 
     $response = $this->mattermost->users()->getUserAccessToken(
-		tokenId: 'test string'
-	);
+        tokenId: 'test string'
+    );
 
     Saloon::assertSent(GetUserAccessToken::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getUserByUsername method in the Users resource', function () {
+it('calls the getUserByUsername method in the Users resource', function (): void {
     Saloon::fake([
         GetUserByUsername::class => MockResponse::fixture('users.getUserByUsername'),
     ]);
 
     $response = $this->mattermost->users()->getUserByUsername(
-		username: 'test string'
-	);
+        username: 'test string'
+    );
 
     Saloon::assertSent(GetUserByUsername::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getUsersByUsernames method in the Users resource', function () {
+it('calls the getUsersByUsernames method in the Users resource', function (): void {
     Saloon::fake([
         GetUsersByUsernames::class => MockResponse::fixture('users.getUsersByUsernames'),
     ]);
 
     $response = $this->mattermost->users()->getUsersByUsernames(
-		
-	);
+
+    );
 
     Saloon::assertSent(GetUsersByUsernames::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getUser method in the Users resource', function () {
+it('calls the getUser method in the Users resource', function (): void {
     Saloon::fake([
         GetUser::class => MockResponse::fixture('users.getUser'),
     ]);
 
     $response = $this->mattermost->users()->getUser(
-		userId: 'test string'
-	);
+        userId: 'test string'
+    );
 
     Saloon::assertSent(GetUser::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the updateUser method in the Users resource', function () {
+it('calls the updateUser method in the Users resource', function (): void {
     Saloon::fake([
         UpdateUser::class => MockResponse::fixture('users.updateUser'),
     ]);
 
     $response = $this->mattermost->users()->updateUser(
-		userId: 'test string'
-	);
+        userId: 'test string'
+    );
 
     Saloon::assertSent(UpdateUser::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the deleteUser method in the Users resource', function () {
+it('calls the deleteUser method in the Users resource', function (): void {
     Saloon::fake([
         DeleteUser::class => MockResponse::fixture('users.deleteUser'),
     ]);
 
     $response = $this->mattermost->users()->deleteUser(
-		userId: 'test string'
-	);
+        userId: 'test string'
+    );
 
     Saloon::assertSent(DeleteUser::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the updateUserActive method in the Users resource', function () {
+it('calls the updateUserActive method in the Users resource', function (): void {
     Saloon::fake([
         UpdateUserActive::class => MockResponse::fixture('users.updateUserActive'),
     ]);
 
     $response = $this->mattermost->users()->updateUserActive(
-		userId: 'test string'
-	);
+        userId: 'test string'
+    );
 
     Saloon::assertSent(UpdateUserActive::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getUserAudits method in the Users resource', function () {
+it('calls the getUserAudits method in the Users resource', function (): void {
     Saloon::fake([
         GetUserAudits::class => MockResponse::fixture('users.getUserAudits'),
     ]);
 
     $response = $this->mattermost->users()->getUserAudits(
-		userId: 'test string'
-	);
+        userId: 'test string'
+    );
 
     Saloon::assertSent(GetUserAudits::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the updateUserAuth method in the Users resource', function () {
+it('calls the updateUserAuth method in the Users resource', function (): void {
     Saloon::fake([
         UpdateUserAuth::class => MockResponse::fixture('users.updateUserAuth'),
     ]);
 
     $response = $this->mattermost->users()->updateUserAuth(
-		userId: 'test string'
-	);
+        userId: 'test string'
+    );
 
     Saloon::assertSent(UpdateUserAuth::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getChannelMembersWithTeamDataForUser method in the Users resource', function () {
+it('calls the getChannelMembersWithTeamDataForUser method in the Users resource', function (): void {
     Saloon::fake([
         GetChannelMembersWithTeamDataForUser::class => MockResponse::fixture('users.getChannelMembersWithTeamDataForUser'),
     ]);
 
     $response = $this->mattermost->users()->getChannelMembersWithTeamDataForUser(
-		userId: 'test string',
-		page: 123,
-		pageSize: 123
-	);
+        userId: 'test string',
+        page: 123,
+        pageSize: 123
+    );
 
     Saloon::assertSent(GetChannelMembersWithTeamDataForUser::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the demoteUserToGuest method in the Users resource', function () {
+it('calls the demoteUserToGuest method in the Users resource', function (): void {
     Saloon::fake([
         DemoteUserToGuest::class => MockResponse::fixture('users.demoteUserToGuest'),
     ]);
 
     $response = $this->mattermost->users()->demoteUserToGuest(
-		userId: 'test string'
-	);
+        userId: 'test string'
+    );
 
     Saloon::assertSent(DemoteUserToGuest::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the verifyUserEmailWithoutToken method in the Users resource', function () {
+it('calls the verifyUserEmailWithoutToken method in the Users resource', function (): void {
     Saloon::fake([
         VerifyUserEmailWithoutToken::class => MockResponse::fixture('users.verifyUserEmailWithoutToken'),
     ]);
 
     $response = $this->mattermost->users()->verifyUserEmailWithoutToken(
-		userId: 'test string'
-	);
+        userId: 'test string'
+    );
 
     Saloon::assertSent(VerifyUserEmailWithoutToken::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the updateUserMfa method in the Users resource', function () {
+it('calls the updateUserMfa method in the Users resource', function (): void {
     Saloon::fake([
         UpdateUserMfa::class => MockResponse::fixture('users.updateUserMfa'),
     ]);
 
     $response = $this->mattermost->users()->updateUserMfa(
-		userId: 'test string'
-	);
+        userId: 'test string'
+    );
 
     Saloon::assertSent(UpdateUserMfa::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the generateMfaSecret method in the Users resource', function () {
+it('calls the generateMfaSecret method in the Users resource', function (): void {
     Saloon::fake([
         GenerateMfaSecret::class => MockResponse::fixture('users.generateMfaSecret'),
     ]);
 
     $response = $this->mattermost->users()->generateMfaSecret(
-		userId: 'test string'
-	);
+        userId: 'test string'
+    );
 
     Saloon::assertSent(GenerateMfaSecret::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the updateUserPassword method in the Users resource', function () {
+it('calls the updateUserPassword method in the Users resource', function (): void {
     Saloon::fake([
         UpdateUserPassword::class => MockResponse::fixture('users.updateUserPassword'),
     ]);
 
     $response = $this->mattermost->users()->updateUserPassword(
-		userId: 'test string'
-	);
+        userId: 'test string'
+    );
 
     Saloon::assertSent(UpdateUserPassword::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the patchUser method in the Users resource', function () {
+it('calls the patchUser method in the Users resource', function (): void {
     Saloon::fake([
         PatchUser::class => MockResponse::fixture('users.patchUser'),
     ]);
 
     $response = $this->mattermost->users()->patchUser(
-		userId: 'test string'
-	);
+        userId: 'test string'
+    );
 
     Saloon::assertSent(PatchUser::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the promoteGuestToUser method in the Users resource', function () {
+it('calls the promoteGuestToUser method in the Users resource', function (): void {
     Saloon::fake([
         PromoteGuestToUser::class => MockResponse::fixture('users.promoteGuestToUser'),
     ]);
 
     $response = $this->mattermost->users()->promoteGuestToUser(
-		userId: 'test string'
-	);
+        userId: 'test string'
+    );
 
     Saloon::assertSent(PromoteGuestToUser::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the updateUserRoles method in the Users resource', function () {
+it('calls the updateUserRoles method in the Users resource', function (): void {
     Saloon::fake([
         UpdateUserRoles::class => MockResponse::fixture('users.updateUserRoles'),
     ]);
 
     $response = $this->mattermost->users()->updateUserRoles(
-		userId: 'test string'
-	);
+        userId: 'test string'
+    );
 
     Saloon::assertSent(UpdateUserRoles::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getSessions method in the Users resource', function () {
+it('calls the getSessions method in the Users resource', function (): void {
     Saloon::fake([
         GetSessions::class => MockResponse::fixture('users.getSessions'),
     ]);
 
     $response = $this->mattermost->users()->getSessions(
-		userId: 'test string'
-	);
+        userId: 'test string'
+    );
 
     Saloon::assertSent(GetSessions::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the revokeSession method in the Users resource', function () {
+it('calls the revokeSession method in the Users resource', function (): void {
     Saloon::fake([
         RevokeSession::class => MockResponse::fixture('users.revokeSession'),
     ]);
 
     $response = $this->mattermost->users()->revokeSession(
-		userId: 'test string'
-	);
+        userId: 'test string'
+    );
 
     Saloon::assertSent(RevokeSession::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the revokeAllSessions method in the Users resource', function () {
+it('calls the revokeAllSessions method in the Users resource', function (): void {
     Saloon::fake([
         RevokeAllSessions::class => MockResponse::fixture('users.revokeAllSessions'),
     ]);
 
     $response = $this->mattermost->users()->revokeAllSessions(
-		userId: 'test string'
-	);
+        userId: 'test string'
+    );
 
     Saloon::assertSent(RevokeAllSessions::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getUserTermsOfService method in the Users resource', function () {
+it('calls the getUserTermsOfService method in the Users resource', function (): void {
     Saloon::fake([
         GetUserTermsOfService::class => MockResponse::fixture('users.getUserTermsOfService'),
     ]);
 
     $response = $this->mattermost->users()->getUserTermsOfService(
-		userId: 'test string'
-	);
+        userId: 'test string'
+    );
 
     Saloon::assertSent(GetUserTermsOfService::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the registerTermsOfServiceAction method in the Users resource', function () {
+it('calls the registerTermsOfServiceAction method in the Users resource', function (): void {
     Saloon::fake([
         RegisterTermsOfServiceAction::class => MockResponse::fixture('users.registerTermsOfServiceAction'),
     ]);
 
     $response = $this->mattermost->users()->registerTermsOfServiceAction(
-		userId: 'test string'
-	);
+        userId: 'test string'
+    );
 
     Saloon::assertSent(RegisterTermsOfServiceAction::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getUserAccessTokensForUser method in the Users resource', function () {
+it('calls the getUserAccessTokensForUser method in the Users resource', function (): void {
     Saloon::fake([
         GetUserAccessTokensForUser::class => MockResponse::fixture('users.getUserAccessTokensForUser'),
     ]);
 
     $response = $this->mattermost->users()->getUserAccessTokensForUser(
-		userId: 'test string',
-		page: 123
-	);
+        userId: 'test string',
+        page: 123
+    );
 
     Saloon::assertSent(GetUserAccessTokensForUser::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the createUserAccessToken method in the Users resource', function () {
+it('calls the createUserAccessToken method in the Users resource', function (): void {
     Saloon::fake([
         CreateUserAccessToken::class => MockResponse::fixture('users.createUserAccessToken'),
     ]);
 
     $response = $this->mattermost->users()->createUserAccessToken(
-		userId: 'test string'
-	);
+        userId: 'test string'
+    );
 
     Saloon::assertSent(CreateUserAccessToken::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the publishUserTyping method in the Users resource', function () {
+it('calls the publishUserTyping method in the Users resource', function (): void {
     Saloon::fake([
         PublishUserTyping::class => MockResponse::fixture('users.publishUserTyping'),
     ]);
 
     $response = $this->mattermost->users()->publishUserTyping(
-		userId: 'test string'
-	);
+        userId: 'test string'
+    );
 
     Saloon::assertSent(PublishUserTyping::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getUploadsForUser method in the Users resource', function () {
+it('calls the getUploadsForUser method in the Users resource', function (): void {
     Saloon::fake([
         GetUploadsForUser::class => MockResponse::fixture('users.getUploadsForUser'),
     ]);
 
     $response = $this->mattermost->users()->getUploadsForUser(
-		userId: 'test string'
-	);
+        userId: 'test string'
+    );
 
     Saloon::assertSent(GetUploadsForUser::class);
 

--- a/src/Client/tests/WebhooksTest.php
+++ b/src/Client/tests/WebhooksTest.php
@@ -2,189 +2,178 @@
 
 // Generated 2026-04-10 23:46:41
 
-use ConduitUI\Mattermost\Client\Requests\Webhooks\GetIncomingWebhooks;
+use ConduitUI\Mattermost\Client\Mattermost;
 use ConduitUI\Mattermost\Client\Requests\Webhooks\CreateIncomingWebhook;
-use ConduitUI\Mattermost\Client\Requests\Webhooks\GetIncomingWebhook;
-use ConduitUI\Mattermost\Client\Requests\Webhooks\UpdateIncomingWebhook;
-use ConduitUI\Mattermost\Client\Requests\Webhooks\DeleteIncomingWebhook;
-use ConduitUI\Mattermost\Client\Requests\Webhooks\GetOutgoingWebhooks;
 use ConduitUI\Mattermost\Client\Requests\Webhooks\CreateOutgoingWebhook;
-use ConduitUI\Mattermost\Client\Requests\Webhooks\GetOutgoingWebhook;
-use ConduitUI\Mattermost\Client\Requests\Webhooks\UpdateOutgoingWebhook;
+use ConduitUI\Mattermost\Client\Requests\Webhooks\DeleteIncomingWebhook;
 use ConduitUI\Mattermost\Client\Requests\Webhooks\DeleteOutgoingWebhook;
+use ConduitUI\Mattermost\Client\Requests\Webhooks\GetIncomingWebhook;
+use ConduitUI\Mattermost\Client\Requests\Webhooks\GetIncomingWebhooks;
+use ConduitUI\Mattermost\Client\Requests\Webhooks\GetOutgoingWebhook;
+use ConduitUI\Mattermost\Client\Requests\Webhooks\GetOutgoingWebhooks;
 use ConduitUI\Mattermost\Client\Requests\Webhooks\RegenOutgoingHookToken;
+use ConduitUI\Mattermost\Client\Requests\Webhooks\UpdateIncomingWebhook;
+use ConduitUI\Mattermost\Client\Requests\Webhooks\UpdateOutgoingWebhook;
 use Saloon\Http\Faking\MockResponse;
 use Saloon\Laravel\Facades\Saloon;
-use Spatie\LaravelData\DataCollection;
 
-beforeEach(function () {
-    $this->mattermost = new ConduitUI\Mattermost\Client\Mattermost(
-		bearerToken: 'replace'
-	);
+beforeEach(function (): void {
+    $this->mattermost = new Mattermost(
+        bearerToken: 'replace'
+    );
 });
 
-
-it('calls the getIncomingWebhooks method in the Webhooks resource', function () {
+it('calls the getIncomingWebhooks method in the Webhooks resource', function (): void {
     Saloon::fake([
         GetIncomingWebhooks::class => MockResponse::fixture('webhooks.getIncomingWebhooks'),
     ]);
 
     $response = $this->mattermost->webhooks()->getIncomingWebhooks(
-		page: 123,
-		teamId: 'test string'
-	);
+        page: 123,
+        teamId: 'test string'
+    );
 
     Saloon::assertSent(GetIncomingWebhooks::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the createIncomingWebhook method in the Webhooks resource', function () {
+it('calls the createIncomingWebhook method in the Webhooks resource', function (): void {
     Saloon::fake([
         CreateIncomingWebhook::class => MockResponse::fixture('webhooks.createIncomingWebhook'),
     ]);
 
     $response = $this->mattermost->webhooks()->createIncomingWebhook(
-		
-	);
+
+    );
 
     Saloon::assertSent(CreateIncomingWebhook::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getIncomingWebhook method in the Webhooks resource', function () {
+it('calls the getIncomingWebhook method in the Webhooks resource', function (): void {
     Saloon::fake([
         GetIncomingWebhook::class => MockResponse::fixture('webhooks.getIncomingWebhook'),
     ]);
 
     $response = $this->mattermost->webhooks()->getIncomingWebhook(
-		hookId: 'test string'
-	);
+        hookId: 'test string'
+    );
 
     Saloon::assertSent(GetIncomingWebhook::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the updateIncomingWebhook method in the Webhooks resource', function () {
+it('calls the updateIncomingWebhook method in the Webhooks resource', function (): void {
     Saloon::fake([
         UpdateIncomingWebhook::class => MockResponse::fixture('webhooks.updateIncomingWebhook'),
     ]);
 
     $response = $this->mattermost->webhooks()->updateIncomingWebhook(
-		hookId: 'test string'
-	);
+        hookId: 'test string'
+    );
 
     Saloon::assertSent(UpdateIncomingWebhook::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the deleteIncomingWebhook method in the Webhooks resource', function () {
+it('calls the deleteIncomingWebhook method in the Webhooks resource', function (): void {
     Saloon::fake([
         DeleteIncomingWebhook::class => MockResponse::fixture('webhooks.deleteIncomingWebhook'),
     ]);
 
     $response = $this->mattermost->webhooks()->deleteIncomingWebhook(
-		hookId: 'test string'
-	);
+        hookId: 'test string'
+    );
 
     Saloon::assertSent(DeleteIncomingWebhook::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getOutgoingWebhooks method in the Webhooks resource', function () {
+it('calls the getOutgoingWebhooks method in the Webhooks resource', function (): void {
     Saloon::fake([
         GetOutgoingWebhooks::class => MockResponse::fixture('webhooks.getOutgoingWebhooks'),
     ]);
 
     $response = $this->mattermost->webhooks()->getOutgoingWebhooks(
-		page: 123,
-		teamId: 'test string',
-		channelId: 'test string'
-	);
+        page: 123,
+        teamId: 'test string',
+        channelId: 'test string'
+    );
 
     Saloon::assertSent(GetOutgoingWebhooks::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the createOutgoingWebhook method in the Webhooks resource', function () {
+it('calls the createOutgoingWebhook method in the Webhooks resource', function (): void {
     Saloon::fake([
         CreateOutgoingWebhook::class => MockResponse::fixture('webhooks.createOutgoingWebhook'),
     ]);
 
     $response = $this->mattermost->webhooks()->createOutgoingWebhook(
-		
-	);
+
+    );
 
     Saloon::assertSent(CreateOutgoingWebhook::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the getOutgoingWebhook method in the Webhooks resource', function () {
+it('calls the getOutgoingWebhook method in the Webhooks resource', function (): void {
     Saloon::fake([
         GetOutgoingWebhook::class => MockResponse::fixture('webhooks.getOutgoingWebhook'),
     ]);
 
     $response = $this->mattermost->webhooks()->getOutgoingWebhook(
-		hookId: 'test string'
-	);
+        hookId: 'test string'
+    );
 
     Saloon::assertSent(GetOutgoingWebhook::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the updateOutgoingWebhook method in the Webhooks resource', function () {
+it('calls the updateOutgoingWebhook method in the Webhooks resource', function (): void {
     Saloon::fake([
         UpdateOutgoingWebhook::class => MockResponse::fixture('webhooks.updateOutgoingWebhook'),
     ]);
 
     $response = $this->mattermost->webhooks()->updateOutgoingWebhook(
-		hookId: 'test string'
-	);
+        hookId: 'test string'
+    );
 
     Saloon::assertSent(UpdateOutgoingWebhook::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the deleteOutgoingWebhook method in the Webhooks resource', function () {
+it('calls the deleteOutgoingWebhook method in the Webhooks resource', function (): void {
     Saloon::fake([
         DeleteOutgoingWebhook::class => MockResponse::fixture('webhooks.deleteOutgoingWebhook'),
     ]);
 
     $response = $this->mattermost->webhooks()->deleteOutgoingWebhook(
-		hookId: 'test string'
-	);
+        hookId: 'test string'
+    );
 
     Saloon::assertSent(DeleteOutgoingWebhook::class);
 
     expect($response->status())->toBe(200);
 });
 
-
-it('calls the regenOutgoingHookToken method in the Webhooks resource', function () {
+it('calls the regenOutgoingHookToken method in the Webhooks resource', function (): void {
     Saloon::fake([
         RegenOutgoingHookToken::class => MockResponse::fixture('webhooks.regenOutgoingHookToken'),
     ]);
 
     $response = $this->mattermost->webhooks()->regenOutgoingHookToken(
-		hookId: 'test string'
-	);
+        hookId: 'test string'
+    );
 
     Saloon::assertSent(RegenOutgoingHookToken::class);
 

--- a/src/Facades/Mattermost.php
+++ b/src/Facades/Mattermost.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\Facades;
+
+use ConduitUI\Mattermost\MattermostManager;
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * @method static \ConduitUI\Mattermost\Client\Mattermost connection(?string $name = null)
+ * @method static \ConduitUI\Mattermost\Client\Resource\Posts posts()
+ * @method static \ConduitUI\Mattermost\Client\Resource\Channels channels()
+ * @method static \ConduitUI\Mattermost\Client\Resource\Users users()
+ * @method static \ConduitUI\Mattermost\Client\Resource\Teams teams()
+ * @method static \ConduitUI\Mattermost\Client\Resource\Files files()
+ * @method static \ConduitUI\Mattermost\Client\Resource\Reactions reactions()
+ * @method static \ConduitUI\Mattermost\Client\Resource\Bots bots()
+ * @method static \ConduitUI\Mattermost\Client\Resource\Webhooks webhooks()
+ * @method static \ConduitUI\Mattermost\Client\Resource\Commands commands()
+ * @method static \ConduitUI\Mattermost\Client\Resource\Emoji emoji()
+ * @method static \ConduitUI\Mattermost\Client\Resource\Status status()
+ * @method static \ConduitUI\Mattermost\Client\Resource\System system()
+ *
+ * @see MattermostManager
+ * @see \ConduitUI\Mattermost\Client\Mattermost
+ */
+class Mattermost extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return MattermostManager::class;
+    }
+
+    /**
+     * Proxy calls to the default connection's connector.
+     *
+     * @param  array<int, mixed>  $args
+     */
+    #[\Override]
+    public static function __callStatic($method, $args): mixed
+    {
+        $manager = static::getFacadeRoot();
+
+        // If the method exists on the manager, call it
+        if (method_exists($manager, $method)) {
+            return $manager->$method(...$args);
+        }
+
+        // Otherwise proxy to the default connection (the Saloon connector)
+        return $manager->connection()->$method(...$args);
+    }
+}

--- a/src/MattermostManager.php
+++ b/src/MattermostManager.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost;
+
+use ConduitUI\Mattermost\Client\Mattermost;
+use InvalidArgumentException;
+
+class MattermostManager
+{
+    /** @var array<string, Mattermost> */
+    private array $connections = [];
+
+    public function connection(?string $name = null): Mattermost
+    {
+        $name ??= config('mattermost.default', 'default');
+
+        if (isset($this->connections[$name])) {
+            return $this->connections[$name];
+        }
+
+        $config = config("mattermost.connections.{$name}");
+
+        if (! $config) {
+            throw new InvalidArgumentException("Mattermost connection [{$name}] is not configured.");
+        }
+
+        return $this->connections[$name] = new Mattermost(
+            baseUrl: $config['url'],
+            token: $config['token'],
+        );
+    }
+
+    public function purge(?string $name = null): void
+    {
+        $name ??= config('mattermost.default', 'default');
+        unset($this->connections[$name]);
+    }
+}

--- a/src/MattermostServiceProvider.php
+++ b/src/MattermostServiceProvider.php
@@ -12,6 +12,8 @@ class MattermostServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->mergeConfigFrom(__DIR__.'/../config/mattermost.php', 'mattermost');
+
+        $this->app->scoped(MattermostManager::class);
     }
 
     public function boot(): void

--- a/tests/Unit/FacadeTest.php
+++ b/tests/Unit/FacadeTest.php
@@ -1,0 +1,26 @@
+<?php
+
+use ConduitUI\Mattermost\Client\Resource\Channels;
+use ConduitUI\Mattermost\Client\Resource\Posts;
+use ConduitUI\Mattermost\Client\Resource\Users;
+use ConduitUI\Mattermost\Facades\Mattermost;
+
+it('resolves the facade root to MattermostManager', function (): void {
+    expect(Mattermost::connection())->toBeInstanceOf(ConduitUI\Mattermost\Client\Mattermost::class);
+});
+
+it('proxies resource calls to default connection', function (): void {
+    expect(Mattermost::posts())->toBeInstanceOf(Posts::class);
+    expect(Mattermost::channels())->toBeInstanceOf(Channels::class);
+    expect(Mattermost::users())->toBeInstanceOf(Users::class);
+});
+
+it('supports named connections via facade', function (): void {
+    config(['mattermost.connections.staging' => [
+        'url' => 'https://staging.mm.com',
+        'token' => 'staging-token',
+    ]]);
+
+    $client = Mattermost::connection('staging');
+    expect($client->resolveBaseUrl())->toBe('https://staging.mm.com');
+});

--- a/tests/Unit/MattermostManagerTest.php
+++ b/tests/Unit/MattermostManagerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+use ConduitUI\Mattermost\Client\Mattermost;
+use ConduitUI\Mattermost\MattermostManager;
+
+it('resolves default connection from config', function (): void {
+    $manager = app(MattermostManager::class);
+    $client = $manager->connection();
+
+    expect($client)->toBeInstanceOf(Mattermost::class);
+    expect($client->resolveBaseUrl())->toBe('http://localhost:8065');
+});
+
+it('caches connections', function (): void {
+    $manager = app(MattermostManager::class);
+
+    $first = $manager->connection();
+    $second = $manager->connection();
+
+    expect($first)->toBe($second);
+});
+
+it('resolves named connections', function (): void {
+    config(['mattermost.connections.prod' => [
+        'url' => 'https://mm.production.com',
+        'token' => 'prod-token',
+    ]]);
+
+    $manager = app(MattermostManager::class);
+    $client = $manager->connection('prod');
+
+    expect($client->resolveBaseUrl())->toBe('https://mm.production.com');
+});
+
+it('throws on unconfigured connection', function (): void {
+    $manager = app(MattermostManager::class);
+    $manager->connection('nonexistent');
+})->throws(InvalidArgumentException::class, 'not configured');
+
+it('purges cached connection', function (): void {
+    $manager = app(MattermostManager::class);
+
+    $first = $manager->connection();
+    $manager->purge();
+    $second = $manager->connection();
+
+    expect($first)->not->toBe($second);
+});
+
+it('is registered as scoped singleton', function (): void {
+    $first = app(MattermostManager::class);
+    $second = app(MattermostManager::class);
+
+    expect($first)->toBe($second);
+});


### PR DESCRIPTION
## Summary

Laravel integration layer for the Mattermost API client.

- **MattermostManager** — named connections with caching, configurable from `config/mattermost.php`
- **Mattermost facade** — `Mattermost::posts()->createPost(...)` or `Mattermost::connection('prod')->channels()->...`
- **MattermostServiceProvider** — scoped singleton, publishable config
- Fixed generated connector to accept configurable base URL + single token auth
- Pint formatting applied to all 450+ generated files (tabs → spaces)

```php
// Simple
Mattermost::posts()->createPost(...);

// Named connection
Mattermost::connection('staging')->channels()->getChannel($id);
```

## Test plan
- [x] 13 tests: manager resolution, caching, named connections, purge, facade proxy
- [x] Pint clean

Closes #3