### PR TITLE
feat: Laravel notification channel + broadcast driver

### DIFF
--- a/src/Client/Requests/Posts/CreatePost.php
+++ b/src/Client/Requests/Posts/CreatePost.php
@@ -17,6 +17,11 @@ use Saloon\Traits\Body\HasJsonBody;
  * ##### Permissions
  * Must have `create_post` permission for the channel the post is being
  * created in.
+ *
+ * Auto-gen gap: the generator emitted the request with no JSON body parameters. The
+ * Mattermost OpenAPI spec defines `channel_id`, `message`, `root_id`, `file_ids`, and
+ * `props` for `POST /api/v4/posts`, so they are wired up here so callers (notification
+ * channel, broadcaster, etc.) can actually create posts.
  */
 class CreatePost extends Request implements HasBody
 {
@@ -30,14 +35,44 @@ class CreatePost extends Request implements HasBody
     }
 
     /**
-     * @param  null|bool  $setOnline  Whether to set the user status as online or not.
+     * @param  string|null  $channelId  The channel ID to post to.
+     * @param  string|null  $message  The message contents (markdown supported).
+     * @param  string|null  $rootId  The post ID to reply to. Creates a thread reply.
+     * @param  array<int, string>|null  $fileIds  IDs of uploaded files to attach.
+     * @param  array<string, mixed>|null  $props  Custom properties (e.g. `attachments`).
+     * @param  bool|null  $setOnline  Whether to set the user status as online or not.
      */
     public function __construct(
+        protected ?string $channelId = null,
+        protected ?string $message = null,
+        protected ?string $rootId = null,
+        protected ?array $fileIds = null,
+        protected ?array $props = null,
         protected ?bool $setOnline = null,
     ) {}
 
+    /**
+     * @return array<string, mixed>
+     */
     public function defaultQuery(): array
     {
-        return array_filter(['set_online' => $this->setOnline]);
+        return array_filter(['set_online' => $this->setOnline], static fn (?bool $v): bool => $v !== null);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function defaultBody(): array
+    {
+        return array_filter(
+            [
+                'channel_id' => $this->channelId,
+                'message' => $this->message,
+                'root_id' => $this->rootId,
+                'file_ids' => $this->fileIds,
+                'props' => $this->props,
+            ],
+            static fn (string|array|null $v): bool => $v !== null,
+        );
     }
 }

--- a/src/Client/Resource/Posts.php
+++ b/src/Client/Resource/Posts.php
@@ -46,11 +46,22 @@ class Posts extends BaseResource
     }
 
     /**
-     * @param  bool  $setOnline  Whether to set the user status as online or not.
+     * @param  string|null  $channelId  The channel ID to post to.
+     * @param  string|null  $message  The message contents (markdown supported).
+     * @param  string|null  $rootId  The post ID to reply to. Creates a thread reply.
+     * @param  array<int, string>|null  $fileIds  IDs of uploaded files to attach.
+     * @param  array<string, mixed>|null  $props  Custom properties (e.g. `attachments`).
+     * @param  bool|null  $setOnline  Whether to set the user status as online or not.
      */
-    public function createPost(?bool $setOnline = null): Response
-    {
-        return $this->connector->send(new CreatePost($setOnline));
+    public function createPost(
+        ?string $channelId = null,
+        ?string $message = null,
+        ?string $rootId = null,
+        ?array $fileIds = null,
+        ?array $props = null,
+        ?bool $setOnline = null,
+    ): Response {
+        return $this->connector->send(new CreatePost($channelId, $message, $rootId, $fileIds, $props, $setOnline));
     }
 
     public function createPostEphemeral(): Response

--- a/src/MattermostServiceProvider.php
+++ b/src/MattermostServiceProvider.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace ConduitUI\Mattermost;
 
+use ConduitUI\Mattermost\Notifications\MattermostBroadcaster;
+use Illuminate\Contracts\Broadcasting\Factory as BroadcastFactory;
 use Illuminate\Support\ServiceProvider;
 
 class MattermostServiceProvider extends ServiceProvider
@@ -23,5 +25,22 @@ class MattermostServiceProvider extends ServiceProvider
                 __DIR__.'/../config/mattermost.php' => config_path('mattermost.php'),
             ], 'mattermost-config');
         }
+
+        $this->registerBroadcaster();
+    }
+
+    private function registerBroadcaster(): void
+    {
+        if (! $this->app->bound(BroadcastFactory::class)) {
+            return;
+        }
+
+        /** @var BroadcastFactory $factory */
+        $factory = $this->app->make(BroadcastFactory::class);
+
+        $factory->extend('mattermost', fn ($app, array $config): MattermostBroadcaster => new MattermostBroadcaster(
+            $app->make(MattermostManager::class),
+            $config['connection'] ?? null,
+        ));
     }
 }

--- a/src/Notifications/MattermostBroadcaster.php
+++ b/src/Notifications/MattermostBroadcaster.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\Notifications;
+
+use ConduitUI\Mattermost\MattermostManager;
+use Illuminate\Broadcasting\Broadcasters\Broadcaster;
+
+/**
+ * Broadcast driver that publishes Laravel events to Mattermost channels.
+ *
+ * Events implementing `ShouldBroadcast` are posted as JSON-encoded code blocks to the
+ * channel ids returned from `broadcastOn()`. The channel id may be a raw `Channel`
+ * name (interpreted as a Mattermost channel id) or a string returned from `formatChannels`.
+ *
+ * The `connection` option on the broadcasting config selects the named Mattermost
+ * connection registered via the package config, supporting multi-server setups.
+ */
+class MattermostBroadcaster extends Broadcaster
+{
+    public function __construct(
+        private readonly MattermostManager $manager,
+        private readonly ?string $connection = null,
+    ) {}
+
+    /**
+     * {@inheritdoc}
+     */
+    public function auth($request): void
+    {
+        // Mattermost broadcasts originate server-side; private-channel auth is not used.
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validAuthenticationResponse($request, $result): void
+    {
+        // No-op: we never authenticate clients via this driver.
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param  array<int, mixed>  $channels
+     * @param  array<string, mixed>  $payload
+     */
+    public function broadcast(array $channels, $event, array $payload = []): void
+    {
+        $body = $this->formatBody($event, $payload);
+
+        $client = $this->manager->connection($this->connection);
+
+        foreach ($this->formatChannels($channels) as $channelId) {
+            $client->posts()->createPost(
+                channelId: $channelId,
+                message: $body,
+            );
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function formatBody(string $event, array $payload): string
+    {
+        $json = json_encode(
+            ['event' => $event, 'payload' => $payload],
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
+        );
+
+        return "```json\n".($json !== false ? $json : '{}')."\n```";
+    }
+}

--- a/src/Notifications/MattermostChannel.php
+++ b/src/Notifications/MattermostChannel.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\Notifications;
+
+use ConduitUI\Mattermost\MattermostManager;
+use Illuminate\Notifications\Notification;
+use RuntimeException;
+
+/**
+ * Laravel notification channel that posts to Mattermost.
+ *
+ * Notifications opt in by implementing a `toMattermost($notifiable)` method that returns
+ * either a {@see MattermostMessage} or an array shaped like the JSON body of
+ * `POST /api/v4/posts` (e.g. `['channel_id' => '...', 'message' => '...']`).
+ *
+ * Notifiables route via `routeNotificationFor('mattermost', $notification)`. The route
+ * may be either a Mattermost channel id (string) or a config array such as
+ * `['channel' => '...', 'connection' => 'staging']` for multi-server setups.
+ *
+ * If the notification doesn't implement `toMattermost()`, this channel is a no-op.
+ */
+class MattermostChannel
+{
+    public function __construct(private readonly MattermostManager $manager) {}
+
+    public function send(mixed $notifiable, Notification $notification): void
+    {
+        if (! method_exists($notification, 'toMattermost')) {
+            return;
+        }
+
+        /** @var MattermostMessage|array<string, mixed>|null $payload */
+        $payload = $notification->toMattermost($notifiable);
+
+        if ($payload === null) {
+            return;
+        }
+
+        $route = $this->resolveRoute($notifiable, $notification);
+
+        $message = $this->normalize($payload);
+
+        $channelId = $message['channel_id']
+            ?? (is_string($route) ? $route : ($route['channel'] ?? null));
+
+        if ($channelId === null || $channelId === '') {
+            throw new RuntimeException(
+                'No Mattermost channel id was provided. Set one via routeNotificationFor("mattermost") '
+                .'or on the MattermostMessage returned from toMattermost().',
+            );
+        }
+
+        $connection = $message['connection']
+            ?? (is_array($route) ? ($route['connection'] ?? null) : null);
+
+        $this->manager->connection($connection)->posts()->createPost(
+            channelId: $channelId,
+            message: $message['message'] ?? null,
+            rootId: $message['root_id'] ?? null,
+            fileIds: $message['file_ids'] ?? null,
+            props: $message['props'] ?? null,
+        );
+    }
+
+    /**
+     * @param  MattermostMessage|array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function normalize(MattermostMessage|array $payload): array
+    {
+        if ($payload instanceof MattermostMessage) {
+            return array_filter(
+                [
+                    'channel_id' => $payload->channelId,
+                    'message' => $payload->text,
+                    'root_id' => $payload->rootId,
+                    'file_ids' => $payload->fileIds,
+                    'props' => $payload->props,
+                    'connection' => $payload->connection,
+                ],
+                static fn (string|array|null $v): bool => $v !== null,
+            );
+        }
+
+        return $payload;
+    }
+
+    /**
+     * @return string|array{channel?: string, connection?: string}|null
+     */
+    private function resolveRoute(mixed $notifiable, Notification $notification): string|array|null
+    {
+        if (! is_object($notifiable) || ! method_exists($notifiable, 'routeNotificationFor')) {
+            return null;
+        }
+
+        /** @var string|array{channel?: string, connection?: string}|null $route */
+        $route = $notifiable->routeNotificationFor('mattermost', $notification);
+
+        return $route;
+    }
+}

--- a/src/Notifications/MattermostMessage.php
+++ b/src/Notifications/MattermostMessage.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\Notifications;
+
+/**
+ * Fluent payload returned from a notification's `toMattermost()` method.
+ *
+ * Channels and connections may be set on the message itself (taking precedence
+ * over routing on the notifiable) or provided via `routeNotificationFor('mattermost')`.
+ */
+class MattermostMessage
+{
+    public ?string $text = null;
+
+    public ?string $channelId = null;
+
+    public ?string $rootId = null;
+
+    public ?string $connection = null;
+
+    /** @var array<int, string>|null */
+    public ?array $fileIds = null;
+
+    /** @var array<string, mixed>|null */
+    public ?array $props = null;
+
+    public static function create(?string $text = null): self
+    {
+        $message = new self;
+        $message->text = $text;
+
+        return $message;
+    }
+
+    public function text(string $text): self
+    {
+        $this->text = $text;
+
+        return $this;
+    }
+
+    public function channel(string $channelId): self
+    {
+        $this->channelId = $channelId;
+
+        return $this;
+    }
+
+    public function rootId(string $rootId): self
+    {
+        $this->rootId = $rootId;
+
+        return $this;
+    }
+
+    public function connection(string $connection): self
+    {
+        $this->connection = $connection;
+
+        return $this;
+    }
+
+    /**
+     * @param  array<int, string>  $fileIds
+     */
+    public function fileIds(array $fileIds): self
+    {
+        $this->fileIds = $fileIds;
+
+        return $this;
+    }
+
+    /**
+     * @param  array<string, mixed>  $props
+     */
+    public function props(array $props): self
+    {
+        $this->props = $props;
+
+        return $this;
+    }
+
+    /**
+     * Attach Slack-style attachments via the `props.attachments` field.
+     *
+     * @param  array<int, array<string, mixed>>  $attachments
+     */
+    public function attachments(array $attachments): self
+    {
+        $props = $this->props ?? [];
+        $props['attachments'] = $attachments;
+        $this->props = $props;
+
+        return $this;
+    }
+}

--- a/tests/Unit/Notifications/MattermostBroadcasterTest.php
+++ b/tests/Unit/Notifications/MattermostBroadcasterTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+use ConduitUI\Mattermost\Client\Requests\Posts\CreatePost;
+use ConduitUI\Mattermost\MattermostManager;
+use ConduitUI\Mattermost\Notifications\MattermostBroadcaster;
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Contracts\Broadcasting\Factory as BroadcastFactory;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+beforeEach(function (): void {
+    $this->mock = MockClient::global([
+        CreatePost::class => MockResponse::make(['id' => 'post-1'], 201),
+    ]);
+
+    config(['broadcasting.connections.mattermost' => [
+        'driver' => 'mattermost',
+        'connection' => 'default',
+    ]]);
+});
+
+afterEach(function (): void {
+    MockClient::destroyGlobal();
+});
+
+describe('MattermostBroadcaster', function (): void {
+    it('posts each broadcast channel as a Mattermost message', function (): void {
+        $broadcaster = new MattermostBroadcaster(app(MattermostManager::class));
+
+        $broadcaster->broadcast(
+            [new Channel('chan-a'), new Channel('chan-b')],
+            'OrderShipped',
+            ['order_id' => 7],
+        );
+
+        $sent = collect($this->mock->getRecordedResponses())
+            ->map(fn ($response): ?array => $response->getPendingRequest()->body()?->all())
+            ->all();
+
+        expect($sent)->toHaveCount(2);
+        expect($sent[0]['channel_id'])->toBe('chan-a');
+        expect($sent[1]['channel_id'])->toBe('chan-b');
+
+        expect($sent[0]['message'])->toContain('OrderShipped');
+        expect($sent[0]['message'])->toContain('"order_id": 7');
+    });
+
+    it('uses the configured named connection', function (): void {
+        config(['mattermost.connections.events' => [
+            'url' => 'https://events.mm.test',
+            'token' => 'events-token',
+        ]]);
+
+        $manager = app(MattermostManager::class);
+        $broadcaster = new MattermostBroadcaster($manager, 'events');
+
+        $broadcaster->broadcast([new Channel('chan-1')], 'Ping', []);
+
+        expect($manager->connection('events')->resolveBaseUrl())->toBe('https://events.mm.test');
+        $this->mock->assertSent(CreatePost::class);
+    });
+
+    it('is registered as a broadcasting driver via the service provider', function (): void {
+        /** @var BroadcastFactory $factory */
+        $factory = app(BroadcastFactory::class);
+
+        $driver = $factory->driver('mattermost');
+
+        expect($driver)->toBeInstanceOf(MattermostBroadcaster::class);
+    });
+});

--- a/tests/Unit/Notifications/MattermostChannelTest.php
+++ b/tests/Unit/Notifications/MattermostChannelTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+use ConduitUI\Mattermost\Client\Requests\Posts\CreatePost;
+use ConduitUI\Mattermost\MattermostManager;
+use ConduitUI\Mattermost\Notifications\MattermostChannel;
+use ConduitUI\Mattermost\Notifications\MattermostMessage;
+use Illuminate\Notifications\AnonymousNotifiable;
+use Illuminate\Notifications\Notification;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+beforeEach(function (): void {
+    $this->mock = MockClient::global([
+        CreatePost::class => MockResponse::make(['id' => 'post-1', 'message' => 'ok'], 201),
+    ]);
+
+    config(['mattermost.connections.staging' => [
+        'url' => 'https://staging.mm.test',
+        'token' => 'staging-token',
+    ]]);
+});
+
+afterEach(function (): void {
+    MockClient::destroyGlobal();
+});
+
+describe('MattermostChannel', function (): void {
+    it('posts a string message returned from toMattermost', function (): void {
+        $channel = app(MattermostChannel::class);
+
+        $notifiable = (new AnonymousNotifiable)->route('mattermost', 'channel-id-123');
+
+        $notification = new class extends Notification
+        {
+            public function toMattermost(mixed $notifiable): array
+            {
+                return ['message' => 'deploy complete'];
+            }
+        };
+
+        $channel->send($notifiable, $notification);
+
+        $this->mock->assertSent(CreatePost::class);
+
+        $body = $this->mock->getLastPendingRequest()?->body()?->all();
+        expect($body)->toBe([
+            'channel_id' => 'channel-id-123',
+            'message' => 'deploy complete',
+        ]);
+    });
+
+    it('posts a MattermostMessage value object', function (): void {
+        $channel = app(MattermostChannel::class);
+
+        $notifiable = (new AnonymousNotifiable)->route('mattermost', 'channel-id-123');
+
+        $notification = new class extends Notification
+        {
+            public function toMattermost(mixed $notifiable): MattermostMessage
+            {
+                return MattermostMessage::create('release shipped')
+                    ->attachments([['text' => 'version 1.2.3']]);
+            }
+        };
+
+        $channel->send($notifiable, $notification);
+
+        $body = $this->mock->getLastPendingRequest()?->body()?->all();
+        expect($body['channel_id'])->toBe('channel-id-123');
+        expect($body['message'])->toBe('release shipped');
+        expect($body['props'])->toBe(['attachments' => [['text' => 'version 1.2.3']]]);
+    });
+
+    it('honors connection name from route array', function (): void {
+        $channel = app(MattermostChannel::class);
+        $manager = app(MattermostManager::class);
+
+        // Touch the default connection so we can see staging gets used after.
+        $defaultConnector = $manager->connection();
+
+        $notifiable = (new AnonymousNotifiable)->route('mattermost', [
+            'channel' => 'staging-channel',
+            'connection' => 'staging',
+        ]);
+
+        $notification = new class extends Notification
+        {
+            public function toMattermost(mixed $notifiable): array
+            {
+                return ['message' => 'hello staging'];
+            }
+        };
+
+        $channel->send($notifiable, $notification);
+
+        $stagingConnector = $manager->connection('staging');
+        expect($stagingConnector->resolveBaseUrl())->toBe('https://staging.mm.test');
+        expect($stagingConnector)->not->toBe($defaultConnector);
+
+        $body = $this->mock->getLastPendingRequest()?->body()?->all();
+        expect($body['channel_id'])->toBe('staging-channel');
+    });
+
+    it('prefers channel id set on the MattermostMessage over the route', function (): void {
+        $channel = app(MattermostChannel::class);
+
+        $notifiable = (new AnonymousNotifiable)->route('mattermost', 'route-channel');
+
+        $notification = new class extends Notification
+        {
+            public function toMattermost(mixed $notifiable): MattermostMessage
+            {
+                return MattermostMessage::create('explicit')->channel('explicit-channel');
+            }
+        };
+
+        $channel->send($notifiable, $notification);
+
+        $body = $this->mock->getLastPendingRequest()?->body()?->all();
+        expect($body['channel_id'])->toBe('explicit-channel');
+    });
+
+    it('is a no-op when toMattermost is not defined', function (): void {
+        $channel = app(MattermostChannel::class);
+
+        $notifiable = (new AnonymousNotifiable)->route('mattermost', 'channel-id-123');
+
+        $notification = new class extends Notification {};
+
+        $channel->send($notifiable, $notification);
+
+        $this->mock->assertNothingSent();
+    });
+
+    it('throws when no channel id is resolvable', function (): void {
+        $channel = app(MattermostChannel::class);
+
+        $notifiable = new AnonymousNotifiable; // no route configured
+
+        $notification = new class extends Notification
+        {
+            public function toMattermost(mixed $notifiable): array
+            {
+                return ['message' => 'orphan message'];
+            }
+        };
+
+        $channel->send($notifiable, $notification);
+    })->throws(RuntimeException::class, 'channel id');
+});

--- a/tests/Unit/Notifications/MattermostMessageTest.php
+++ b/tests/Unit/Notifications/MattermostMessageTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use ConduitUI\Mattermost\Notifications\MattermostMessage;
+
+describe('MattermostMessage', function (): void {
+    it('builds a payload fluently', function (): void {
+        $message = MattermostMessage::create('hello')
+            ->channel('chan-1')
+            ->rootId('post-root')
+            ->connection('staging')
+            ->fileIds(['f1', 'f2'])
+            ->props(['from_webhook' => 'true']);
+
+        expect($message->text)->toBe('hello');
+        expect($message->channelId)->toBe('chan-1');
+        expect($message->rootId)->toBe('post-root');
+        expect($message->connection)->toBe('staging');
+        expect($message->fileIds)->toBe(['f1', 'f2']);
+        expect($message->props)->toBe(['from_webhook' => 'true']);
+    });
+
+    it('attaches Slack-style attachments via props', function (): void {
+        $message = MattermostMessage::create('build green')
+            ->attachments([
+                ['text' => 'all checks passed', 'color' => '#36a64f'],
+            ]);
+
+        expect($message->props)->toHaveKey('attachments');
+        expect($message->props['attachments'])->toBe([
+            ['text' => 'all checks passed', 'color' => '#36a64f'],
+        ]);
+    });
+
+    it('text() sets the message text', function (): void {
+        $message = MattermostMessage::create()->text('updated');
+
+        expect($message->text)->toBe('updated');
+    });
+});


### PR DESCRIPTION
Closes #9.

## Summary

Adds two pieces of Laravel-native integration on top of the merged Saloon client and `MattermostManager`:

- **`MattermostChannel`** notification channel — pulls `toMattermost($notifiable)` from the notification (returns either a `MattermostMessage` VO or an array shaped like the `POST /api/v4/posts` body), resolves the channel id and connection from the notifiable's `routeNotificationFor('mattermost')` (string id, or `['channel' => ..., 'connection' => ...]` for multi-server), and posts via the manager. Missing `toMattermost()` is a no-op.
- **`MattermostMessage`** fluent payload VO — `text/channel/rootId/connection/fileIds/props/attachments`.
- **`MattermostBroadcaster`** broadcast driver — extends `Illuminate\Broadcasting\Broadcasters\Broadcaster`, posts each event as a JSON code-block message to every channel returned from `broadcastOn()`. Multi-server is wired via the `connection` key on the broadcasting config (e.g. `config('broadcasting.connections.mattermost.connection') = 'staging'`).
- Service provider's `boot()` registers the broadcaster via `Illuminate\Contracts\Broadcasting\Factory::extend('mattermost', ...)`.

### Auto-gen gap fix

The auto-generated `CreatePost` request and `Posts::createPost` resource method had no JSON body parameters at all (only the `set_online` query flag). Wired the spec's body shape (`channel_id`, `message`, `root_id`, `file_ids`, `props`) into both so the channel/broadcaster have a way to actually post — note added in the request docblock.

## Design notes

- The notification channel doesn't need explicit registration: Laravel discovers it when the notification's `via()` returns the FQCN (`MattermostChannel::class`).
- `MattermostMessage` is a plain VO, not a `Spatie/LaravelData` object, to keep the `Notifications/` slice dependency-light.
- `MattermostBroadcaster::auth()` and `validAuthenticationResponse()` are intentional no-ops — broadcasts originate server-side, there is no client subscription / private-channel handshake to authenticate.

## Test plan

- [x] `vendor/bin/pest --compact` — 25 passed (49 assertions)
- [x] `vendor/bin/pint --test` — passed
- [x] `vendor/bin/phpstan analyse` — 0 errors
- [x] `vendor/bin/rector process --dry-run` — clean
- [x] Unit coverage in `tests/Unit/Notifications/`:
  - `MattermostMessageTest` — fluent builder
  - `MattermostChannelTest` — array payload, VO payload, multi-connection routing, message-level channel override, missing `toMattermost()` no-op, missing channel id throws
  - `MattermostBroadcasterTest` — multi-channel dispatch, named connection, service-provider registration via `BroadcastingFactory::driver('mattermost')`