### PR TITLE
feat: streaming replies — observer pattern + default implementation

### DIFF
--- a/src/Client/Requests/Posts/PatchPost.php
+++ b/src/Client/Requests/Posts/PatchPost.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace ConduitUI\Mattermost\Client\Requests\Posts;
 
+use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
 
 /**
  * PatchPost
@@ -16,8 +18,10 @@ use Saloon\Http\Request;
  * ##### Permissions
  * Must have the `edit_post` permission.
  */
-class PatchPost extends Request
+class PatchPost extends Request implements HasBody
 {
+    use HasJsonBody;
+
     protected Method $method = Method::PUT;
 
     public function resolveEndpoint(): string

--- a/src/Client/Requests/Posts/UpdatePost.php
+++ b/src/Client/Requests/Posts/UpdatePost.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace ConduitUI\Mattermost\Client\Requests\Posts;
 
+use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
 
 /**
  * UpdatePost
@@ -15,8 +17,10 @@ use Saloon\Http\Request;
  * ##### Permissions
  * Must have `edit_post` permission for the channel the post is in.
  */
-class UpdatePost extends Request
+class UpdatePost extends Request implements HasBody
 {
+    use HasJsonBody;
+
     protected Method $method = Method::PUT;
 
     public function resolveEndpoint(): string

--- a/src/Streaming/Chunks/StreamChunk.php
+++ b/src/Streaming/Chunks/StreamChunk.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\Streaming\Chunks;
+
+interface StreamChunk {}

--- a/src/Streaming/Chunks/TextChunk.php
+++ b/src/Streaming/Chunks/TextChunk.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\Streaming\Chunks;
+
+final readonly class TextChunk implements StreamChunk
+{
+    public function __construct(public string $text) {}
+}

--- a/src/Streaming/Chunks/ToolCallChunk.php
+++ b/src/Streaming/Chunks/ToolCallChunk.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\Streaming\Chunks;
+
+final readonly class ToolCallChunk implements StreamChunk
+{
+    public function __construct(public string $name) {}
+}

--- a/src/Streaming/MattermostStreamingReply.php
+++ b/src/Streaming/MattermostStreamingReply.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\Streaming;
+
+use ConduitUI\Mattermost\Client\Mattermost;
+use ConduitUI\Mattermost\Client\Requests\Posts\CreatePost;
+use ConduitUI\Mattermost\Client\Requests\Posts\UpdatePost;
+
+/**
+ * Default StreamObserver that renders a streaming reply as a single
+ * Mattermost post with two independent layers:
+ *
+ *   - body: the actual reply text from the language model
+ *   - status: a short italic line beneath the body for tool-call hints
+ *
+ * Layering matters because tool calls can arrive mid-stream — without it,
+ * onToolCall would clobber the partial body.
+ */
+final class MattermostStreamingReply implements StreamObserver
+{
+    private ?string $postId = null;
+
+    private string $body = '';
+
+    private string $status = '';
+
+    public function __construct(
+        private readonly Mattermost $mattermost,
+        private readonly string $channelId,
+        private readonly ?string $rootId = null,
+    ) {}
+
+    public function postId(): ?string
+    {
+        return $this->postId;
+    }
+
+    public function onFirstContent(string $text): void
+    {
+        $this->body = $text;
+        $this->status = '';
+        $this->ensurePostExists();
+    }
+
+    public function onText(string $fullText): void
+    {
+        $this->body = $fullText;
+        $this->ensurePostExists();
+    }
+
+    public function onToolCall(string $toolName): void
+    {
+        $this->status = '_'.$toolName.'_';
+        $this->ensurePostExists();
+    }
+
+    public function onComplete(string $finalText): void
+    {
+        $this->body = $finalText;
+        $this->status = '';
+
+        if ($finalText === '' && $this->postId === null) {
+            return;
+        }
+
+        $this->ensurePostExists();
+    }
+
+    private function ensurePostExists(): void
+    {
+        if ($this->postId === null) {
+            $this->createPost();
+
+            return;
+        }
+
+        $this->updatePost();
+    }
+
+    private function compose(): string
+    {
+        if ($this->status === '') {
+            return $this->body;
+        }
+
+        return $this->body === ''
+            ? $this->status
+            : $this->body."\n\n".$this->status;
+    }
+
+    private function createPost(): void
+    {
+        $request = new CreatePost;
+        $body = [
+            'channel_id' => $this->channelId,
+            'message' => $this->compose(),
+        ];
+
+        if ($this->rootId !== null) {
+            $body['root_id'] = $this->rootId;
+        }
+
+        $request->body()->merge($body);
+
+        $response = $this->mattermost->send($request);
+        $id = $response->json('id');
+
+        if (is_string($id)) {
+            $this->postId = $id;
+        }
+    }
+
+    private function updatePost(): void
+    {
+        if ($this->postId === null) {
+            return;
+        }
+
+        $request = new UpdatePost($this->postId);
+        $request->body()->merge([
+            'id' => $this->postId,
+            'message' => $this->compose(),
+        ]);
+
+        $this->mattermost->send($request);
+    }
+}

--- a/src/Streaming/StreamCollector.php
+++ b/src/Streaming/StreamCollector.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\Streaming;
+
+use ConduitUI\Mattermost\Streaming\Chunks\StreamChunk;
+use ConduitUI\Mattermost\Streaming\Chunks\TextChunk;
+use ConduitUI\Mattermost\Streaming\Chunks\ToolCallChunk;
+
+final class StreamCollector
+{
+    public function __construct(
+        private readonly float $updateInterval = 1.5,
+        private readonly int $minCharDelta = 20,
+    ) {}
+
+    /**
+     * @param  iterable<StreamChunk>  $stream
+     */
+    public function collect(iterable $stream, StreamObserver $observer): string
+    {
+        $text = '';
+        $firstContentEmitted = false;
+        $lastUpdateAt = microtime(true);
+        $lastUpdateLen = 0;
+
+        foreach ($stream as $chunk) {
+            if ($chunk instanceof TextChunk) {
+                $text .= $chunk->text;
+
+                if (! $firstContentEmitted && strlen($text) >= $this->minCharDelta) {
+                    $observer->onFirstContent($text);
+                    $firstContentEmitted = true;
+                    $lastUpdateAt = microtime(true);
+                    $lastUpdateLen = strlen($text);
+
+                    continue;
+                }
+
+                $now = microtime(true);
+                if ($firstContentEmitted
+                    && ($now - $lastUpdateAt) >= $this->updateInterval
+                    && (strlen($text) - $lastUpdateLen) >= $this->minCharDelta
+                ) {
+                    $observer->onText($text);
+                    $lastUpdateAt = $now;
+                    $lastUpdateLen = strlen($text);
+                }
+            } elseif ($chunk instanceof ToolCallChunk) {
+                $observer->onToolCall($chunk->name);
+            }
+        }
+
+        if (! $firstContentEmitted && $text !== '') {
+            $observer->onFirstContent($text);
+        }
+
+        $observer->onComplete($text);
+
+        return trim($text);
+    }
+}

--- a/src/Streaming/StreamCollector.php
+++ b/src/Streaming/StreamCollector.php
@@ -8,11 +8,11 @@ use ConduitUI\Mattermost\Streaming\Chunks\StreamChunk;
 use ConduitUI\Mattermost\Streaming\Chunks\TextChunk;
 use ConduitUI\Mattermost\Streaming\Chunks\ToolCallChunk;
 
-final class StreamCollector
+final readonly class StreamCollector
 {
     public function __construct(
-        private readonly float $updateInterval = 1.5,
-        private readonly int $minCharDelta = 20,
+        private float $updateInterval = 1.5,
+        private int $minCharDelta = 20,
     ) {}
 
     /**

--- a/src/Streaming/StreamObserver.php
+++ b/src/Streaming/StreamObserver.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\Streaming;
+
+interface StreamObserver
+{
+    public function onFirstContent(string $text): void;
+
+    public function onText(string $fullText): void;
+
+    public function onToolCall(string $toolName): void;
+
+    public function onComplete(string $finalText): void;
+}

--- a/tests/Unit/Streaming/MattermostStreamingReplyTest.php
+++ b/tests/Unit/Streaming/MattermostStreamingReplyTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+use ConduitUI\Mattermost\Client\Mattermost;
+use ConduitUI\Mattermost\Client\Requests\Posts\CreatePost;
+use ConduitUI\Mattermost\Client\Requests\Posts\UpdatePost;
+use ConduitUI\Mattermost\Streaming\MattermostStreamingReply;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+function streamingHarness(?string $rootId = null): array
+{
+    $mattermost = new Mattermost(baseUrl: 'http://localhost:8065', token: 'test-token');
+
+    $mock = new MockClient([
+        CreatePost::class => MockResponse::make(['id' => 'post_abc']),
+        UpdatePost::class => MockResponse::make(['id' => 'post_abc']),
+    ]);
+
+    $mattermost->withMockClient($mock);
+
+    $reply = new MattermostStreamingReply($mattermost, channelId: 'ch_123', rootId: $rootId);
+
+    return [$mattermost, $mock, $reply];
+}
+
+describe('MattermostStreamingReply', function (): void {
+    it('lazily creates a post on first content with channel and message', function (): void {
+        [, $mock, $reply] = streamingHarness();
+
+        $reply->onFirstContent('hello world');
+
+        expect($reply->postId())->toBe('post_abc');
+        expect($mock->getRecordedResponses())->toHaveCount(1);
+
+        $request = $mock->getLastRequest();
+        expect($request)->toBeInstanceOf(CreatePost::class);
+        expect($request?->body()->all())->toMatchArray([
+            'channel_id' => 'ch_123',
+            'message' => 'hello world',
+        ]);
+    });
+
+    it('passes the root_id when threading', function (): void {
+        [, $mock, $reply] = streamingHarness(rootId: 'root_999');
+
+        $reply->onFirstContent('threaded reply');
+
+        $body = $mock->getLastRequest()?->body()->all();
+        expect($body)->toMatchArray([
+            'channel_id' => 'ch_123',
+            'message' => 'threaded reply',
+            'root_id' => 'root_999',
+        ]);
+    });
+
+    it('updates the existing post on subsequent onText calls', function (): void {
+        [, $mock, $reply] = streamingHarness();
+
+        $reply->onFirstContent('first');
+        $reply->onText('first more');
+
+        expect($mock->getRecordedResponses())->toHaveCount(2);
+
+        $request = $mock->getLastRequest();
+        expect($request)->toBeInstanceOf(UpdatePost::class);
+        expect($request?->body()->all())->toMatchArray([
+            'id' => 'post_abc',
+            'message' => 'first more',
+        ]);
+    });
+
+    it('keeps the body intact when a tool call fires mid-stream', function (): void {
+        [, $mock, $reply] = streamingHarness();
+
+        $reply->onFirstContent('Here is the answer');
+        $reply->onToolCall('MemorySearch');
+
+        $request = $mock->getLastRequest();
+        expect($request)->toBeInstanceOf(UpdatePost::class);
+
+        $message = $request?->body()->all()['message'] ?? '';
+        expect($message)->toStartWith('Here is the answer');
+        expect($message)->toContain('MemorySearch');
+    });
+
+    it('lazily creates a post when only a tool call has fired', function (): void {
+        [, $mock, $reply] = streamingHarness();
+
+        $reply->onToolCall('MemorySearch');
+
+        expect($reply->postId())->toBe('post_abc');
+
+        $request = $mock->getLastRequest();
+        expect($request)->toBeInstanceOf(CreatePost::class);
+        expect($request?->body()->all()['message'])->toContain('MemorySearch');
+    });
+
+    it('finalizes with onComplete by clearing the status and writing final text', function (): void {
+        [, $mock, $reply] = streamingHarness();
+
+        $reply->onFirstContent('partial');
+        $reply->onToolCall('MemorySearch');
+        $reply->onComplete('partial then the full answer');
+
+        $request = $mock->getLastRequest();
+        expect($request)->toBeInstanceOf(UpdatePost::class);
+        expect($request?->body()->all()['message'])->toBe('partial then the full answer');
+    });
+
+    it('skips API calls entirely when onComplete is called with empty text and no prior post', function (): void {
+        [, $mock, $reply] = streamingHarness();
+
+        $reply->onComplete('');
+
+        expect($reply->postId())->toBeNull();
+        expect($mock->getRecordedResponses())->toBeEmpty();
+    });
+
+    it('handles short replies that bypass onFirstContent and complete directly', function (): void {
+        [, $mock, $reply] = streamingHarness();
+
+        // Mimic StreamCollector behavior for short replies: onFirstContent
+        // fires before onComplete with the same text.
+        $reply->onFirstContent('hi');
+        $reply->onComplete('hi');
+
+        expect($reply->postId())->toBe('post_abc');
+        $request = $mock->getLastRequest();
+        expect($request)->toBeInstanceOf(UpdatePost::class);
+        expect($request?->body()->all()['message'])->toBe('hi');
+    });
+});

--- a/tests/Unit/Streaming/StreamCollectorTest.php
+++ b/tests/Unit/Streaming/StreamCollectorTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+use ConduitUI\Mattermost\Streaming\Chunks\TextChunk;
+use ConduitUI\Mattermost\Streaming\Chunks\ToolCallChunk;
+use ConduitUI\Mattermost\Streaming\StreamCollector;
+use ConduitUI\Mattermost\Streaming\StreamObserver;
+
+function recordingObserver(): StreamObserver
+{
+    return new class implements StreamObserver
+    {
+        /** @var list<array{0: string, 1: string}> */
+        public array $calls = [];
+
+        public function onFirstContent(string $text): void
+        {
+            $this->calls[] = ['onFirstContent', $text];
+        }
+
+        public function onText(string $fullText): void
+        {
+            $this->calls[] = ['onText', $fullText];
+        }
+
+        public function onToolCall(string $toolName): void
+        {
+            $this->calls[] = ['onToolCall', $toolName];
+        }
+
+        public function onComplete(string $finalText): void
+        {
+            $this->calls[] = ['onComplete', $finalText];
+        }
+    };
+}
+
+describe('StreamCollector', function (): void {
+    it('emits onFirstContent once char threshold is met', function (): void {
+        $observer = recordingObserver();
+        $stream = [
+            new TextChunk('Hello '),
+            new TextChunk('world, this is a '),
+            new TextChunk('long enough chunk'),
+        ];
+
+        $collector = new StreamCollector(updateInterval: 1.5, minCharDelta: 20);
+        $result = $collector->collect($stream, $observer);
+
+        expect($result)->toBe('Hello world, this is a long enough chunk');
+        expect($observer->calls[0][0])->toBe('onFirstContent');
+        expect($observer->calls[0][1])->toContain('Hello world, this is a');
+    });
+
+    it('always emits onComplete with the full text', function (): void {
+        $observer = recordingObserver();
+
+        (new StreamCollector)->collect([
+            new TextChunk('chunk one '),
+            new TextChunk('chunk two'),
+        ], $observer);
+
+        $last = end($observer->calls);
+        expect($last[0])->toBe('onComplete');
+        expect($last[1])->toBe('chunk one chunk two');
+    });
+
+    it('emits onFirstContent even for short replies under the threshold', function (): void {
+        $observer = recordingObserver();
+
+        (new StreamCollector(minCharDelta: 100))->collect([
+            new TextChunk('hi'),
+        ], $observer);
+
+        expect($observer->calls[0][0])->toBe('onFirstContent');
+        expect($observer->calls[0][1])->toBe('hi');
+        expect(end($observer->calls)[0])->toBe('onComplete');
+    });
+
+    it('does not emit onFirstContent when stream is empty', function (): void {
+        $observer = recordingObserver();
+
+        (new StreamCollector)->collect([], $observer);
+
+        expect($observer->calls)->toHaveCount(1);
+        expect($observer->calls[0])->toBe(['onComplete', '']);
+    });
+
+    it('forwards tool calls to the observer in order', function (): void {
+        $observer = recordingObserver();
+
+        (new StreamCollector)->collect([
+            new TextChunk('searching for the '),
+            new TextChunk('answer to your question'),
+            new ToolCallChunk('MemorySearch'),
+            new ToolCallChunk('WebSearch'),
+        ], $observer);
+
+        $toolCalls = array_values(array_filter($observer->calls, fn ($c) => $c[0] === 'onToolCall'));
+        expect($toolCalls)->toBe([
+            ['onToolCall', 'MemorySearch'],
+            ['onToolCall', 'WebSearch'],
+        ]);
+    });
+
+    it('throttles onText updates by both interval and char delta', function (): void {
+        $observer = recordingObserver();
+        // Two chunks far above char threshold but inside the interval window.
+        // Only the first triggers onFirstContent; the second should NOT trigger
+        // onText because the interval (1.5s) hasn't elapsed.
+        (new StreamCollector(updateInterval: 1.5, minCharDelta: 20))->collect([
+            new TextChunk(str_repeat('a', 25)),
+            new TextChunk(str_repeat('b', 25)),
+        ], $observer);
+
+        $onTextCalls = array_filter($observer->calls, fn ($c) => $c[0] === 'onText');
+        expect($onTextCalls)->toBeEmpty();
+    });
+
+    it('returns the trimmed final text', function (): void {
+        $observer = recordingObserver();
+
+        $result = (new StreamCollector)->collect([
+            new TextChunk("  hello world  \n"),
+        ], $observer);
+
+        expect($result)->toBe('hello world');
+    });
+});


### PR DESCRIPTION
## Summary

Adds the streaming reply primitives the rest of the bot framework will lean on:

- **`StreamObserver`** interface — `onFirstContent`, `onText`, `onToolCall`, `onComplete`
- **`MattermostStreamingReply`** default observer — lazily creates a post on first signal, then edits it as the stream evolves
- **`StreamCollector`** — iterates chunks, throttles `onText` by both interval (1.5s) and min char delta (20), guarantees `onComplete` fires
- **`StreamChunk` / `TextChunk` / `ToolCallChunk`** — small value objects so callers can adapt any LLM SDK without dragging Prism (or any other framework) into this package

Body and status are layered (`body \n\n _status_`), so a tool call mid-stream no longer clobbers partial reply text — a regression we hit in lexi-agent's earlier observer.

### Drive-by fix

`UpdatePost` and `PatchPost` were missing the `HasBody` trait, which meant the auto-generated client couldn't actually send a body on `PUT /posts/{id}` or `PUT /posts/{id}/patch`. Streaming replies need both — fixed inline rather than blocking on a separate auto-gen polish PR.

### Design notes

- Throttling lives in `StreamCollector`, not the observer — observer just renders. Lets you swap implementations (Slack, console, log) without re-implementing throttle logic.
- `onComplete` always fires, even on empty streams. Empty + no-prior-post is a no-op (no API call) so callers can safely route `[PASS]`-style declines through it.
- `MattermostStreamingReply` takes the Saloon `Mattermost` connector directly so consumers retain full control of the named connection.

## Test plan

- [x] `vendor/bin/pest --compact` — 28 passed
- [x] `vendor/bin/pint --test` — clean
- [x] `vendor/bin/phpstan analyse` — no errors
- [ ] Manual smoke against a real Mattermost instance (Jordan / lexi-agent integration)

Closes #5