### PR TITLE
feat: fluent message builder

### DIFF
--- a/src/Messages/Action.php
+++ b/src/Messages/Action.php
@@ -59,10 +59,10 @@ class Action
         $this->options = array_map(
             static function (array $option): array {
                 if (isset($option['text'], $option['value'])) {
-                    return ['text' => (string) $option['text'], 'value' => (string) $option['value']];
+                    return ['text' => $option['text'], 'value' => $option['value']];
                 }
 
-                return ['text' => (string) $option[0], 'value' => (string) $option[1]];
+                return ['text' => $option[0], 'value' => $option[1]];
             },
             $options,
         );

--- a/src/Messages/Action.php
+++ b/src/Messages/Action.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\Messages;
+
+/**
+ * Builder for an interactive message action (button or select menu).
+ *
+ * @see https://docs.mattermost.com/developer/interactive-messages.html
+ */
+class Action
+{
+    private ?string $id = null;
+
+    private ?string $name = null;
+
+    /** @var 'button'|'select'|null */
+    private ?string $type = null;
+
+    /** @var array<string, mixed>|null */
+    private ?array $integration = null;
+
+    /** @var 'default'|'primary'|'success'|'good'|'warning'|'danger'|null */
+    private ?string $style = null;
+
+    /** @var list<array{text: string, value: string}>|null */
+    private ?array $options = null;
+
+    private ?string $dataSource = null;
+
+    /**
+     * @param  array<string, mixed>  $context
+     */
+    public function button(string $name, string $url, array $context = []): self
+    {
+        $this->type = 'button';
+        $this->name = $name;
+        $this->integration = [
+            'url' => $url,
+            'context' => $context,
+        ];
+
+        return $this;
+    }
+
+    /**
+     * @param  list<array{text: string, value: string}|array{0: string, 1: string}>  $options
+     * @param  array<string, mixed>  $context
+     */
+    public function select(string $name, string $url, array $options, array $context = []): self
+    {
+        $this->type = 'select';
+        $this->name = $name;
+        $this->integration = [
+            'url' => $url,
+            'context' => $context,
+        ];
+        $this->options = array_map(
+            static function (array $option): array {
+                if (isset($option['text'], $option['value'])) {
+                    return ['text' => (string) $option['text'], 'value' => (string) $option['value']];
+                }
+
+                return ['text' => (string) $option[0], 'value' => (string) $option[1]];
+            },
+            $options,
+        );
+
+        return $this;
+    }
+
+    /**
+     * Use a built-in Mattermost data source (e.g. 'users', 'channels')
+     * instead of a static options list.
+     */
+    public function dataSource(string $source): self
+    {
+        $this->dataSource = $source;
+
+        return $this;
+    }
+
+    public function id(string $id): self
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function name(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function style(string $style): self
+    {
+        /** @var 'default'|'primary'|'success'|'good'|'warning'|'danger' $style */
+        $this->style = $style;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $payload = [];
+
+        if ($this->id !== null) {
+            $payload['id'] = $this->id;
+        }
+
+        if ($this->name !== null) {
+            $payload['name'] = $this->name;
+        }
+
+        if ($this->type !== null) {
+            $payload['type'] = $this->type;
+        }
+
+        if ($this->style !== null) {
+            $payload['style'] = $this->style;
+        }
+
+        if ($this->integration !== null) {
+            $payload['integration'] = $this->integration;
+        }
+
+        if ($this->options !== null) {
+            $payload['options'] = $this->options;
+        }
+
+        if ($this->dataSource !== null) {
+            $payload['data_source'] = $this->dataSource;
+        }
+
+        return $payload;
+    }
+}

--- a/src/Messages/Attachment.php
+++ b/src/Messages/Attachment.php
@@ -1,0 +1,250 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\Messages;
+
+use Closure;
+use DateTimeInterface;
+
+/**
+ * Builder for a Mattermost message attachment (Slack-compatible).
+ *
+ * @see https://docs.mattermost.com/developer/message-attachments.html
+ */
+class Attachment
+{
+    private ?string $fallback = null;
+
+    private ?string $color = null;
+
+    private ?string $pretext = null;
+
+    private ?string $authorName = null;
+
+    private ?string $authorLink = null;
+
+    private ?string $authorIcon = null;
+
+    private ?string $title = null;
+
+    private ?string $titleLink = null;
+
+    private ?string $text = null;
+
+    /** @var list<array{title: string, value: string, short: bool}> */
+    private array $fields = [];
+
+    private ?string $imageUrl = null;
+
+    private ?string $thumbUrl = null;
+
+    private ?string $footer = null;
+
+    private ?string $footerIcon = null;
+
+    private ?int $timestamp = null;
+
+    /** @var list<Action> */
+    private array $actions = [];
+
+    public function fallback(string $fallback): self
+    {
+        $this->fallback = $fallback;
+
+        return $this;
+    }
+
+    public function color(string $color): self
+    {
+        $this->color = $color;
+
+        return $this;
+    }
+
+    public function pretext(string $pretext): self
+    {
+        $this->pretext = $pretext;
+
+        return $this;
+    }
+
+    public function author(string $name, ?string $link = null, ?string $icon = null): self
+    {
+        $this->authorName = $name;
+        $this->authorLink = $link;
+        $this->authorIcon = $icon;
+
+        return $this;
+    }
+
+    public function title(string $title, ?string $link = null): self
+    {
+        $this->title = $title;
+        $this->titleLink = $link;
+
+        return $this;
+    }
+
+    public function text(string $text): self
+    {
+        $this->text = $text;
+
+        return $this;
+    }
+
+    public function field(string $title, string $value, bool $short = false): self
+    {
+        $this->fields[] = [
+            'title' => $title,
+            'value' => $value,
+            'short' => $short,
+        ];
+
+        return $this;
+    }
+
+    /**
+     * @param  list<array{title: string, value: string, short?: bool}>  $fields
+     */
+    public function fields(array $fields): self
+    {
+        foreach ($fields as $field) {
+            $this->field(
+                $field['title'],
+                $field['value'],
+                $field['short'] ?? false,
+            );
+        }
+
+        return $this;
+    }
+
+    public function image(string $url): self
+    {
+        $this->imageUrl = $url;
+
+        return $this;
+    }
+
+    public function thumb(string $url): self
+    {
+        $this->thumbUrl = $url;
+
+        return $this;
+    }
+
+    public function footer(string $footer, ?string $icon = null): self
+    {
+        $this->footer = $footer;
+        $this->footerIcon = $icon;
+
+        return $this;
+    }
+
+    public function timestamp(int|DateTimeInterface $ts): self
+    {
+        $this->timestamp = $ts instanceof DateTimeInterface ? $ts->getTimestamp() : $ts;
+
+        return $this;
+    }
+
+    /**
+     * Add an interactive action (button or select menu) via a builder closure.
+     *
+     * @param  Closure(Action): void|Closure(Action): Action  $configure
+     */
+    public function action(Closure $configure): self
+    {
+        $action = new Action;
+        $configure($action);
+        $this->actions[] = $action;
+
+        return $this;
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     */
+    public function button(string $name, string $url, array $context = []): self
+    {
+        return $this->action(static fn (Action $a): Action => $a->button($name, $url, $context));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $payload = [];
+
+        if ($this->fallback !== null) {
+            $payload['fallback'] = $this->fallback;
+        }
+
+        if ($this->color !== null) {
+            $payload['color'] = $this->color;
+        }
+
+        if ($this->pretext !== null) {
+            $payload['pretext'] = $this->pretext;
+        }
+
+        if ($this->authorName !== null) {
+            $payload['author_name'] = $this->authorName;
+        }
+
+        if ($this->authorLink !== null) {
+            $payload['author_link'] = $this->authorLink;
+        }
+
+        if ($this->authorIcon !== null) {
+            $payload['author_icon'] = $this->authorIcon;
+        }
+
+        if ($this->title !== null) {
+            $payload['title'] = $this->title;
+        }
+
+        if ($this->titleLink !== null) {
+            $payload['title_link'] = $this->titleLink;
+        }
+
+        if ($this->text !== null) {
+            $payload['text'] = $this->text;
+        }
+
+        if ($this->fields !== []) {
+            $payload['fields'] = $this->fields;
+        }
+
+        if ($this->imageUrl !== null) {
+            $payload['image_url'] = $this->imageUrl;
+        }
+
+        if ($this->thumbUrl !== null) {
+            $payload['thumb_url'] = $this->thumbUrl;
+        }
+
+        if ($this->footer !== null) {
+            $payload['footer'] = $this->footer;
+        }
+
+        if ($this->footerIcon !== null) {
+            $payload['footer_icon'] = $this->footerIcon;
+        }
+
+        if ($this->timestamp !== null) {
+            $payload['ts'] = $this->timestamp;
+        }
+
+        if ($this->actions !== []) {
+            $payload['actions'] = array_map(
+                static fn (Action $action): array => $action->toArray(),
+                $this->actions,
+            );
+        }
+
+        return $payload;
+    }
+}

--- a/src/Messages/Markdown.php
+++ b/src/Messages/Markdown.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\Messages;
+
+/**
+ * Markdown helpers for Mattermost messages.
+ *
+ * Pure string helpers — no formatting state. Use as a static utility
+ * when composing message text.
+ *
+ * @see https://docs.mattermost.com/messaging/formatting-text.html
+ */
+final class Markdown
+{
+    public static function bold(string $text): string
+    {
+        return '**'.$text.'**';
+    }
+
+    public static function italic(string $text): string
+    {
+        return '*'.$text.'*';
+    }
+
+    public static function strikethrough(string $text): string
+    {
+        return '~~'.$text.'~~';
+    }
+
+    public static function code(string $text): string
+    {
+        return '`'.$text.'`';
+    }
+
+    public static function codeBlock(string $text, ?string $language = null): string
+    {
+        return '```'.($language ?? '')."\n".$text."\n".'```';
+    }
+
+    public static function link(string $text, string $url): string
+    {
+        return '['.$text.']('.$url.')';
+    }
+
+    public static function image(string $alt, string $url): string
+    {
+        return '!['.$alt.']('.$url.')';
+    }
+
+    public static function blockquote(string $text): string
+    {
+        $lines = preg_split('/\r\n|\r|\n/', $text) ?: [];
+
+        return implode("\n", array_map(static fn (string $line): string => '> '.$line, $lines));
+    }
+
+    /**
+     * Render a markdown table.
+     *
+     * @param  list<string>  $headers
+     * @param  list<list<string>>  $rows
+     */
+    public static function table(array $headers, array $rows): string
+    {
+        $headerLine = '| '.implode(' | ', $headers).' |';
+        $separator = '| '.implode(' | ', array_fill(0, count($headers), '---')).' |';
+
+        $body = array_map(
+            static fn (array $row): string => '| '.implode(' | ', $row).' |',
+            $rows,
+        );
+
+        return implode("\n", [$headerLine, $separator, ...$body]);
+    }
+
+    public static function mention(string $username): string
+    {
+        return '@'.ltrim($username, '@');
+    }
+
+    public static function channel(string $name): string
+    {
+        return '~'.ltrim($name, '~');
+    }
+
+    public static function emoji(string $name): string
+    {
+        return ':'.trim($name, ':').':';
+    }
+}

--- a/src/Messages/Message.php
+++ b/src/Messages/Message.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\Messages;
+
+use Closure;
+
+/**
+ * Fluent builder for a Mattermost post payload.
+ *
+ * Pure value object — produces an array suitable for the Posts API. It does
+ * not perform any HTTP calls. Send via the Saloon client / facade.
+ *
+ * @see https://api.mattermost.com/#tag/posts/operation/CreatePost
+ */
+class Message
+{
+    private ?string $channelId = null;
+
+    private ?string $message = null;
+
+    private ?string $rootId = null;
+
+    /** @var list<string> */
+    private array $fileIds = [];
+
+    /** @var list<Attachment> */
+    private array $attachments = [];
+
+    /** @var array<string, mixed> */
+    private array $props = [];
+
+    public static function make(?string $message = null): self
+    {
+        $instance = new self;
+
+        if ($message !== null) {
+            $instance->text($message);
+        }
+
+        return $instance;
+    }
+
+    /**
+     * Target a channel by ID. The Posts API accepts a channel_id, so this
+     * method names the channel/channel-id field — callers may pass either a
+     * channel ID or a name and resolve it before sending.
+     */
+    public static function to(string $channel): self
+    {
+        return (new self)->channel($channel);
+    }
+
+    public function channel(string $channelId): self
+    {
+        $this->channelId = $channelId;
+
+        return $this;
+    }
+
+    public function text(string $message): self
+    {
+        $this->message = $message;
+
+        return $this;
+    }
+
+    /**
+     * Append additional text to the message body.
+     */
+    public function append(string $text, string $separator = "\n"): self
+    {
+        $this->message = $this->message === null
+            ? $text
+            : $this->message.$separator.$text;
+
+        return $this;
+    }
+
+    public function inThread(string $rootId): self
+    {
+        $this->rootId = $rootId;
+
+        return $this;
+    }
+
+    /**
+     * @param  list<string>|string  $ids
+     */
+    public function files(array|string $ids): self
+    {
+        $ids = is_array($ids) ? $ids : [$ids];
+
+        foreach ($ids as $id) {
+            $this->fileIds[] = $id;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add an attachment via a builder closure or an existing Attachment.
+     *
+     * @param  Closure(Attachment): void|Closure(Attachment): Attachment|Attachment  $attachment
+     */
+    public function attachment(Closure|Attachment $attachment): self
+    {
+        if ($attachment instanceof Attachment) {
+            $this->attachments[] = $attachment;
+
+            return $this;
+        }
+
+        $built = new Attachment;
+        $attachment($built);
+        $this->attachments[] = $built;
+
+        return $this;
+    }
+
+    /**
+     * Set an arbitrary key on the message props bag. Reserved key
+     * "attachments" is rejected — use attachment() instead.
+     */
+    public function prop(string $key, mixed $value): self
+    {
+        if ($key === 'attachments') {
+            throw new \InvalidArgumentException('Use attachment() to set message attachments.');
+        }
+
+        $this->props[$key] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $payload = [];
+
+        if ($this->channelId !== null) {
+            $payload['channel_id'] = $this->channelId;
+        }
+
+        $payload['message'] = $this->message ?? '';
+
+        if ($this->rootId !== null) {
+            $payload['root_id'] = $this->rootId;
+        }
+
+        if ($this->fileIds !== []) {
+            $payload['file_ids'] = $this->fileIds;
+        }
+
+        $props = $this->props;
+
+        if ($this->attachments !== []) {
+            $props['attachments'] = array_map(
+                static fn (Attachment $a): array => $a->toArray(),
+                $this->attachments,
+            );
+        }
+
+        if ($props !== []) {
+            $payload['props'] = $props;
+        }
+
+        return $payload;
+    }
+}

--- a/tests/Unit/Messages/ActionTest.php
+++ b/tests/Unit/Messages/ActionTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+use ConduitUI\Mattermost\Messages\Action;
+
+describe('Action builder', function (): void {
+    it('builds a button action', function (): void {
+        $payload = (new Action)
+            ->button('Approve', 'https://example.test/cb', ['post_id' => 'p1'])
+            ->toArray();
+
+        expect($payload)->toBe([
+            'name' => 'Approve',
+            'type' => 'button',
+            'integration' => [
+                'url' => 'https://example.test/cb',
+                'context' => ['post_id' => 'p1'],
+            ],
+        ]);
+    });
+
+    it('builds a select action with assoc options', function (): void {
+        $payload = (new Action)
+            ->select('Pick', 'https://example.test/cb', [
+                ['text' => 'One', 'value' => '1'],
+                ['text' => 'Two', 'value' => '2'],
+            ])
+            ->toArray();
+
+        expect($payload['type'])->toBe('select');
+        expect($payload['options'])->toBe([
+            ['text' => 'One', 'value' => '1'],
+            ['text' => 'Two', 'value' => '2'],
+        ]);
+    });
+
+    it('builds a select action with positional option tuples', function (): void {
+        $payload = (new Action)
+            ->select('Pick', 'https://example.test/cb', [
+                ['One', '1'],
+                ['Two', '2'],
+            ])
+            ->toArray();
+
+        expect($payload['options'])->toBe([
+            ['text' => 'One', 'value' => '1'],
+            ['text' => 'Two', 'value' => '2'],
+        ]);
+    });
+
+    it('uses a built-in data source', function (): void {
+        $payload = (new Action)
+            ->select('Pick a user', 'https://example.test/cb', [])
+            ->dataSource('users')
+            ->toArray();
+
+        expect($payload['data_source'])->toBe('users');
+    });
+
+    it('captures id and style', function (): void {
+        $payload = (new Action)
+            ->id('act-1')
+            ->style('danger')
+            ->button('Delete', 'https://example.test/del')
+            ->toArray();
+
+        expect($payload)->toMatchArray([
+            'id' => 'act-1',
+            'style' => 'danger',
+            'name' => 'Delete',
+            'type' => 'button',
+        ]);
+    });
+
+    it('serializes empty when nothing is set', function (): void {
+        expect((new Action)->toArray())->toBe([]);
+    });
+});

--- a/tests/Unit/Messages/AttachmentTest.php
+++ b/tests/Unit/Messages/AttachmentTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+use ConduitUI\Mattermost\Messages\Action;
+use ConduitUI\Mattermost\Messages\Attachment;
+
+describe('Attachment builder', function (): void {
+    it('serializes empty when nothing is set', function (): void {
+        expect((new Attachment)->toArray())->toBe([]);
+    });
+
+    it('captures the full surface of attachment fields', function (): void {
+        $payload = (new Attachment)
+            ->fallback('plain-text fallback')
+            ->color('#22c55e')
+            ->pretext('above the box')
+            ->author('Lexi', 'https://example.test/lexi', 'https://example.test/lexi.png')
+            ->title('Build status', 'https://example.test/build/123')
+            ->text('all green')
+            ->field('Branch', 'main', short: true)
+            ->field('Commit', 'abc123', short: true)
+            ->image('https://example.test/img.png')
+            ->thumb('https://example.test/thumb.png')
+            ->footer('CI bot', 'https://example.test/footer.png')
+            ->timestamp(1700000000)
+            ->toArray();
+
+        expect($payload)->toBe([
+            'fallback' => 'plain-text fallback',
+            'color' => '#22c55e',
+            'pretext' => 'above the box',
+            'author_name' => 'Lexi',
+            'author_link' => 'https://example.test/lexi',
+            'author_icon' => 'https://example.test/lexi.png',
+            'title' => 'Build status',
+            'title_link' => 'https://example.test/build/123',
+            'text' => 'all green',
+            'fields' => [
+                ['title' => 'Branch', 'value' => 'main', 'short' => true],
+                ['title' => 'Commit', 'value' => 'abc123', 'short' => true],
+            ],
+            'image_url' => 'https://example.test/img.png',
+            'thumb_url' => 'https://example.test/thumb.png',
+            'footer' => 'CI bot',
+            'footer_icon' => 'https://example.test/footer.png',
+            'ts' => 1700000000,
+        ]);
+    });
+
+    it('defaults short=false for fields', function (): void {
+        $payload = (new Attachment)->field('K', 'V')->toArray();
+
+        expect($payload['fields'])->toBe([
+            ['title' => 'K', 'value' => 'V', 'short' => false],
+        ]);
+    });
+
+    it('accepts bulk fields and merges with single field calls in order', function (): void {
+        $payload = (new Attachment)
+            ->field('a', '1')
+            ->fields([
+                ['title' => 'b', 'value' => '2', 'short' => true],
+                ['title' => 'c', 'value' => '3'],
+            ])
+            ->field('d', '4')
+            ->toArray();
+
+        expect(array_column($payload['fields'], 'title'))->toBe(['a', 'b', 'c', 'd']);
+        expect($payload['fields'][2]['short'])->toBeFalse();
+    });
+
+    it('accepts a DateTimeInterface for timestamp', function (): void {
+        $dt = new DateTimeImmutable('2024-01-15T10:30:00Z');
+
+        $payload = (new Attachment)->timestamp($dt)->toArray();
+
+        expect($payload['ts'])->toBe($dt->getTimestamp());
+    });
+
+    it('omits author_link and author_icon when only a name is provided', function (): void {
+        $payload = (new Attachment)->author('Lexi')->toArray();
+
+        expect($payload)->toBe(['author_name' => 'Lexi']);
+    });
+
+    it('omits title_link when only a title is provided', function (): void {
+        $payload = (new Attachment)->title('only-title')->toArray();
+
+        expect($payload)->toBe(['title' => 'only-title']);
+    });
+
+    it('builds button actions via the convenience helper', function (): void {
+        $payload = (new Attachment)
+            ->button('Approve', 'https://example.test/approve', ['id' => 42])
+            ->toArray();
+
+        expect($payload['actions'])->toBe([[
+            'name' => 'Approve',
+            'type' => 'button',
+            'integration' => [
+                'url' => 'https://example.test/approve',
+                'context' => ['id' => 42],
+            ],
+        ]]);
+    });
+
+    it('builds actions via closure', function (): void {
+        $payload = (new Attachment)
+            ->action(fn (Action $a) => $a
+                ->id('approve-btn')
+                ->style('primary')
+                ->button('Approve', 'https://example.test/approve')
+            )
+            ->toArray();
+
+        expect($payload['actions'][0])->toMatchArray([
+            'id' => 'approve-btn',
+            'name' => 'Approve',
+            'type' => 'button',
+            'style' => 'primary',
+        ]);
+    });
+
+    it('preserves action ordering', function (): void {
+        $payload = (new Attachment)
+            ->button('one', 'https://x.test/1')
+            ->button('two', 'https://x.test/2')
+            ->button('three', 'https://x.test/3')
+            ->toArray();
+
+        expect(array_column($payload['actions'], 'name'))->toBe(['one', 'two', 'three']);
+    });
+
+    it('returns the same instance from chained calls', function (): void {
+        $a = new Attachment;
+
+        expect($a->color('#fff'))->toBe($a)
+            ->and($a->title('t'))->toBe($a)
+            ->and($a->field('k', 'v'))->toBe($a);
+    });
+});

--- a/tests/Unit/Messages/MarkdownTest.php
+++ b/tests/Unit/Messages/MarkdownTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+use ConduitUI\Mattermost\Messages\Markdown;
+
+describe('Markdown helpers', function (): void {
+    it('formats bold', fn () => expect(Markdown::bold('x'))->toBe('**x**'));
+    it('formats italic', fn () => expect(Markdown::italic('x'))->toBe('*x*'));
+    it('formats strikethrough', fn () => expect(Markdown::strikethrough('x'))->toBe('~~x~~'));
+    it('formats inline code', fn () => expect(Markdown::code('x'))->toBe('`x`'));
+
+    it('formats a code block without language', function (): void {
+        expect(Markdown::codeBlock('hello'))->toBe("```\nhello\n```");
+    });
+
+    it('formats a code block with language', function (): void {
+        expect(Markdown::codeBlock('echo 1', 'php'))->toBe("```php\necho 1\n```");
+    });
+
+    it('formats a link', function (): void {
+        expect(Markdown::link('site', 'https://example.test'))
+            ->toBe('[site](https://example.test)');
+    });
+
+    it('formats an image', function (): void {
+        expect(Markdown::image('alt', 'https://example.test/i.png'))
+            ->toBe('![alt](https://example.test/i.png)');
+    });
+
+    it('formats a multi-line blockquote', function (): void {
+        expect(Markdown::blockquote("a\nb"))->toBe("> a\n> b");
+    });
+
+    it('formats a table', function (): void {
+        $table = Markdown::table(
+            ['H1', 'H2'],
+            [['a', 'b'], ['c', 'd']],
+        );
+
+        expect($table)->toBe(
+            "| H1 | H2 |\n".
+            "| --- | --- |\n".
+            "| a | b |\n".
+            '| c | d |'
+        );
+    });
+
+    it('renders a mention with or without leading @', function (): void {
+        expect(Markdown::mention('alice'))->toBe('@alice')
+            ->and(Markdown::mention('@bob'))->toBe('@bob');
+    });
+
+    it('renders a channel reference with or without leading ~', function (): void {
+        expect(Markdown::channel('town-square'))->toBe('~town-square')
+            ->and(Markdown::channel('~off-topic'))->toBe('~off-topic');
+    });
+
+    it('renders an emoji with or without surrounding colons', function (): void {
+        expect(Markdown::emoji('rocket'))->toBe(':rocket:')
+            ->and(Markdown::emoji(':tada:'))->toBe(':tada:');
+    });
+});

--- a/tests/Unit/Messages/MessageTest.php
+++ b/tests/Unit/Messages/MessageTest.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+use ConduitUI\Mattermost\Messages\Attachment;
+use ConduitUI\Mattermost\Messages\Message;
+
+describe('Message builder', function (): void {
+    it('builds an empty message', function (): void {
+        expect(Message::make()->toArray())->toBe(['message' => '']);
+    });
+
+    it('captures text via make()', function (): void {
+        expect(Message::make('hello')->toArray())
+            ->toBe(['message' => 'hello']);
+    });
+
+    it('captures text via text()', function (): void {
+        expect(Message::make()->text('hello')->toArray())
+            ->toBe(['message' => 'hello']);
+    });
+
+    it('targets a channel via to()', function (): void {
+        $payload = Message::to('town-square')->text('hi')->toArray();
+
+        expect($payload)->toBe([
+            'channel_id' => 'town-square',
+            'message' => 'hi',
+        ]);
+    });
+
+    it('appends text with default newline separator', function (): void {
+        $payload = Message::make('first')->append('second')->toArray();
+
+        expect($payload['message'])->toBe("first\nsecond");
+    });
+
+    it('appends text with custom separator', function (): void {
+        $payload = Message::make('a')->append('b', ' | ')->toArray();
+
+        expect($payload['message'])->toBe('a | b');
+    });
+
+    it('append on empty message starts the body', function (): void {
+        $payload = Message::make()->append('only')->toArray();
+
+        expect($payload['message'])->toBe('only');
+    });
+
+    it('threads via inThread()', function (): void {
+        $payload = Message::make('reply')->inThread('root-post-id')->toArray();
+
+        expect($payload)->toBe([
+            'message' => 'reply',
+            'root_id' => 'root-post-id',
+        ]);
+    });
+
+    it('attaches a single file id', function (): void {
+        $payload = Message::make('see attached')->files('file-1')->toArray();
+
+        expect($payload['file_ids'])->toBe(['file-1']);
+    });
+
+    it('attaches multiple file ids and preserves order across calls', function (): void {
+        $payload = Message::make('hi')
+            ->files(['file-1', 'file-2'])
+            ->files('file-3')
+            ->toArray();
+
+        expect($payload['file_ids'])->toBe(['file-1', 'file-2', 'file-3']);
+    });
+
+    it('builds attachments via closure', function (): void {
+        $payload = Message::make('Deploy complete')
+            ->attachment(fn (Attachment $a) => $a
+                ->color('#36a64f')
+                ->title('v2.1.0 shipped')
+                ->field('Environment', 'production', short: true)
+                ->field('Duration', '45s', short: true)
+                ->footer('Deployed by Lexi')
+            )
+            ->toArray();
+
+        expect($payload)->toBe([
+            'message' => 'Deploy complete',
+            'props' => [
+                'attachments' => [[
+                    'color' => '#36a64f',
+                    'title' => 'v2.1.0 shipped',
+                    'fields' => [
+                        ['title' => 'Environment', 'value' => 'production', 'short' => true],
+                        ['title' => 'Duration', 'value' => '45s', 'short' => true],
+                    ],
+                    'footer' => 'Deployed by Lexi',
+                ]],
+            ],
+        ]);
+    });
+
+    it('accepts a pre-built Attachment instance', function (): void {
+        $attachment = (new Attachment)->title('built outside');
+
+        $payload = Message::make('hi')->attachment($attachment)->toArray();
+
+        expect($payload['props']['attachments'])->toBe([['title' => 'built outside']]);
+    });
+
+    it('preserves attachment ordering across multiple calls', function (): void {
+        $payload = Message::make()
+            ->attachment(fn (Attachment $a) => $a->title('first'))
+            ->attachment(fn (Attachment $a) => $a->title('second'))
+            ->attachment(fn (Attachment $a) => $a->title('third'))
+            ->toArray();
+
+        expect(array_column($payload['props']['attachments'], 'title'))
+            ->toBe(['first', 'second', 'third']);
+    });
+
+    it('omits props when no attachments or custom props are set', function (): void {
+        $payload = Message::make('plain')->toArray();
+
+        expect($payload)->not->toHaveKey('props');
+    });
+
+    it('serializes mixed text + attachment', function (): void {
+        $payload = Message::make()
+            ->text('Heads up')
+            ->attachment(fn (Attachment $a) => $a->text('details'))
+            ->toArray();
+
+        expect($payload)->toBe([
+            'message' => 'Heads up',
+            'props' => [
+                'attachments' => [['text' => 'details']],
+            ],
+        ]);
+    });
+
+    it('text() called twice keeps the last value', function (): void {
+        $payload = Message::make('first')->text('second')->toArray();
+
+        expect($payload['message'])->toBe('second');
+    });
+
+    it('supports custom props alongside attachments', function (): void {
+        $payload = Message::make('hi')
+            ->prop('from_webhook', 'true')
+            ->attachment(fn (Attachment $a) => $a->title('t'))
+            ->toArray();
+
+        expect($payload['props'])->toBe([
+            'from_webhook' => 'true',
+            'attachments' => [['title' => 't']],
+        ]);
+    });
+
+    it('rejects setting attachments via prop()', function (): void {
+        Message::make()->prop('attachments', []);
+    })->throws(InvalidArgumentException::class, 'attachment()');
+
+    it('returns the same instance from chained calls', function (): void {
+        $message = Message::make();
+
+        expect($message->text('hi'))->toBe($message)
+            ->and($message->channel('c'))->toBe($message)
+            ->and($message->inThread('r'))->toBe($message);
+    });
+});


### PR DESCRIPTION
Closes #6.

## Summary

Pure value-object builders for composing Mattermost post payloads. No HTTP, no facade binding, no Client/ touches — `toArray()` is the serializer; sending is the Saloon client's job.

- `Message` — root builder. `make()`, `to(channel)`, `text()`, `append()`, `inThread()`, `files()`, `prop()`, `attachment()`. Yields `['channel_id' => ..., 'message' => ..., 'props' => ['attachments' => [...]]]`.
- `Attachment` — full Slack-compatible surface: `fallback`, `color`, `pretext`, `author(name, link?, icon?)`, `title(text, link?)`, `text`, `field(title, value, short)`, `fields(bulk)`, `image`, `thumb`, `footer(text, icon?)`, `timestamp(int|DateTimeInterface)`, plus `action(closure)` and `button(name, url, context)`.
- `Action` — `button(name, url, context)`, `select(name, url, options, context)` (assoc or positional tuples), `dataSource('users'|'channels'|...)`, `id`, `style`, `name`.
- `Markdown` — stateless helpers: `bold`, `italic`, `strikethrough`, `code`, `codeBlock(lang?)`, `link`, `image`, `blockquote`, `table`, `mention`, `channel`, `emoji`.

Each fluent call returns `$this`. `toArray()` only emits keys that were set, so an empty builder serializes to a minimal payload (`Message::make()->toArray() === ['message' => '']`).

## Design notes

- No `send()` method — keeping this PR strictly to value-object work per the issue's split with #1 (Posts API) and the constraint not to modify `Client/`.
- `Message::to('town-square')` sets `channel_id` directly. Callers who pass a channel name can resolve it before sending; the builder is content-shape-agnostic.
- `prop('attachments', ...)` is rejected — use `attachment()` so attachments and other props compose cleanly.
- Markdown is a separate static class (not a trait on Message) so it can be used anywhere a string is composed, including inside attachments and outside the builder.

## Test plan

- [x] `vendor/bin/pint --test` — passes
- [x] `vendor/bin/phpstan analyse` — 0 errors
- [x] `vendor/bin/pest --compact` — 62 passed (93 assertions)
- [x] Coverage: composition, ordering across repeated calls, mixed text+attachment, empty builders, action button/select variants, markdown edge cases (mention/channel/emoji idempotency, multi-line blockquote, table rendering)