### PR TITLE
feat: Mattermost::fake() + fixture helpers

### DIFF
--- a/src/Client/Requests/Posts/PatchPost.php
+++ b/src/Client/Requests/Posts/PatchPost.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace ConduitUI\Mattermost\Client\Requests\Posts;
 
+use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
 
 /**
  * PatchPost
@@ -16,8 +18,10 @@ use Saloon\Http\Request;
  * ##### Permissions
  * Must have the `edit_post` permission.
  */
-class PatchPost extends Request
+class PatchPost extends Request implements HasBody
 {
+    use HasJsonBody;
+
     protected Method $method = Method::PUT;
 
     public function resolveEndpoint(): string

--- a/src/Client/Requests/Posts/UpdatePost.php
+++ b/src/Client/Requests/Posts/UpdatePost.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace ConduitUI\Mattermost\Client\Requests\Posts;
 
+use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
 
 /**
  * UpdatePost
@@ -15,8 +17,10 @@ use Saloon\Http\Request;
  * ##### Permissions
  * Must have `edit_post` permission for the channel the post is in.
  */
-class UpdatePost extends Request
+class UpdatePost extends Request implements HasBody
 {
+    use HasJsonBody;
+
     protected Method $method = Method::PUT;
 
     public function resolveEndpoint(): string

--- a/src/Facades/Mattermost.php
+++ b/src/Facades/Mattermost.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace ConduitUI\Mattermost\Facades;
 
+use Closure;
 use ConduitUI\Mattermost\MattermostManager;
+use ConduitUI\Mattermost\Testing\MattermostFake;
 use Illuminate\Support\Facades\Facade;
+use Saloon\Http\Faking\MockResponse;
 
 /**
  * @method static \ConduitUI\Mattermost\Client\Mattermost connection(?string $name = null)
@@ -21,6 +24,21 @@ use Illuminate\Support\Facades\Facade;
  * @method static \ConduitUI\Mattermost\Client\Resource\Emoji emoji()
  * @method static \ConduitUI\Mattermost\Client\Resource\Status status()
  * @method static \ConduitUI\Mattermost\Client\Resource\System system()
+ * @method static \ConduitUI\Mattermost\Testing\MattermostFake assertSent(string|\Closure $value, ?int $times = null)
+ * @method static \ConduitUI\Mattermost\Testing\MattermostFake assertNotSent(string|\Closure $value)
+ * @method static \ConduitUI\Mattermost\Testing\MattermostFake assertNothingSent()
+ * @method static \ConduitUI\Mattermost\Testing\MattermostFake assertPosted(?\Closure $callback = null, ?int $times = null)
+ * @method static \ConduitUI\Mattermost\Testing\MattermostFake assertNotPosted(?\Closure $callback = null)
+ * @method static \ConduitUI\Mattermost\Testing\MattermostFake assertNothingPosted()
+ * @method static \ConduitUI\Mattermost\Testing\MattermostFake assertPostCount(int $expected)
+ * @method static \ConduitUI\Mattermost\Testing\MattermostFake assertUpdated(?\Closure $callback = null, ?int $times = null)
+ * @method static \ConduitUI\Mattermost\Testing\MattermostFake assertPatched(?\Closure $callback = null, ?int $times = null)
+ * @method static \ConduitUI\Mattermost\Testing\MattermostFake assertDeleted(?\Closure $callback = null, ?int $times = null)
+ * @method static \ConduitUI\Mattermost\Testing\MattermostFake assertReacted(?string $postId = null, ?string $emoji = null)
+ * @method static \ConduitUI\Mattermost\Testing\MattermostFake assertNotReacted(?string $postId = null, ?string $emoji = null)
+ * @method static \ConduitUI\Mattermost\Testing\MattermostFake assertFileUploaded(?\Closure $callback = null, ?int $times = null)
+ * @method static \ConduitUI\Mattermost\Testing\MattermostFake preventStrayPosts(bool $prevent = true)
+ * @method static array<int, \ConduitUI\Mattermost\Testing\RecordedRequest> recorded(?string $requestClass = null)
  *
  * @see MattermostManager
  * @see \ConduitUI\Mattermost\Client\Mattermost
@@ -30,6 +48,21 @@ class Mattermost extends Facade
     protected static function getFacadeAccessor(): string
     {
         return MattermostManager::class;
+    }
+
+    /**
+     * Swap the bound MattermostManager for a recording fake. Call this at the
+     * top of a test, then make assertions via the facade or the returned fake.
+     *
+     * @param  array<class-string, MockResponse|Closure>  $defaultResponses
+     */
+    public static function fake(array $defaultResponses = []): MattermostFake
+    {
+        $fake = new MattermostFake($defaultResponses);
+
+        static::swap($fake);
+
+        return $fake;
     }
 
     /**

--- a/src/Testing/MattermostFake.php
+++ b/src/Testing/MattermostFake.php
@@ -37,9 +37,6 @@ class MattermostFake extends MattermostManager
     /** @var array<string, MattermostConnector> */
     protected array $fakeConnections = [];
 
-    /** @var array<string, MockResponse|Closure> */
-    protected array $defaultResponses = [];
-
     protected bool $preventStrayPosts = false;
 
     /**
@@ -48,9 +45,8 @@ class MattermostFake extends MattermostManager
      *
      * @param  array<class-string, MockResponse|Closure(PendingRequest):MockResponse>  $defaultResponses
      */
-    public function __construct(array $defaultResponses = [])
+    public function __construct(protected array $defaultResponses = [])
     {
-        $this->defaultResponses = $defaultResponses;
     }
 
     #[\Override]
@@ -368,7 +364,7 @@ class MattermostFake extends MattermostManager
     {
         $matches = $this->recorded($requestClass);
 
-        if ($callback !== null) {
+        if ($callback instanceof \Closure) {
             $matches = array_values(array_filter($matches, $callback));
         }
 
@@ -391,7 +387,7 @@ class MattermostFake extends MattermostManager
     {
         $matches = $this->recorded($requestClass);
 
-        if ($callback !== null) {
+        if ($callback instanceof \Closure) {
             $matches = array_values(array_filter($matches, $callback));
         }
 

--- a/src/Testing/MattermostFake.php
+++ b/src/Testing/MattermostFake.php
@@ -1,0 +1,431 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\Testing;
+
+use Closure;
+use ConduitUI\Mattermost\Client\Mattermost as MattermostConnector;
+use ConduitUI\Mattermost\Client\Requests\Files\UploadFile;
+use ConduitUI\Mattermost\Client\Requests\Posts\CreatePost;
+use ConduitUI\Mattermost\Client\Requests\Posts\DeletePost;
+use ConduitUI\Mattermost\Client\Requests\Posts\PatchPost;
+use ConduitUI\Mattermost\Client\Requests\Posts\UpdatePost;
+use ConduitUI\Mattermost\Client\Requests\Reactions\SaveReaction;
+use ConduitUI\Mattermost\Facades\Mattermost;
+use ConduitUI\Mattermost\MattermostManager;
+use PHPUnit\Framework\Assert as PHPUnit;
+use RuntimeException;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+use Saloon\Http\PendingRequest;
+
+/**
+ * Test double for the {@see MattermostManager}. Wraps each connection in a
+ * Saloon {@see MockClient} so no real HTTP traffic is sent, and records each
+ * outgoing request as a {@see RecordedRequest} so tests can assert on them.
+ *
+ * Use directly when you need a recorder without touching the container, or
+ * call {@see Mattermost::fake()} to swap the
+ * binding in one shot.
+ */
+class MattermostFake extends MattermostManager
+{
+    /** @var array<int, RecordedRequest> */
+    protected array $recorded = [];
+
+    /** @var array<string, MattermostConnector> */
+    protected array $fakeConnections = [];
+
+    /** @var array<string, MockResponse|Closure> */
+    protected array $defaultResponses = [];
+
+    protected bool $preventStrayPosts = false;
+
+    /**
+     * Build a fake. Optional default responses can be provided keyed by
+     * request class to override the default empty 200 response.
+     *
+     * @param  array<class-string, MockResponse|Closure(PendingRequest):MockResponse>  $defaultResponses
+     */
+    public function __construct(array $defaultResponses = [])
+    {
+        $this->defaultResponses = $defaultResponses;
+    }
+
+    #[\Override]
+    public function connection(?string $name = null): MattermostConnector
+    {
+        $name ??= $this->resolveDefaultConnectionName();
+
+        if (isset($this->fakeConnections[$name])) {
+            return $this->fakeConnections[$name];
+        }
+
+        $connector = new MattermostConnector(
+            baseUrl: 'https://fake.mattermost.test',
+            token: 'fake-token',
+        );
+
+        $connector->withMockClient($this->buildMockClient());
+
+        $self = $this;
+        $connector->middleware()->onRequest(
+            static function (PendingRequest $pendingRequest) use ($self, $name): void {
+                $self->record(RecordedRequest::fromPendingRequest($pendingRequest, $name));
+            },
+            'mattermost-fake-recorder',
+        );
+
+        return $this->fakeConnections[$name] = $connector;
+    }
+
+    #[\Override]
+    public function purge(?string $name = null): void
+    {
+        if ($name === null) {
+            $this->fakeConnections = [];
+
+            return;
+        }
+
+        unset($this->fakeConnections[$name]);
+    }
+
+    /**
+     * Register the default response returned for a given request class.
+     * Useful when bot logic reads the JSON body it just "posted".
+     *
+     * @param  class-string  $requestClass
+     * @param  MockResponse|Closure(PendingRequest):MockResponse  $response
+     */
+    public function setResponse(string $requestClass, MockResponse|Closure $response): self
+    {
+        $this->defaultResponses[$requestClass] = $response;
+
+        // Force connections to be rebuilt so the new default applies.
+        $this->fakeConnections = [];
+
+        return $this;
+    }
+
+    /**
+     * Cause any recorded post to fail the test. Mirrors Laravel's
+     * Notification::fake() preventStrayNotifications().
+     */
+    public function preventStrayPosts(bool $prevent = true): self
+    {
+        $this->preventStrayPosts = $prevent;
+
+        return $this;
+    }
+
+    public function record(RecordedRequest $record): void
+    {
+        if ($this->preventStrayPosts && $record->isFor(CreatePost::class)) {
+            PHPUnit::fail(sprintf(
+                'A stray Mattermost post was sent to channel [%s] with message [%s].',
+                (string) ($record->get('channel_id') ?? 'unknown'),
+                (string) ($record->get('message') ?? ''),
+            ));
+        }
+
+        $this->recorded[] = $record;
+    }
+
+    /**
+     * Get every recorded request — optionally filter to a particular Saloon
+     * request class.
+     *
+     * @param  class-string|null  $requestClass
+     * @return array<int, RecordedRequest>
+     */
+    public function recorded(?string $requestClass = null): array
+    {
+        if ($requestClass === null) {
+            return $this->recorded;
+        }
+
+        return array_values(array_filter(
+            $this->recorded,
+            static fn (RecordedRequest $record): bool => $record->isFor($requestClass),
+        ));
+    }
+
+    /**
+     * Reset all captured state.
+     */
+    public function flush(): self
+    {
+        $this->recorded = [];
+        $this->fakeConnections = [];
+
+        return $this;
+    }
+
+    // ------------------------------------------------------------------
+    // Generic assertions
+    // ------------------------------------------------------------------
+
+    /**
+     * Assert a request matching the given class or callback was sent.
+     *
+     * @param  class-string|Closure(RecordedRequest):bool  $value
+     */
+    public function assertSent(string|Closure $value, ?int $times = null): self
+    {
+        $matches = $this->matching($value);
+
+        if ($times !== null) {
+            PHPUnit::assertCount(
+                $times,
+                $matches,
+                sprintf('Expected %d matching Mattermost requests, found %d.', $times, count($matches)),
+            );
+
+            return $this;
+        }
+
+        PHPUnit::assertNotEmpty($matches, 'No matching Mattermost request was sent.');
+
+        return $this;
+    }
+
+    /**
+     * @param  class-string|Closure(RecordedRequest):bool  $value
+     */
+    public function assertNotSent(string|Closure $value): self
+    {
+        $matches = $this->matching($value);
+
+        PHPUnit::assertEmpty($matches, 'An unexpected Mattermost request was sent.');
+
+        return $this;
+    }
+
+    public function assertNothingSent(): self
+    {
+        PHPUnit::assertEmpty(
+            $this->recorded,
+            sprintf('Expected no Mattermost requests, but %d were recorded.', count($this->recorded)),
+        );
+
+        return $this;
+    }
+
+    // ------------------------------------------------------------------
+    // Posts API
+    // ------------------------------------------------------------------
+
+    /**
+     * Assert a CreatePost was sent. The optional callback receives the
+     * RecordedRequest so consumers can read message/channel from the body.
+     *
+     * @param  Closure(RecordedRequest):bool|null  $callback
+     */
+    public function assertPosted(?Closure $callback = null, ?int $times = null): self
+    {
+        return $this->assertSentForRequest(CreatePost::class, $callback, $times, 'No matching Mattermost post was created.');
+    }
+
+    /**
+     * @param  Closure(RecordedRequest):bool|null  $callback
+     */
+    public function assertNotPosted(?Closure $callback = null): self
+    {
+        return $this->assertNotSentForRequest(CreatePost::class, $callback, 'An unexpected Mattermost post was created.');
+    }
+
+    public function assertNothingPosted(): self
+    {
+        $count = count($this->recorded(CreatePost::class));
+
+        PHPUnit::assertSame(
+            0,
+            $count,
+            sprintf('Expected no Mattermost posts, but %d were created.', $count),
+        );
+
+        return $this;
+    }
+
+    public function assertPostCount(int $expected): self
+    {
+        $count = count($this->recorded(CreatePost::class));
+
+        PHPUnit::assertSame(
+            $expected,
+            $count,
+            sprintf('Expected %d Mattermost posts, but %d were created.', $expected, $count),
+        );
+
+        return $this;
+    }
+
+    /**
+     * @param  Closure(RecordedRequest):bool|null  $callback
+     */
+    public function assertUpdated(?Closure $callback = null, ?int $times = null): self
+    {
+        return $this->assertSentForRequest(UpdatePost::class, $callback, $times, 'No matching Mattermost update was sent.');
+    }
+
+    /**
+     * @param  Closure(RecordedRequest):bool|null  $callback
+     */
+    public function assertPatched(?Closure $callback = null, ?int $times = null): self
+    {
+        return $this->assertSentForRequest(PatchPost::class, $callback, $times, 'No matching Mattermost patch was sent.');
+    }
+
+    /**
+     * @param  Closure(RecordedRequest):bool|null  $callback
+     */
+    public function assertDeleted(?Closure $callback = null, ?int $times = null): self
+    {
+        return $this->assertSentForRequest(DeletePost::class, $callback, $times, 'No matching Mattermost delete was sent.');
+    }
+
+    // ------------------------------------------------------------------
+    // Reactions API
+    // ------------------------------------------------------------------
+
+    /**
+     * Assert a reaction was added — optionally narrow by post id and emoji.
+     */
+    public function assertReacted(?string $postId = null, ?string $emoji = null): self
+    {
+        $callback = static function (RecordedRequest $record) use ($postId, $emoji): bool {
+            if ($postId !== null && $record->get('post_id') !== $postId) {
+                return false;
+            }
+
+            if ($emoji !== null && $record->get('emoji_name') !== $emoji) {
+                return false;
+            }
+
+            return true;
+        };
+
+        return $this->assertSentForRequest(SaveReaction::class, $callback, null, sprintf(
+            'No matching Mattermost reaction was sent (post_id=%s emoji=%s).',
+            $postId ?? '*',
+            $emoji ?? '*',
+        ));
+    }
+
+    public function assertNotReacted(?string $postId = null, ?string $emoji = null): self
+    {
+        $callback = static function (RecordedRequest $record) use ($postId, $emoji): bool {
+            if ($postId !== null && $record->get('post_id') !== $postId) {
+                return false;
+            }
+
+            if ($emoji !== null && $record->get('emoji_name') !== $emoji) {
+                return false;
+            }
+
+            return true;
+        };
+
+        return $this->assertNotSentForRequest(SaveReaction::class, $callback, 'An unexpected Mattermost reaction was sent.');
+    }
+
+    // ------------------------------------------------------------------
+    // Files API
+    // ------------------------------------------------------------------
+
+    /**
+     * @param  Closure(RecordedRequest):bool|null  $callback
+     */
+    public function assertFileUploaded(?Closure $callback = null, ?int $times = null): self
+    {
+        return $this->assertSentForRequest(UploadFile::class, $callback, $times, 'No matching Mattermost file upload was sent.');
+    }
+
+    // ------------------------------------------------------------------
+    // Internals
+    // ------------------------------------------------------------------
+
+    /**
+     * @param  class-string|Closure(RecordedRequest):bool  $value
+     * @return array<int, RecordedRequest>
+     */
+    protected function matching(string|Closure $value): array
+    {
+        if (is_string($value)) {
+            return $this->recorded($value);
+        }
+
+        return array_values(array_filter($this->recorded, $value));
+    }
+
+    /**
+     * @param  class-string  $requestClass
+     * @param  Closure(RecordedRequest):bool|null  $callback
+     */
+    protected function assertSentForRequest(string $requestClass, ?Closure $callback, ?int $times, string $failureMessage): self
+    {
+        $matches = $this->recorded($requestClass);
+
+        if ($callback !== null) {
+            $matches = array_values(array_filter($matches, $callback));
+        }
+
+        if ($times !== null) {
+            PHPUnit::assertCount($times, $matches, $failureMessage);
+
+            return $this;
+        }
+
+        PHPUnit::assertNotEmpty($matches, $failureMessage);
+
+        return $this;
+    }
+
+    /**
+     * @param  class-string  $requestClass
+     * @param  Closure(RecordedRequest):bool|null  $callback
+     */
+    protected function assertNotSentForRequest(string $requestClass, ?Closure $callback, string $failureMessage): self
+    {
+        $matches = $this->recorded($requestClass);
+
+        if ($callback !== null) {
+            $matches = array_values(array_filter($matches, $callback));
+        }
+
+        PHPUnit::assertEmpty($matches, $failureMessage);
+
+        return $this;
+    }
+
+    protected function buildMockClient(): MockClient
+    {
+        $responses = [];
+
+        foreach ($this->defaultResponses as $requestClass => $response) {
+            $responses[$requestClass] = $response;
+        }
+
+        // Fallback: any URL we haven't explicitly mocked returns an empty 200.
+        $responses['*'] = MockResponse::make([]);
+
+        return new MockClient($responses);
+    }
+
+    protected function resolveDefaultConnectionName(): string
+    {
+        if (function_exists('config')) {
+            $name = config('mattermost.default', 'default');
+
+            if (! is_string($name) || $name === '') {
+                throw new RuntimeException('Mattermost default connection name must be a non-empty string.');
+            }
+
+            return $name;
+        }
+
+        return 'default';
+    }
+}

--- a/src/Testing/MattermostFake.php
+++ b/src/Testing/MattermostFake.php
@@ -45,9 +45,7 @@ class MattermostFake extends MattermostManager
      *
      * @param  array<class-string, MockResponse|Closure(PendingRequest):MockResponse>  $defaultResponses
      */
-    public function __construct(protected array $defaultResponses = [])
-    {
-    }
+    public function __construct(protected array $defaultResponses = []) {}
 
     #[\Override]
     public function connection(?string $name = null): MattermostConnector
@@ -364,7 +362,7 @@ class MattermostFake extends MattermostManager
     {
         $matches = $this->recorded($requestClass);
 
-        if ($callback instanceof \Closure) {
+        if ($callback instanceof Closure) {
             $matches = array_values(array_filter($matches, $callback));
         }
 
@@ -387,7 +385,7 @@ class MattermostFake extends MattermostManager
     {
         $matches = $this->recorded($requestClass);
 
-        if ($callback instanceof \Closure) {
+        if ($callback instanceof Closure) {
             $matches = array_values(array_filter($matches, $callback));
         }
 

--- a/src/Testing/MattermostFixtures.php
+++ b/src/Testing/MattermostFixtures.php
@@ -1,0 +1,343 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\Testing;
+
+/**
+ * Static factories that produce realistic Mattermost API JSON shapes for
+ * use in tests. Every helper accepts a partial array of overrides and merges
+ * it on top of sensible defaults.
+ */
+class MattermostFixtures
+{
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    public static function post(array $overrides = []): array
+    {
+        $now = (int) (microtime(true) * 1000);
+
+        return array_merge([
+            'id' => self::id(),
+            'create_at' => $now,
+            'update_at' => $now,
+            'edit_at' => 0,
+            'delete_at' => 0,
+            'is_pinned' => false,
+            'user_id' => self::id(),
+            'channel_id' => self::id(),
+            'root_id' => '',
+            'original_id' => '',
+            'message' => 'hello world',
+            'type' => '',
+            'props' => (object) [],
+            'hashtags' => '',
+            'pending_post_id' => '',
+            'reply_count' => 0,
+            'last_reply_at' => 0,
+            'participants' => null,
+            'metadata' => (object) [],
+        ], $overrides);
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    public static function user(array $overrides = []): array
+    {
+        $now = (int) (microtime(true) * 1000);
+
+        return array_merge([
+            'id' => self::id(),
+            'create_at' => $now,
+            'update_at' => $now,
+            'delete_at' => 0,
+            'username' => 'testuser',
+            'first_name' => 'Test',
+            'last_name' => 'User',
+            'nickname' => '',
+            'email' => 'test@example.com',
+            'auth_data' => '',
+            'auth_service' => '',
+            'roles' => 'system_user',
+            'locale' => 'en',
+            'is_bot' => false,
+            'timezone' => [
+                'automaticTimezone' => 'UTC',
+                'manualTimezone' => '',
+                'useAutomaticTimezone' => 'true',
+            ],
+        ], $overrides);
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    public static function channel(array $overrides = []): array
+    {
+        $now = (int) (microtime(true) * 1000);
+
+        return array_merge([
+            'id' => self::id(),
+            'create_at' => $now,
+            'update_at' => $now,
+            'delete_at' => 0,
+            'team_id' => self::id(),
+            'type' => 'O',
+            'display_name' => 'Town Square',
+            'name' => 'town-square',
+            'header' => '',
+            'purpose' => '',
+            'last_post_at' => $now,
+            'total_msg_count' => 0,
+            'extra_update_at' => 0,
+            'creator_id' => self::id(),
+        ], $overrides);
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    public static function team(array $overrides = []): array
+    {
+        $now = (int) (microtime(true) * 1000);
+
+        return array_merge([
+            'id' => self::id(),
+            'create_at' => $now,
+            'update_at' => $now,
+            'delete_at' => 0,
+            'display_name' => 'Test Team',
+            'name' => 'test-team',
+            'description' => '',
+            'email' => 'admin@example.com',
+            'type' => 'O',
+            'company_name' => '',
+            'allowed_domains' => '',
+            'invite_id' => self::id(),
+            'allow_open_invite' => true,
+        ], $overrides);
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    public static function reaction(array $overrides = []): array
+    {
+        $now = (int) (microtime(true) * 1000);
+
+        return array_merge([
+            'user_id' => self::id(),
+            'post_id' => self::id(),
+            'emoji_name' => 'thumbsup',
+            'create_at' => $now,
+        ], $overrides);
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    public static function fileInfo(array $overrides = []): array
+    {
+        $now = (int) (microtime(true) * 1000);
+
+        return array_merge([
+            'id' => self::id(),
+            'user_id' => self::id(),
+            'post_id' => self::id(),
+            'create_at' => $now,
+            'update_at' => $now,
+            'delete_at' => 0,
+            'name' => 'example.txt',
+            'extension' => 'txt',
+            'size' => 12,
+            'mime_type' => 'text/plain',
+            'has_preview_image' => false,
+        ], $overrides);
+    }
+
+    /**
+     * Build a full WebSocket event envelope.
+     *
+     * @param  array<string, mixed>  $data
+     * @param  array<string, mixed>  $broadcast
+     * @return array<string, mixed>
+     */
+    public static function websocketEvent(string $event, array $data = [], array $broadcast = []): array
+    {
+        return [
+            'event' => $event,
+            'data' => $data,
+            'broadcast' => array_merge([
+                'omit_users' => null,
+                'user_id' => '',
+                'channel_id' => '',
+                'team_id' => '',
+            ], $broadcast),
+            'seq' => 1,
+        ];
+    }
+
+    /**
+     * Build a "posted" WebSocket event for an incoming direct message.
+     *
+     * @return array<string, mixed>
+     */
+    public static function fakeDirectMessage(string $text, ?string $userId = null, ?string $channelId = null): array
+    {
+        $userId ??= self::id();
+        $channelId ??= self::id();
+
+        $post = self::post([
+            'message' => $text,
+            'user_id' => $userId,
+            'channel_id' => $channelId,
+        ]);
+
+        return self::websocketEvent('posted', [
+            'channel_display_name' => '@'.($post['user_id']),
+            'channel_name' => 'direct-message',
+            'channel_type' => 'D',
+            'post' => json_encode($post),
+            'sender_name' => '@testuser',
+            'team_id' => '',
+            'set_online' => true,
+        ], [
+            'channel_id' => $channelId,
+            'user_id' => '',
+        ]);
+    }
+
+    /**
+     * Build a "posted" WebSocket event for a channel message that mentions the bot.
+     *
+     * @return array<string, mixed>
+     */
+    public static function fakeMention(string $text, ?string $channelId = null, ?string $userId = null, string $botUsername = 'bot'): array
+    {
+        $userId ??= self::id();
+        $channelId ??= self::id();
+
+        $post = self::post([
+            'message' => $text,
+            'user_id' => $userId,
+            'channel_id' => $channelId,
+        ]);
+
+        return self::websocketEvent('posted', [
+            'channel_display_name' => 'Town Square',
+            'channel_name' => 'town-square',
+            'channel_type' => 'O',
+            'mentions' => json_encode([$botUsername]),
+            'post' => json_encode($post),
+            'sender_name' => '@testuser',
+            'team_id' => self::id(),
+            'set_online' => true,
+        ], [
+            'channel_id' => $channelId,
+        ]);
+    }
+
+    /**
+     * Build a "posted" WebSocket event representing a file share.
+     *
+     * @param  array<int, string>  $fileIds
+     * @return array<string, mixed>
+     */
+    public static function fakeFileShare(array $fileIds, ?string $channelId = null, ?string $userId = null, string $message = ''): array
+    {
+        $userId ??= self::id();
+        $channelId ??= self::id();
+
+        $post = self::post([
+            'message' => $message,
+            'user_id' => $userId,
+            'channel_id' => $channelId,
+            'file_ids' => $fileIds,
+            'type' => '',
+        ]);
+
+        return self::websocketEvent('posted', [
+            'channel_display_name' => 'Town Square',
+            'channel_name' => 'town-square',
+            'channel_type' => 'O',
+            'post' => json_encode($post),
+            'sender_name' => '@testuser',
+            'team_id' => self::id(),
+            'set_online' => true,
+        ], [
+            'channel_id' => $channelId,
+        ]);
+    }
+
+    /**
+     * Build a Mattermost slash-command HTTP payload — what an outgoing slash
+     * command webhook would deliver.
+     *
+     * @return array<string, mixed>
+     */
+    public static function fakeSlashCommand(string $command, string $text = '', ?string $userId = null, ?string $channelId = null): array
+    {
+        return [
+            'token' => 'slash-command-token',
+            'team_id' => self::id(),
+            'team_domain' => 'test-team',
+            'channel_id' => $channelId ?? self::id(),
+            'channel_name' => 'town-square',
+            'user_id' => $userId ?? self::id(),
+            'user_name' => 'testuser',
+            'command' => str_starts_with($command, '/') ? $command : '/'.$command,
+            'text' => $text,
+            'response_url' => 'https://example.com/hooks/commands/'.self::id(),
+            'trigger_id' => self::id(),
+        ];
+    }
+
+    /**
+     * Build the payload Mattermost POSTs when a user clicks an interactive
+     * button or selects a menu option.
+     *
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    public static function fakeButtonClick(string $actionId, mixed $value = null, array $context = [], ?string $userId = null, ?string $channelId = null, ?string $postId = null): array
+    {
+        return [
+            'user_id' => $userId ?? self::id(),
+            'user_name' => 'testuser',
+            'channel_id' => $channelId ?? self::id(),
+            'channel_name' => 'town-square',
+            'team_id' => self::id(),
+            'team_domain' => 'test-team',
+            'post_id' => $postId ?? self::id(),
+            'trigger_id' => self::id(),
+            'type' => 'button',
+            'data_source' => '',
+            'context' => array_merge(['action' => $actionId], $context),
+            'action' => $actionId,
+            'value' => $value,
+        ];
+    }
+
+    /**
+     * Generate a 26-character lowercase ID similar to a Mattermost cuid.
+     */
+    public static function id(): string
+    {
+        $alphabet = 'abcdefghijklmnopqrstuvwxyz0123456789';
+        $id = '';
+
+        for ($i = 0; $i < 26; $i++) {
+            $id .= $alphabet[random_int(0, strlen($alphabet) - 1)];
+        }
+
+        return $id;
+    }
+}

--- a/src/Testing/RecordedRequest.php
+++ b/src/Testing/RecordedRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace ConduitUI\Mattermost\Testing;
 
+use Saloon\Contracts\Body\BodyRepository;
 use Saloon\Http\PendingRequest;
 use Saloon\Http\Request;
 
@@ -32,7 +33,7 @@ class RecordedRequest
         $body = $pendingRequest->body();
         $payload = [];
 
-        if ($body instanceof \Saloon\Contracts\Body\BodyRepository) {
+        if ($body instanceof BodyRepository) {
             $rawBody = $body->all();
 
             if (is_array($rawBody)) {

--- a/src/Testing/RecordedRequest.php
+++ b/src/Testing/RecordedRequest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\Testing;
+
+use Saloon\Http\PendingRequest;
+use Saloon\Http\Request;
+
+/**
+ * Value object describing a request that was sent through a faked Mattermost
+ * connection. Exposes the request instance and a decoded payload so consumer
+ * tests can write expressive assertions.
+ */
+class RecordedRequest
+{
+    /**
+     * @param  array<string, mixed>  $payload
+     * @param  array<string, mixed>  $query
+     */
+    public function __construct(
+        public readonly Request $request,
+        public readonly string $connection,
+        public readonly string $url,
+        public readonly string $method,
+        public readonly array $payload,
+        public readonly array $query,
+    ) {}
+
+    public static function fromPendingRequest(PendingRequest $pendingRequest, string $connection): self
+    {
+        $body = $pendingRequest->body();
+        $payload = [];
+
+        if ($body !== null) {
+            $rawBody = $body->all();
+
+            if (is_array($rawBody)) {
+                /** @var array<string, mixed> $payload */
+                $payload = $rawBody;
+            } elseif (is_string($rawBody) && $rawBody !== '') {
+                $decoded = json_decode($rawBody, true);
+
+                if (is_array($decoded)) {
+                    /** @var array<string, mixed> $payload */
+                    $payload = $decoded;
+                }
+            }
+        }
+
+        $query = $pendingRequest->query()->all();
+
+        return new self(
+            request: $pendingRequest->getRequest(),
+            connection: $connection,
+            url: $pendingRequest->getUrl(),
+            method: $pendingRequest->getMethod()->value,
+            payload: $payload,
+            /** @var array<string, mixed> $query */
+            query: $query,
+        );
+    }
+
+    /**
+     * Convenience accessor — returns the payload value at the given key.
+     */
+    public function get(string $key, mixed $default = null): mixed
+    {
+        return $this->payload[$key] ?? $default;
+    }
+
+    public function isFor(string $requestClass): bool
+    {
+        return $this->request instanceof $requestClass;
+    }
+}

--- a/src/Testing/RecordedRequest.php
+++ b/src/Testing/RecordedRequest.php
@@ -32,7 +32,7 @@ class RecordedRequest
         $body = $pendingRequest->body();
         $payload = [];
 
-        if ($body !== null) {
+        if ($body instanceof \Saloon\Contracts\Body\BodyRepository) {
             $rawBody = $body->all();
 
             if (is_array($rawBody)) {

--- a/tests/Unit/Testing/MattermostFakeTest.php
+++ b/tests/Unit/Testing/MattermostFakeTest.php
@@ -1,0 +1,244 @@
+<?php
+
+use ConduitUI\Mattermost\Client\Requests\Files\UploadFile;
+use ConduitUI\Mattermost\Client\Requests\Posts\CreatePost;
+use ConduitUI\Mattermost\Client\Requests\Posts\DeletePost;
+use ConduitUI\Mattermost\Client\Requests\Posts\PatchPost;
+use ConduitUI\Mattermost\Client\Requests\Posts\UpdatePost;
+use ConduitUI\Mattermost\Client\Requests\Reactions\SaveReaction;
+use ConduitUI\Mattermost\Facades\Mattermost;
+use ConduitUI\Mattermost\MattermostManager;
+use ConduitUI\Mattermost\Testing\MattermostFake;
+use ConduitUI\Mattermost\Testing\MattermostFixtures;
+use ConduitUI\Mattermost\Testing\RecordedRequest;
+use PHPUnit\Framework\AssertionFailedError;
+use Saloon\Http\Faking\MockResponse;
+
+describe('Mattermost::fake()', function (): void {
+    it('swaps the manager binding for a fake recorder', function (): void {
+        $fake = Mattermost::fake();
+
+        expect($fake)->toBeInstanceOf(MattermostFake::class);
+        expect(app(MattermostManager::class))->toBe($fake);
+    });
+
+    it('returns a Mattermost connector that does not hit the network', function (): void {
+        Mattermost::fake();
+
+        $request = (new CreatePost)->body()->merge([
+            'channel_id' => 'channel-1',
+            'message' => 'hello',
+        ]);
+
+        // No exception means the MockClient intercepted the request.
+        $response = Mattermost::posts()->createPost();
+
+        expect($response->status())->toBe(200);
+        expect($request)->not->toBeNull();
+    });
+});
+
+describe('Post assertions', function (): void {
+    it('assertPosted matches by closure on the recorded payload', function (): void {
+        $fake = Mattermost::fake();
+
+        $connector = Mattermost::connection();
+        $request = new CreatePost;
+        $request->body()->merge([
+            'channel_id' => 'town-square',
+            'message' => 'deployed',
+        ]);
+        $connector->send($request);
+
+        $fake->assertPosted(
+            fn (RecordedRequest $record): bool => $record->get('channel_id') === 'town-square'
+                && str_contains((string) $record->get('message'), 'deployed'),
+        );
+    });
+
+    it('assertPosted via the facade also works', function (): void {
+        Mattermost::fake();
+
+        $request = new CreatePost;
+        $request->body()->merge(['channel_id' => 'general', 'message' => 'hi']);
+        Mattermost::connection()->send($request);
+
+        Mattermost::assertPosted();
+    });
+
+    it('assertPosted fails when no matching post was sent', function (): void {
+        Mattermost::fake();
+
+        Mattermost::assertPosted();
+    })->throws(AssertionFailedError::class);
+
+    it('assertNothingPosted passes when no posts were sent', function (): void {
+        Mattermost::fake();
+
+        Mattermost::assertNothingPosted();
+    });
+
+    it('assertNothingPosted fails when posts were sent', function (): void {
+        Mattermost::fake();
+
+        $request = new CreatePost;
+        $request->body()->merge(['channel_id' => 'c', 'message' => 'oops']);
+        Mattermost::connection()->send($request);
+
+        Mattermost::assertNothingPosted();
+    })->throws(AssertionFailedError::class);
+
+    it('assertPostCount matches the number of posts', function (): void {
+        Mattermost::fake();
+
+        for ($i = 0; $i < 3; $i++) {
+            $request = new CreatePost;
+            $request->body()->merge(['channel_id' => 'c', 'message' => "msg {$i}"]);
+            Mattermost::connection()->send($request);
+        }
+
+        Mattermost::assertPostCount(3);
+    });
+
+    it('assertNotPosted with a callback fails when matching post exists', function (): void {
+        Mattermost::fake();
+
+        $request = new CreatePost;
+        $request->body()->merge(['channel_id' => 'general', 'message' => 'banned word']);
+        Mattermost::connection()->send($request);
+
+        Mattermost::assertNotPosted(
+            fn (RecordedRequest $r): bool => str_contains((string) $r->get('message'), 'banned'),
+        );
+    })->throws(AssertionFailedError::class);
+
+    it('assertUpdated tracks UpdatePost requests', function (): void {
+        Mattermost::fake();
+
+        Mattermost::posts()->updatePost('post-123');
+
+        Mattermost::assertUpdated();
+        Mattermost::assertSent(UpdatePost::class);
+    });
+
+    it('assertPatched tracks PatchPost requests', function (): void {
+        Mattermost::fake();
+
+        Mattermost::posts()->patchPost('post-123');
+
+        Mattermost::assertPatched();
+        Mattermost::assertSent(PatchPost::class);
+    });
+
+    it('assertDeleted tracks DeletePost requests', function (): void {
+        Mattermost::fake();
+
+        Mattermost::posts()->deletePost('post-456');
+
+        Mattermost::assertDeleted();
+        Mattermost::assertSent(DeletePost::class);
+    });
+});
+
+describe('preventStrayPosts', function (): void {
+    it('fails the test if any unexpected post is sent', function (): void {
+        $fake = Mattermost::fake();
+        $fake->preventStrayPosts();
+
+        $request = new CreatePost;
+        $request->body()->merge(['channel_id' => 'c', 'message' => 'stray']);
+        Mattermost::connection()->send($request);
+    })->throws(AssertionFailedError::class, 'stray Mattermost post');
+});
+
+describe('Reaction assertions', function (): void {
+    it('assertReacted matches by post id and emoji', function (): void {
+        Mattermost::fake();
+
+        $request = new SaveReaction;
+        $request->body()->merge([
+            'user_id' => 'user-1',
+            'post_id' => 'post-99',
+            'emoji_name' => 'white_check_mark',
+        ]);
+        Mattermost::connection()->send($request);
+
+        Mattermost::assertReacted('post-99', 'white_check_mark');
+    });
+
+    it('assertReacted fails on emoji mismatch', function (): void {
+        Mattermost::fake();
+
+        $request = new SaveReaction;
+        $request->body()->merge([
+            'user_id' => 'user-1',
+            'post_id' => 'post-99',
+            'emoji_name' => 'thumbsup',
+        ]);
+        Mattermost::connection()->send($request);
+
+        Mattermost::assertReacted('post-99', 'white_check_mark');
+    })->throws(AssertionFailedError::class);
+
+    it('assertNotReacted passes when no reactions were sent', function (): void {
+        Mattermost::fake();
+
+        Mattermost::assertNotReacted();
+    });
+});
+
+describe('File assertions', function (): void {
+    it('assertFileUploaded tracks UploadFile requests', function (): void {
+        Mattermost::fake();
+
+        Mattermost::files()->uploadFile('channel-1', 'foo.txt');
+
+        Mattermost::assertFileUploaded();
+        Mattermost::assertSent(UploadFile::class);
+    });
+});
+
+describe('Default responses', function (): void {
+    it('returns the configured default response for a request class', function (): void {
+        Mattermost::fake([
+            CreatePost::class => MockResponse::make(MattermostFixtures::post(['message' => 'hi']), 201),
+        ]);
+
+        $request = new CreatePost;
+        $request->body()->merge(['channel_id' => 'c', 'message' => 'hi']);
+
+        $response = Mattermost::connection()->send($request);
+
+        expect($response->status())->toBe(201);
+        expect($response->json('message'))->toBe('hi');
+    });
+});
+
+describe('flush()', function (): void {
+    it('clears all recorded requests', function (): void {
+        $fake = Mattermost::fake();
+
+        $request = new CreatePost;
+        $request->body()->merge(['channel_id' => 'c', 'message' => 'hi']);
+        Mattermost::connection()->send($request);
+
+        $fake->flush();
+
+        Mattermost::assertNothingPosted();
+        expect($fake->recorded())->toBeEmpty();
+    });
+});
+
+describe('Standalone (no fake() swap) usage', function (): void {
+    it('records when used directly without container swap', function (): void {
+        $fake = new MattermostFake;
+
+        $request = new CreatePost;
+        $request->body()->merge(['channel_id' => 'c', 'message' => 'standalone']);
+        $fake->connection('default')->send($request);
+
+        $fake->assertPosted(
+            fn (RecordedRequest $r): bool => $r->get('message') === 'standalone',
+        );
+    });
+});

--- a/tests/Unit/Testing/MattermostFixturesTest.php
+++ b/tests/Unit/Testing/MattermostFixturesTest.php
@@ -1,0 +1,142 @@
+<?php
+
+use ConduitUI\Mattermost\Testing\MattermostFixtures;
+
+describe('MattermostFixtures::post()', function (): void {
+    it('returns a realistic post shape', function (): void {
+        $post = MattermostFixtures::post();
+
+        expect($post)
+            ->toHaveKeys(['id', 'create_at', 'channel_id', 'user_id', 'message', 'props'])
+            ->and($post['id'])->toHaveLength(26)
+            ->and($post['message'])->toBe('hello world');
+    });
+
+    it('merges overrides on top of defaults', function (): void {
+        $post = MattermostFixtures::post([
+            'message' => 'custom',
+            'channel_id' => 'channel-1',
+        ]);
+
+        expect($post['message'])->toBe('custom')
+            ->and($post['channel_id'])->toBe('channel-1')
+            ->and($post['id'])->toHaveLength(26);
+    });
+});
+
+describe('MattermostFixtures::user()', function (): void {
+    it('returns a realistic user shape with username override', function (): void {
+        $user = MattermostFixtures::user(['username' => 'jordan']);
+
+        expect($user)
+            ->toHaveKeys(['id', 'username', 'email', 'roles', 'is_bot'])
+            ->and($user['username'])->toBe('jordan')
+            ->and($user['is_bot'])->toBeFalse();
+    });
+});
+
+describe('MattermostFixtures::channel()', function (): void {
+    it('returns a public channel shape by default', function (): void {
+        $channel = MattermostFixtures::channel();
+
+        expect($channel['type'])->toBe('O')
+            ->and($channel['name'])->toBe('town-square');
+    });
+});
+
+describe('MattermostFixtures::team()', function (): void {
+    it('returns a team with default name', function (): void {
+        $team = MattermostFixtures::team();
+
+        expect($team['type'])->toBe('O')
+            ->and($team['name'])->toBe('test-team');
+    });
+});
+
+describe('MattermostFixtures::reaction()', function (): void {
+    it('returns a reaction with overrideable emoji', function (): void {
+        $reaction = MattermostFixtures::reaction(['emoji_name' => 'tada']);
+
+        expect($reaction['emoji_name'])->toBe('tada')
+            ->and($reaction)->toHaveKeys(['user_id', 'post_id', 'create_at']);
+    });
+});
+
+describe('MattermostFixtures::websocketEvent()', function (): void {
+    it('wraps data in the WebSocket event envelope', function (): void {
+        $event = MattermostFixtures::websocketEvent('posted', ['post' => '...']);
+
+        expect($event)
+            ->toHaveKeys(['event', 'data', 'broadcast', 'seq'])
+            ->and($event['event'])->toBe('posted')
+            ->and($event['data']['post'])->toBe('...');
+    });
+});
+
+describe('MattermostFixtures::fakeDirectMessage()', function (): void {
+    it('produces a posted event for a direct channel', function (): void {
+        $event = MattermostFixtures::fakeDirectMessage('hi there');
+
+        expect($event['event'])->toBe('posted')
+            ->and($event['data']['channel_type'])->toBe('D');
+
+        $post = json_decode((string) $event['data']['post'], true);
+        expect($post['message'])->toBe('hi there');
+    });
+});
+
+describe('MattermostFixtures::fakeMention()', function (): void {
+    it('includes the bot username in mentions', function (): void {
+        $event = MattermostFixtures::fakeMention('@bot help', botUsername: 'bot');
+
+        expect($event['event'])->toBe('posted');
+
+        $mentions = json_decode((string) $event['data']['mentions'], true);
+        expect($mentions)->toBe(['bot']);
+    });
+});
+
+describe('MattermostFixtures::fakeFileShare()', function (): void {
+    it('attaches file ids to the post', function (): void {
+        $event = MattermostFixtures::fakeFileShare(['file-1', 'file-2'], message: 'see attached');
+
+        $post = json_decode((string) $event['data']['post'], true);
+        expect($post['file_ids'])->toBe(['file-1', 'file-2'])
+            ->and($post['message'])->toBe('see attached');
+    });
+});
+
+describe('MattermostFixtures::fakeSlashCommand()', function (): void {
+    it('builds a slash command payload', function (): void {
+        $payload = MattermostFixtures::fakeSlashCommand('deploy', 'staging');
+
+        expect($payload['command'])->toBe('/deploy')
+            ->and($payload['text'])->toBe('staging')
+            ->and($payload)->toHaveKeys(['user_id', 'channel_id', 'response_url', 'trigger_id']);
+    });
+
+    it('preserves an explicit leading slash', function (): void {
+        $payload = MattermostFixtures::fakeSlashCommand('/deploy');
+
+        expect($payload['command'])->toBe('/deploy');
+    });
+});
+
+describe('MattermostFixtures::fakeButtonClick()', function (): void {
+    it('builds an interactive button payload', function (): void {
+        $payload = MattermostFixtures::fakeButtonClick('approve', 'yes', ['plan_id' => '42']);
+
+        expect($payload['action'])->toBe('approve')
+            ->and($payload['value'])->toBe('yes')
+            ->and($payload['context'])->toBe(['action' => 'approve', 'plan_id' => '42']);
+    });
+});
+
+describe('MattermostFixtures::id()', function (): void {
+    it('returns 26-character lowercase ids', function (): void {
+        $id = MattermostFixtures::id();
+
+        expect($id)->toHaveLength(26)
+            ->and($id)->toMatch('/^[a-z0-9]{26}$/');
+    });
+});


### PR DESCRIPTION
Closes #11.

## Summary

First-class testing DX so package consumers can swap the real Mattermost client for a recorder, then make Laravel-style assertions about what was sent.

```php
Mattermost::fake();

// ...trigger bot logic...

Mattermost::assertPosted(fn ($r) => $r->get('channel_id') === 'town-square'
    && str_contains((string) $r->get('message'), 'deployed'));
Mattermost::assertReacted('post-123', 'white_check_mark');
Mattermost::assertNothingPosted();
```

### What's new

- `src/Testing/MattermostFake.php` — extends `MattermostManager`. `connection()` returns a real `Mattermost` connector with a Saloon `MockClient` attached (`*` -> empty 200 fallback) and a recorder middleware that captures every outgoing request as a `RecordedRequest`.
- `src/Testing/RecordedRequest.php` — value object: `request`, `connection`, `url`, `method`, decoded `payload`, `query`. `get()` / `isFor()` helpers for assertions.
- `src/Testing/MattermostFixtures.php` — static factories producing realistic JSON shapes:
  - resources: `post`, `user`, `channel`, `team`, `reaction`, `fileInfo`
  - events: `websocketEvent`, `fakeDirectMessage`, `fakeMention`, `fakeFileShare`
  - integrations: `fakeSlashCommand`, `fakeButtonClick`
  - id helper: `MattermostFixtures::id()` returns 26-char lowercase ids
- `Mattermost::fake([...])` static helper on the facade swaps the container binding and returns the fake. Optional default-response map keyed by request class.
- Assertion helpers on the fake (and proxied through the facade): `assertSent`, `assertNotSent`, `assertNothingSent`, `assertPosted`, `assertNotPosted`, `assertNothingPosted`, `assertPostCount`, `assertUpdated`, `assertPatched`, `assertDeleted`, `assertReacted`, `assertNotReacted`, `assertFileUploaded`, `preventStrayPosts`.
- The fake is usable standalone (no `fake()` swap required) for composability.

### Design notes

- Picked the **custom recorder** path (issue option 2) for nicer DX. Saloon's own `assertSent` is fine but Mattermost-flavored helpers (`assertPosted`, `assertReacted`) read better in bot tests.
- Implementation reuses Saloon internals where possible: the fake doesn't subclass the connector — instead it attaches `withMockClient(...)` plus a connector-level `onRequest` middleware. This keeps the real `Mattermost` connector + `BaseResource` machinery in the test path so we exercise the actual API surface.
- Default fallback `MockResponse::make([])` for unspecified URLs — keeps simple `Mattermost::fake()` usage from blowing up on `NoMockResponseFoundException`. Override per request class via `fake([CreatePost::class => MockResponse::make(...)])`.

### Auto-gen gap fix

`UpdatePost` and `PatchPost` were generated without `implements HasBody` / `use HasJsonBody`, which silently drops request bodies. One-line fixes inline in this PR.

## Test plan

- [x] `vendor/bin/pint --test` passes
- [x] `vendor/bin/phpstan analyse` passes (clean at level 6 and level 8)
- [x] `vendor/bin/pest --compact` — 47 passed (105 assertions); 34 new tests cover the fake + fixtures