### PR TITLE
feat: WebSocket client — auto-reconnect + typed events

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,8 @@
         "php": "^8.4",
         "illuminate/contracts": "^13.0",
         "illuminate/support": "^13.0",
+        "ratchet/pawl": "^0.4.1",
+        "react/event-loop": "^1.5",
         "saloonphp/saloon": "^4.0"
     },
     "require-dev": {

--- a/src/WebSocket/Backoff.php
+++ b/src/WebSocket/Backoff.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\WebSocket;
+
+/**
+ * Exponential reconnect backoff: 1s, 2s, 4s, 8s ... up to a configurable
+ * maximum. `reset()` is called after a successful authentication so future
+ * disconnects start from 1s again.
+ */
+final class Backoff
+{
+    private int $current;
+
+    public function __construct(
+        private readonly int $initial = 1,
+        private readonly int $max = 60,
+    ) {
+        $this->current = max(1, $initial);
+    }
+
+    /**
+     * Returns the next delay (in seconds) and advances the schedule.
+     */
+    public function next(): int
+    {
+        $delay = min($this->current, $this->max);
+        $this->current = min($this->current * 2, $this->max);
+
+        return $delay;
+    }
+
+    public function reset(): void
+    {
+        $this->current = max(1, $this->initial);
+    }
+
+    public function current(): int
+    {
+        return min($this->current, $this->max);
+    }
+}

--- a/src/WebSocket/Client.php
+++ b/src/WebSocket/Client.php
@@ -1,0 +1,507 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\WebSocket;
+
+use ConduitUI\Mattermost\WebSocket\Contracts\WebSocketConnector;
+use ConduitUI\Mattermost\WebSocket\Events\Event;
+use ConduitUI\Mattermost\WebSocket\Events\EventFactory;
+use ConduitUI\Mattermost\WebSocket\Events\Hello;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Ratchet\Client\WebSocket;
+use Ratchet\RFC6455\Messaging\MessageInterface;
+use React\EventLoop\Loop;
+use React\EventLoop\LoopInterface;
+use React\EventLoop\TimerInterface;
+use Throwable;
+
+/**
+ * Mattermost WebSocket client.
+ *
+ * Long-lived event-loop driven client for `/api/v4/websocket`. Owns the
+ * full reconnect lifecycle:
+ *
+ *  1. Connect via the injected `WebSocketConnector` (Pawl by default).
+ *  2. Send `authentication_challenge` with the bot token (seq 1).
+ *  3. On every server frame, dispatch:
+ *       - `status: OK` reply → mark authenticated, reset backoff.
+ *       - `event: hello` → also dispatched as a `Hello` event.
+ *       - typed event → invoke listeners for that event name + wildcard.
+ *  4. On close, schedule a reconnect with exponential backoff (1, 2, 4
+ *     ... up to `reconnect_max_delay`). Initiation is idempotent so a
+ *     concurrent close + heartbeat-recycle don't double-schedule.
+ *  5. On SIGTERM/SIGINT, set `selfInitiatedClose`, close the socket,
+ *     stop the loop. The shell-level reconnect loop pattern from the
+ *     reference implementation is intentionally not used here — a single
+ *     long-lived loop avoids fd leaks across reconnects.
+ *
+ * The client is intentionally framework-agnostic. Laravel callers wire
+ * the logger via `Log::channel('mattermost')` from a console command;
+ * unit tests inject a no-op connector and a `BufferingLogger` to assert
+ * lifecycle behaviour without opening sockets.
+ *
+ * Listener registration is type-fluent:
+ *
+ *   $client->on(PostCreated::class, function (PostCreated $e) { ... });
+ *   $client->onAny(function (Event $e) { ... });
+ *
+ * Listeners are called in registration order. Throwing a listener does
+ * not crash the loop — exceptions are logged and swallowed.
+ */
+final class Client
+{
+    private readonly LoggerInterface $logger;
+
+    private readonly LoopInterface $loop;
+
+    private readonly WebSocketConnector $connector;
+
+    private readonly Backoff $backoff;
+
+    private readonly int $pingIntervalSeconds;
+
+    private readonly int $heartbeatTimeoutSeconds;
+
+    private readonly int $serverEvictionDelaySeconds;
+
+    private readonly string $wsUrl;
+
+    /** @var array<string, array<int, callable(Event): void>> */
+    private array $listeners = [];
+
+    /** @var array<int, callable(Event): void> */
+    private array $wildcardListeners = [];
+
+    private ?WebSocket $socket = null;
+
+    private ?TimerInterface $heartbeatTimer = null;
+
+    private ConnectionState $state = ConnectionState::Disconnected;
+
+    private bool $reconnecting = false;
+
+    private bool $selfInitiatedClose = false;
+
+    private bool $running = false;
+
+    private int $sequence = 2;
+
+    private int $lastFrameAt = 0;
+
+    public function __construct(
+        string $baseUrl,
+        private readonly string $token,
+        ?LoggerInterface $logger = null,
+        ?LoopInterface $loop = null,
+        ?WebSocketConnector $connector = null,
+        ?Backoff $backoff = null,
+        int $pingIntervalSeconds = 30,
+        int $heartbeatTimeoutSeconds = 120,
+        int $serverEvictionDelaySeconds = 30,
+    ) {
+        $this->logger = $logger ?? new NullLogger;
+        $this->loop = $loop ?? Loop::get();
+        $this->connector = $connector ?? new PawlConnector($this->loop);
+        $this->backoff = $backoff ?? new Backoff;
+        $this->pingIntervalSeconds = max(1, $pingIntervalSeconds);
+        $this->heartbeatTimeoutSeconds = max(1, $heartbeatTimeoutSeconds);
+        $this->serverEvictionDelaySeconds = max(1, $serverEvictionDelaySeconds);
+        $this->wsUrl = WebSocketUrl::fromBaseUrl($baseUrl);
+    }
+
+    /**
+     * Register a listener for a specific typed event class (or Mattermost
+     * event-name string for `GenericEvent` matches).
+     *
+     * @param  class-string<Event>|string  $eventClassOrName
+     * @param  callable(Event): void  $handler
+     */
+    public function on(string $eventClassOrName, callable $handler): self
+    {
+        $this->listeners[$eventClassOrName][] = $handler;
+
+        return $this;
+    }
+
+    /**
+     * Register a listener invoked for every event (typed or generic).
+     *
+     * @param  callable(Event): void  $handler
+     */
+    public function onAny(callable $handler): self
+    {
+        $this->wildcardListeners[] = $handler;
+
+        return $this;
+    }
+
+    public function state(): ConnectionState
+    {
+        return $this->state;
+    }
+
+    public function url(): string
+    {
+        return $this->wsUrl;
+    }
+
+    /**
+     * Open the connection and run the event loop until disconnected.
+     *
+     * Installs SIGTERM/SIGINT handlers (where supported) so a graceful
+     * shutdown closes the socket and exits the loop cleanly.
+     */
+    public function run(): void
+    {
+        if ($this->running) {
+            return;
+        }
+
+        $this->running = true;
+        $this->installSignalHandlers();
+        $this->scheduleConnect(0);
+        $this->loop->run();
+    }
+
+    /**
+     * Initiate a graceful shutdown — close the socket, cancel timers,
+     * stop the loop. Safe to call from a signal handler.
+     */
+    public function disconnect(): void
+    {
+        $this->setState(ConnectionState::Closing);
+        $this->running = false;
+        $this->selfInitiatedClose = true;
+
+        $this->cancelHeartbeat();
+
+        if ($this->socket instanceof WebSocket) {
+            try {
+                $this->socket->close();
+            } catch (Throwable $e) {
+                $this->logger->warning('Error closing Mattermost WS socket', ['error' => $e->getMessage()]);
+            }
+            $this->socket = null;
+        }
+
+        $this->loop->stop();
+        $this->setState(ConnectionState::Disconnected);
+    }
+
+    /**
+     * Idempotent: schedule a connect attempt after `$delaySeconds`.
+     * A second call while a reconnect is already pending is a no-op.
+     */
+    private function scheduleConnect(int $delaySeconds): void
+    {
+        if ($this->reconnecting) {
+            return;
+        }
+
+        if (! $this->running) {
+            return;
+        }
+
+        $this->reconnecting = true;
+
+        if ($delaySeconds > 0) {
+            $this->setState(ConnectionState::Reconnecting);
+            $this->logger->info('Mattermost WS reconnecting', [
+                'url' => $this->wsUrl,
+                'delay_seconds' => $delaySeconds,
+            ]);
+        } else {
+            $this->setState(ConnectionState::Connecting);
+        }
+
+        $this->loop->addTimer(max(0, $delaySeconds), function (): void {
+            $this->openSocket();
+        });
+    }
+
+    private function openSocket(): void
+    {
+        $this->setState(ConnectionState::Connecting);
+        $this->logger->info('Mattermost WS connecting', ['url' => $this->wsUrl]);
+
+        $this->connector->connect($this->wsUrl)->then(
+            function (WebSocket $conn): void {
+                $this->onOpen($conn);
+            },
+            function (Throwable $error): void {
+                $this->onConnectError($error);
+            }
+        );
+    }
+
+    private function onOpen(WebSocket $conn): void
+    {
+        $this->socket = $conn;
+        $this->reconnecting = false;
+        $this->sequence = 2;
+        $this->lastFrameAt = time();
+        $this->setState(ConnectionState::Authenticating);
+        $this->logger->info('Mattermost WS connected, sending auth challenge');
+
+        $this->sendAuthChallenge($conn);
+
+        $conn->on('message', function (MessageInterface $message): void {
+            $this->lastFrameAt = time();
+            $this->handleFrame((string) $message);
+        });
+
+        $conn->on('close', function ($code = null, $reason = null): void {
+            $this->onClose((int) ($code ?? 0), (string) ($reason ?? ''));
+        });
+
+        $conn->on('error', function (Throwable $error): void {
+            $this->logger->warning('Mattermost WS error', ['error' => $error->getMessage()]);
+        });
+
+        $this->scheduleHeartbeat($conn);
+    }
+
+    private function sendAuthChallenge(WebSocket $conn): void
+    {
+        $payload = json_encode([
+            'seq' => 1,
+            'action' => 'authentication_challenge',
+            'data' => ['token' => $this->token],
+        ]);
+
+        if ($payload === false) {
+            $this->logger->error('Failed to encode Mattermost WS auth challenge');
+
+            return;
+        }
+
+        $conn->send($payload);
+    }
+
+    private function scheduleHeartbeat(WebSocket $conn): void
+    {
+        $this->cancelHeartbeat();
+
+        $this->heartbeatTimer = $this->loop->addPeriodicTimer(
+            $this->pingIntervalSeconds,
+            function () use ($conn): void {
+                $this->emitHeartbeat($conn);
+            }
+        );
+    }
+
+    private function emitHeartbeat(WebSocket $conn): void
+    {
+        try {
+            $payload = json_encode(['seq' => $this->sequence++, 'action' => 'ping']);
+
+            if ($payload !== false) {
+                $conn->send($payload);
+            }
+        } catch (Throwable $error) {
+            $this->logger->warning('Mattermost WS heartbeat failed — recycling', [
+                'error' => $error->getMessage(),
+            ]);
+            $this->selfInitiatedClose = true;
+            $conn->close();
+
+            return;
+        }
+
+        if ((time() - $this->lastFrameAt) > $this->heartbeatTimeoutSeconds) {
+            $this->logger->warning('Mattermost WS heartbeat timeout — recycling', [
+                'last_frame_seconds_ago' => time() - $this->lastFrameAt,
+            ]);
+            $this->selfInitiatedClose = true;
+            $conn->close();
+        }
+    }
+
+    private function cancelHeartbeat(): void
+    {
+        if ($this->heartbeatTimer instanceof TimerInterface) {
+            $this->loop->cancelTimer($this->heartbeatTimer);
+            $this->heartbeatTimer = null;
+        }
+    }
+
+    private function onConnectError(Throwable $error): void
+    {
+        $this->reconnecting = false;
+        $delay = $this->backoff->next();
+
+        $this->logger->warning('Mattermost WS connect failed', [
+            'error' => $error->getMessage(),
+            'retry_in_seconds' => $delay,
+        ]);
+
+        $this->scheduleConnect($delay);
+    }
+
+    private function onClose(int $code, string $reason): void
+    {
+        $self = $this->selfInitiatedClose;
+        $this->socket = null;
+        $this->cancelHeartbeat();
+
+        $this->logger->info('Mattermost WS closed', [
+            'code' => $code,
+            'reason' => $reason,
+            'self_initiated' => $self,
+        ]);
+
+        // If the user called disconnect(), don't reconnect.
+        if (! $this->running) {
+            $this->setState(ConnectionState::Disconnected);
+
+            return;
+        }
+
+        $delay = $this->resolveCloseDelay($code, $self);
+        $this->selfInitiatedClose = false;
+        $this->scheduleConnect($delay);
+    }
+
+    /**
+     * Pick a reconnect delay based on the close code.
+     *
+     * Server-initiated close 1000 (normal closure) often indicates the
+     * Mattermost server has evicted a duplicate session for the same bot
+     * token. Backing off the standard 1s would cause an infinite flap, so
+     * we hold for the full max delay before retrying.
+     */
+    private function resolveCloseDelay(int $code, bool $selfInitiated): int
+    {
+        if ($code === 1000 && ! $selfInitiated) {
+            // Server kicked us — likely duplicate-session eviction.
+            // Hold for a wider delay before retrying to avoid a flap.
+            $this->backoff->reset();
+            $this->logger->warning('Mattermost WS server-initiated close 1000 — extended backoff', [
+                'delay_seconds' => $this->serverEvictionDelaySeconds,
+            ]);
+
+            return $this->serverEvictionDelaySeconds;
+        }
+
+        if ($selfInitiated) {
+            // Self-recycle: nothing's wrong, retry quickly without
+            // burning the backoff budget.
+            return 1;
+        }
+
+        return $this->backoff->next();
+    }
+
+    private function handleFrame(string $raw): void
+    {
+        $decoded = json_decode($raw, true);
+
+        if (! is_array($decoded)) {
+            return;
+        }
+
+        // Auth-challenge ack → status: OK.
+        if (($decoded['status'] ?? null) === 'OK' && $this->state === ConnectionState::Authenticating) {
+            $this->setState(ConnectionState::Connected);
+            $this->backoff->reset();
+            $this->logger->info('Mattermost WS authenticated');
+
+            return;
+        }
+
+        $event = EventFactory::fromArray($decoded);
+
+        if (! $event instanceof Event) {
+            return;
+        }
+
+        // The server's `hello` event arrives after a successful auth
+        // and is a useful redundant "we're healthy" cue. If we somehow
+        // missed the OK reply, accept hello as the same signal.
+        if ($event instanceof Hello && $this->state === ConnectionState::Authenticating) {
+            $this->setState(ConnectionState::Connected);
+            $this->backoff->reset();
+        }
+
+        $this->dispatchEvent($event);
+    }
+
+    private function dispatchEvent(Event $event): void
+    {
+        $candidates = [];
+
+        // Match against both the concrete class and the underlying
+        // event-name string so users can subscribe either way.
+        $candidates[] = $event::class;
+        $candidates[] = $event->name();
+
+        foreach ($candidates as $key) {
+            foreach ($this->listeners[$key] ?? [] as $listener) {
+                $this->invokeListener($listener, $event);
+            }
+        }
+
+        foreach ($this->wildcardListeners as $listener) {
+            $this->invokeListener($listener, $event);
+        }
+    }
+
+    /**
+     * @param  callable(Event): void  $listener
+     */
+    private function invokeListener(callable $listener, Event $event): void
+    {
+        try {
+            $listener($event);
+        } catch (Throwable $error) {
+            $this->logger->error('Mattermost WS listener threw', [
+                'event' => $event->name(),
+                'error' => $error->getMessage(),
+            ]);
+        }
+    }
+
+    private function setState(ConnectionState $next): void
+    {
+        if ($this->state === $next) {
+            return;
+        }
+
+        $this->logger->info('Mattermost WS state change', [
+            'from' => $this->state->value,
+            'to' => $next->value,
+        ]);
+
+        $this->state = $next;
+    }
+
+    private function installSignalHandlers(): void
+    {
+        if (! function_exists('pcntl_signal') || ! extension_loaded('pcntl')) {
+            return;
+        }
+
+        $handler = function (): void {
+            $this->logger->info('Mattermost WS received shutdown signal');
+            $this->disconnect();
+        };
+
+        try {
+            if (defined('SIGTERM')) {
+                $this->loop->addSignal(SIGTERM, $handler);
+            }
+            if (defined('SIGINT')) {
+                $this->loop->addSignal(SIGINT, $handler);
+            }
+        } catch (Throwable $error) {
+            // Some loops (e.g. StreamSelectLoop without pcntl) reject
+            // signal registration. Logged + ignored — Ctrl-C will still
+            // kill the process, just without graceful close.
+            $this->logger->debug('Mattermost WS signal handlers unavailable', [
+                'error' => $error->getMessage(),
+            ]);
+        }
+    }
+}

--- a/src/WebSocket/ConnectionState.php
+++ b/src/WebSocket/ConnectionState.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\WebSocket;
+
+/**
+ * Lifecycle states for the WebSocket client. Used for state-change logging
+ * and as a source of truth callers can query (e.g. health checks).
+ */
+enum ConnectionState: string
+{
+    case Disconnected = 'disconnected';
+    case Connecting = 'connecting';
+    case Authenticating = 'authenticating';
+    case Connected = 'connected';
+    case Reconnecting = 'reconnecting';
+    case Closing = 'closing';
+}

--- a/src/WebSocket/Contracts/WebSocketConnector.php
+++ b/src/WebSocket/Contracts/WebSocketConnector.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\WebSocket\Contracts;
+
+use Ratchet\Client\WebSocket;
+use React\Promise\PromiseInterface;
+
+/**
+ * Tiny abstraction over `Ratchet\Client\Connector` so the WebSocket client
+ * can be exercised in unit tests without opening real TCP sockets.
+ *
+ * Implementations resolve to a Pawl `WebSocket` instance (or a mock
+ * implementing the same `Evenement\EventEmitterInterface` + `send/close`
+ * contract) on success, and reject with `\Throwable` on failure.
+ */
+interface WebSocketConnector
+{
+    /**
+     * @param  string  $url  ws:// or wss:// URL
+     * @param  array<int, string>  $subProtocols
+     * @param  array<string, string>  $headers
+     * @return PromiseInterface<WebSocket>
+     */
+    public function connect(string $url, array $subProtocols = [], array $headers = []): PromiseInterface;
+}

--- a/src/WebSocket/Events/ChannelViewed.php
+++ b/src/WebSocket/Events/ChannelViewed.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\WebSocket\Events;
+
+/**
+ * Fired when a channel is marked as viewed (`channel_viewed`).
+ */
+final class ChannelViewed extends Event
+{
+    public const string EVENT_NAME = 'channel_viewed';
+
+    #[\Override]
+    public function name(): string
+    {
+        return self::EVENT_NAME;
+    }
+
+    public function channelId(): string
+    {
+        return (string) ($this->data['channel_id'] ?? $this->broadcast['channel_id'] ?? '');
+    }
+
+    public function userId(): string
+    {
+        return (string) ($this->broadcast['user_id'] ?? '');
+    }
+}

--- a/src/WebSocket/Events/Event.php
+++ b/src/WebSocket/Events/Event.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\WebSocket\Events;
+
+/**
+ * Base class for typed Mattermost WebSocket events.
+ *
+ * Mattermost wraps every event frame as:
+ * `{ event: string, data: array, broadcast: array, seq: int }`
+ *
+ * Subclasses expose convenience getters over the `data` payload while
+ * preserving the raw arrays for callers that want everything.
+ */
+abstract class Event
+{
+    /**
+     * @param  array<string, mixed>  $data  Event-specific payload.
+     * @param  array<string, mixed>  $broadcast  Routing info (channel_id, team_id, user_id, omit_users).
+     * @param  int  $seq  Server sequence number.
+     */
+    public function __construct(
+        public readonly array $data,
+        public readonly array $broadcast,
+        public readonly int $seq,
+    ) {}
+
+    /**
+     * The Mattermost event name, e.g. `posted`, `post_edited`.
+     */
+    abstract public function name(): string;
+}

--- a/src/WebSocket/Events/EventFactory.php
+++ b/src/WebSocket/Events/EventFactory.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\WebSocket\Events;
+
+/**
+ * Parses a raw Mattermost WebSocket frame into a typed `Event` value object.
+ *
+ * Mattermost frames come in three shapes:
+ *  - Auth-challenge response: `{ status: "OK", seq_reply: 1 }`
+ *  - Server event: `{ event: "...", data: {...}, broadcast: {...}, seq: N }`
+ *  - Action reply (response to a client `seq`): `{ seq_reply: N, ... }`
+ *
+ * `make()` returns `null` for non-event frames (status replies, malformed
+ * JSON) so the caller can ignore them without exception handling.
+ */
+final class EventFactory
+{
+    /**
+     * Map of Mattermost event names to typed event classes.
+     *
+     * @var array<string, class-string<Event>>
+     */
+    private const array EVENT_MAP = [
+        PostCreated::EVENT_NAME => PostCreated::class,
+        PostEdited::EVENT_NAME => PostEdited::class,
+        PostDeleted::EVENT_NAME => PostDeleted::class,
+        Typing::EVENT_NAME => Typing::class,
+        ReactionAdded::EVENT_NAME => ReactionAdded::class,
+        ReactionRemoved::EVENT_NAME => ReactionRemoved::class,
+        ChannelViewed::EVENT_NAME => ChannelViewed::class,
+        UserStatusChanged::EVENT_NAME => UserStatusChanged::class,
+        Hello::EVENT_NAME => Hello::class,
+    ];
+
+    public static function fromJson(string $raw): ?Event
+    {
+        $decoded = json_decode($raw, true);
+
+        if (! is_array($decoded)) {
+            return null;
+        }
+
+        return self::fromArray($decoded);
+    }
+
+    /**
+     * @param  array<string, mixed>  $frame
+     */
+    public static function fromArray(array $frame): ?Event
+    {
+        $event = $frame['event'] ?? null;
+
+        if (! is_string($event) || $event === '') {
+            return null;
+        }
+
+        $data = is_array($frame['data'] ?? null) ? $frame['data'] : [];
+        $broadcast = is_array($frame['broadcast'] ?? null) ? $frame['broadcast'] : [];
+        $seq = (int) ($frame['seq'] ?? 0);
+
+        $class = self::EVENT_MAP[$event] ?? null;
+
+        if ($class === null) {
+            return new GenericEvent($event, $data, $broadcast, $seq);
+        }
+
+        return new $class($data, $broadcast, $seq);
+    }
+}

--- a/src/WebSocket/Events/GenericEvent.php
+++ b/src/WebSocket/Events/GenericEvent.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\WebSocket\Events;
+
+/**
+ * Fallback event for any Mattermost event we don't model with a typed
+ * subclass yet. Preserves the original event name plus the raw payload
+ * so callers can still inspect unrecognised frames.
+ */
+final class GenericEvent extends Event
+{
+    public function __construct(
+        private readonly string $name,
+        array $data,
+        array $broadcast,
+        int $seq,
+    ) {
+        parent::__construct($data, $broadcast, $seq);
+    }
+
+    #[\Override]
+    public function name(): string
+    {
+        return $this->name;
+    }
+}

--- a/src/WebSocket/Events/Hello.php
+++ b/src/WebSocket/Events/Hello.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\WebSocket\Events;
+
+/**
+ * Sent by the server immediately after a successful auth handshake (`hello`).
+ *
+ * Contains the server version, build date, and build hash. Useful as a
+ * cue that the connection is healthy and authenticated.
+ */
+final class Hello extends Event
+{
+    public const string EVENT_NAME = 'hello';
+
+    #[\Override]
+    public function name(): string
+    {
+        return self::EVENT_NAME;
+    }
+
+    public function serverVersion(): string
+    {
+        return (string) ($this->data['server_version'] ?? '');
+    }
+}

--- a/src/WebSocket/Events/PostCreated.php
+++ b/src/WebSocket/Events/PostCreated.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\WebSocket\Events;
+
+/**
+ * Fired when a new post is created in any channel the bot can see.
+ *
+ * Mattermost JSON-encodes the nested `post` object inside `data.post`,
+ * so we eagerly decode it here for callers.
+ */
+final class PostCreated extends Event
+{
+    public const string EVENT_NAME = 'posted';
+
+    #[\Override]
+    public function name(): string
+    {
+        return self::EVENT_NAME;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function post(): ?array
+    {
+        return $this->decodeJsonField('post');
+    }
+
+    public function channelId(): string
+    {
+        $post = $this->post();
+
+        return (string) ($post['channel_id'] ?? $this->broadcast['channel_id'] ?? '');
+    }
+
+    public function channelType(): string
+    {
+        return (string) ($this->data['channel_type'] ?? '');
+    }
+
+    public function channelName(): string
+    {
+        return (string) ($this->data['channel_name'] ?? '');
+    }
+
+    public function senderName(): string
+    {
+        return (string) ($this->data['sender_name'] ?? '');
+    }
+
+    public function userId(): string
+    {
+        return (string) ($this->post()['user_id'] ?? '');
+    }
+
+    public function message(): string
+    {
+        return (string) ($this->post()['message'] ?? '');
+    }
+
+    public function rootId(): string
+    {
+        return (string) ($this->post()['root_id'] ?? '');
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function decodeJsonField(string $key): ?array
+    {
+        $raw = $this->data[$key] ?? null;
+
+        if (is_array($raw)) {
+            return $raw;
+        }
+
+        if (is_string($raw) && $raw !== '') {
+            $decoded = json_decode($raw, true);
+
+            return is_array($decoded) ? $decoded : null;
+        }
+
+        return null;
+    }
+}

--- a/src/WebSocket/Events/PostDeleted.php
+++ b/src/WebSocket/Events/PostDeleted.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\WebSocket\Events;
+
+/**
+ * Fired when a post is deleted (`post_deleted`).
+ */
+final class PostDeleted extends Event
+{
+    public const string EVENT_NAME = 'post_deleted';
+
+    #[\Override]
+    public function name(): string
+    {
+        return self::EVENT_NAME;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function post(): ?array
+    {
+        $raw = $this->data['post'] ?? null;
+
+        if (is_array($raw)) {
+            return $raw;
+        }
+
+        if (is_string($raw) && $raw !== '') {
+            $decoded = json_decode($raw, true);
+
+            return is_array($decoded) ? $decoded : null;
+        }
+
+        return null;
+    }
+
+    public function postId(): string
+    {
+        return (string) ($this->post()['id'] ?? '');
+    }
+
+    public function channelId(): string
+    {
+        return (string) ($this->post()['channel_id'] ?? $this->broadcast['channel_id'] ?? '');
+    }
+
+    public function userId(): string
+    {
+        return (string) ($this->post()['user_id'] ?? '');
+    }
+}

--- a/src/WebSocket/Events/PostEdited.php
+++ b/src/WebSocket/Events/PostEdited.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\WebSocket\Events;
+
+/**
+ * Fired when an existing post is edited (`post_edited`).
+ */
+final class PostEdited extends Event
+{
+    public const string EVENT_NAME = 'post_edited';
+
+    #[\Override]
+    public function name(): string
+    {
+        return self::EVENT_NAME;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function post(): ?array
+    {
+        $raw = $this->data['post'] ?? null;
+
+        if (is_array($raw)) {
+            return $raw;
+        }
+
+        if (is_string($raw) && $raw !== '') {
+            $decoded = json_decode($raw, true);
+
+            return is_array($decoded) ? $decoded : null;
+        }
+
+        return null;
+    }
+
+    public function postId(): string
+    {
+        return (string) ($this->post()['id'] ?? '');
+    }
+
+    public function channelId(): string
+    {
+        return (string) ($this->post()['channel_id'] ?? $this->broadcast['channel_id'] ?? '');
+    }
+
+    public function userId(): string
+    {
+        return (string) ($this->post()['user_id'] ?? '');
+    }
+
+    public function message(): string
+    {
+        return (string) ($this->post()['message'] ?? '');
+    }
+}

--- a/src/WebSocket/Events/ReactionAdded.php
+++ b/src/WebSocket/Events/ReactionAdded.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\WebSocket\Events;
+
+/**
+ * Fired when a user adds a reaction to a post (`reaction_added`).
+ */
+final class ReactionAdded extends Event
+{
+    public const string EVENT_NAME = 'reaction_added';
+
+    #[\Override]
+    public function name(): string
+    {
+        return self::EVENT_NAME;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function reaction(): ?array
+    {
+        $raw = $this->data['reaction'] ?? null;
+
+        if (is_array($raw)) {
+            return $raw;
+        }
+
+        if (is_string($raw) && $raw !== '') {
+            $decoded = json_decode($raw, true);
+
+            return is_array($decoded) ? $decoded : null;
+        }
+
+        return null;
+    }
+
+    public function emoji(): string
+    {
+        return (string) ($this->reaction()['emoji_name'] ?? '');
+    }
+
+    public function postId(): string
+    {
+        return (string) ($this->reaction()['post_id'] ?? '');
+    }
+
+    public function userId(): string
+    {
+        return (string) ($this->reaction()['user_id'] ?? '');
+    }
+
+    public function channelId(): string
+    {
+        return (string) ($this->broadcast['channel_id'] ?? '');
+    }
+}

--- a/src/WebSocket/Events/ReactionRemoved.php
+++ b/src/WebSocket/Events/ReactionRemoved.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\WebSocket\Events;
+
+/**
+ * Fired when a user removes a reaction (`reaction_removed`).
+ */
+final class ReactionRemoved extends Event
+{
+    public const string EVENT_NAME = 'reaction_removed';
+
+    #[\Override]
+    public function name(): string
+    {
+        return self::EVENT_NAME;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function reaction(): ?array
+    {
+        $raw = $this->data['reaction'] ?? null;
+
+        if (is_array($raw)) {
+            return $raw;
+        }
+
+        if (is_string($raw) && $raw !== '') {
+            $decoded = json_decode($raw, true);
+
+            return is_array($decoded) ? $decoded : null;
+        }
+
+        return null;
+    }
+
+    public function emoji(): string
+    {
+        return (string) ($this->reaction()['emoji_name'] ?? '');
+    }
+
+    public function postId(): string
+    {
+        return (string) ($this->reaction()['post_id'] ?? '');
+    }
+
+    public function userId(): string
+    {
+        return (string) ($this->reaction()['user_id'] ?? '');
+    }
+
+    public function channelId(): string
+    {
+        return (string) ($this->broadcast['channel_id'] ?? '');
+    }
+}

--- a/src/WebSocket/Events/Typing.php
+++ b/src/WebSocket/Events/Typing.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\WebSocket\Events;
+
+/**
+ * Fired while a user is typing in a channel (`typing`).
+ */
+final class Typing extends Event
+{
+    public const string EVENT_NAME = 'typing';
+
+    #[\Override]
+    public function name(): string
+    {
+        return self::EVENT_NAME;
+    }
+
+    public function userId(): string
+    {
+        return (string) ($this->data['user_id'] ?? '');
+    }
+
+    public function channelId(): string
+    {
+        return (string) ($this->broadcast['channel_id'] ?? '');
+    }
+
+    public function parentId(): string
+    {
+        return (string) ($this->data['parent_id'] ?? '');
+    }
+}

--- a/src/WebSocket/Events/UserStatusChanged.php
+++ b/src/WebSocket/Events/UserStatusChanged.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\WebSocket\Events;
+
+/**
+ * Fired when a user's online status changes (`status_change`).
+ */
+final class UserStatusChanged extends Event
+{
+    public const string EVENT_NAME = 'status_change';
+
+    #[\Override]
+    public function name(): string
+    {
+        return self::EVENT_NAME;
+    }
+
+    public function userId(): string
+    {
+        return (string) ($this->data['user_id'] ?? $this->broadcast['user_id'] ?? '');
+    }
+
+    public function status(): string
+    {
+        return (string) ($this->data['status'] ?? '');
+    }
+}

--- a/src/WebSocket/PawlConnector.php
+++ b/src/WebSocket/PawlConnector.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\WebSocket;
+
+use ConduitUI\Mattermost\WebSocket\Contracts\WebSocketConnector;
+use Ratchet\Client\Connector as PawlClientConnector;
+use React\EventLoop\LoopInterface;
+use React\Promise\PromiseInterface;
+
+/**
+ * Default `WebSocketConnector` implementation backed by `ratchet/pawl`.
+ *
+ * Thin wrapper — exists so we can mock the connector seam in unit tests
+ * and keep the `Client` framework-agnostic.
+ */
+final readonly class PawlConnector implements WebSocketConnector
+{
+    private PawlClientConnector $connector;
+
+    public function __construct(LoopInterface $loop)
+    {
+        $this->connector = new PawlClientConnector($loop);
+    }
+
+    #[\Override]
+    public function connect(string $url, array $subProtocols = [], array $headers = []): PromiseInterface
+    {
+        $connector = $this->connector;
+
+        return $connector($url, $subProtocols, $headers);
+    }
+}

--- a/src/WebSocket/WebSocketUrl.php
+++ b/src/WebSocket/WebSocketUrl.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\WebSocket;
+
+use InvalidArgumentException;
+
+/**
+ * Helper to build the Mattermost WebSocket endpoint URL from the REST
+ * connector base URL.
+ *
+ * The mapping is `http://` → `ws://`, `https://` → `wss://`, then we
+ * append `/api/v4/websocket` (Mattermost's fixed WS path).
+ */
+final class WebSocketUrl
+{
+    private const string PATH = '/api/v4/websocket';
+
+    public static function fromBaseUrl(string $baseUrl): string
+    {
+        $trimmed = rtrim($baseUrl, '/');
+
+        if ($trimmed === '') {
+            throw new InvalidArgumentException('Mattermost base URL cannot be empty.');
+        }
+
+        if (str_starts_with($trimmed, 'https://')) {
+            return 'wss://'.substr($trimmed, 8).self::PATH;
+        }
+
+        if (str_starts_with($trimmed, 'http://')) {
+            return 'ws://'.substr($trimmed, 7).self::PATH;
+        }
+
+        if (str_starts_with($trimmed, 'wss://') || str_starts_with($trimmed, 'ws://')) {
+            return $trimmed.self::PATH;
+        }
+
+        throw new InvalidArgumentException(
+            "Mattermost base URL must use http(s):// or ws(s):// scheme; got: {$baseUrl}"
+        );
+    }
+}

--- a/tests/Unit/WebSocket/BackoffTest.php
+++ b/tests/Unit/WebSocket/BackoffTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use ConduitUI\Mattermost\WebSocket\Backoff;
+
+describe('Backoff', function (): void {
+    it('doubles each step until the cap', function (): void {
+        $b = new Backoff(initial: 1, max: 60);
+
+        expect([
+            $b->next(),
+            $b->next(),
+            $b->next(),
+            $b->next(),
+            $b->next(),
+            $b->next(),
+            $b->next(),
+        ])->toBe([1, 2, 4, 8, 16, 32, 60]);
+    });
+
+    it('stays at the cap on further calls', function (): void {
+        $b = new Backoff(initial: 1, max: 8);
+
+        $b->next(); // 1
+        $b->next(); // 2
+        $b->next(); // 4
+        $b->next(); // 8
+
+        expect($b->next())->toBe(8);
+        expect($b->next())->toBe(8);
+    });
+
+    it('resets to initial', function (): void {
+        $b = new Backoff(initial: 1, max: 60);
+        $b->next();
+        $b->next();
+        $b->next();
+
+        $b->reset();
+
+        expect($b->next())->toBe(1);
+    });
+});

--- a/tests/Unit/WebSocket/ClientTest.php
+++ b/tests/Unit/WebSocket/ClientTest.php
@@ -1,0 +1,306 @@
+<?php
+
+declare(strict_types=1);
+
+use ConduitUI\Mattermost\Tests\Unit\WebSocket\Doubles\FakeConnector;
+use ConduitUI\Mattermost\Tests\Unit\WebSocket\Doubles\FakeWebSocket;
+use ConduitUI\Mattermost\Tests\Unit\WebSocket\Doubles\RecordingLogger;
+use ConduitUI\Mattermost\WebSocket\Backoff;
+use ConduitUI\Mattermost\WebSocket\Client;
+use ConduitUI\Mattermost\WebSocket\ConnectionState;
+use ConduitUI\Mattermost\WebSocket\Events\Hello;
+use ConduitUI\Mattermost\WebSocket\Events\PostCreated;
+use React\EventLoop\StreamSelectLoop;
+
+/**
+ * Drive the Client's lifecycle in-process by injecting a real ReactPHP
+ * loop together with our `FakeConnector` + `FakeWebSocket`.
+ *
+ * Each test arranges the connector behaviour, runs the client briefly,
+ * then asserts on what was sent / what state we ended in. The loop is
+ * stopped by `$client->disconnect()` from a deferred callback so we
+ * never actually wait in real time.
+ */
+function makeClient(
+    StreamSelectLoop $loop,
+    FakeConnector $connector,
+    RecordingLogger $logger,
+    int $heartbeatTimeout = 9999,
+    ?Backoff $backoff = null,
+): Client {
+    return new Client(
+        baseUrl: 'http://localhost:8065',
+        token: 'test-token',
+        logger: $logger,
+        loop: $loop,
+        connector: $connector,
+        backoff: $backoff,
+        pingIntervalSeconds: 9999, // disable heartbeat fires during tests
+        heartbeatTimeoutSeconds: $heartbeatTimeout,
+        serverEvictionDelaySeconds: 30,
+    );
+}
+
+describe('Client', function (): void {
+    it('builds the ws URL by transforming the connector base URL', function (): void {
+        $loop = new StreamSelectLoop;
+        $connector = new FakeConnector;
+        $client = makeClient($loop, $connector, new RecordingLogger);
+
+        expect($client->url())->toBe('ws://localhost:8065/api/v4/websocket');
+    });
+
+    it('starts in disconnected state', function (): void {
+        $loop = new StreamSelectLoop;
+        $client = makeClient($loop, new FakeConnector, new RecordingLogger);
+
+        expect($client->state())->toBe(ConnectionState::Disconnected);
+    });
+
+    it('sends the auth challenge frame on open and dispatches the auth-OK reply', function (): void {
+        $loop = new StreamSelectLoop;
+        $socket = new FakeWebSocket;
+        $connector = new FakeConnector;
+        $connector->alwaysResolveWith($socket);
+        $logger = new RecordingLogger;
+        $client = makeClient($loop, $connector, $logger);
+
+        // After the auth-OK reply we'll be in Connected state — exit
+        // the loop from a wildcard listener (none fires for status:OK)
+        // so instead schedule a future-tick that pushes a frame in,
+        // then disconnects.
+        $loop->addTimer(0.001, function () use ($socket): void {
+            $socket->emitMessage(json_encode(['status' => 'OK', 'seq_reply' => 1]));
+        });
+        $loop->addTimer(0.01, fn () => $client->disconnect());
+
+        $client->run();
+
+        expect($connector->calls)->toBe(['ws://localhost:8065/api/v4/websocket']);
+        expect($socket->sent)->toHaveCount(1);
+
+        $authFrame = json_decode($socket->sent[0], true);
+        expect($authFrame)->toBe([
+            'seq' => 1,
+            'action' => 'authentication_challenge',
+            'data' => ['token' => 'test-token'],
+        ]);
+
+        expect($logger->has('Mattermost WS authenticated'))->toBeTrue();
+    });
+
+    it('dispatches typed events to listeners registered by class name', function (): void {
+        $loop = new StreamSelectLoop;
+        $socket = new FakeWebSocket;
+        $connector = new FakeConnector;
+        $connector->alwaysResolveWith($socket);
+        $client = makeClient($loop, $connector, new RecordingLogger);
+
+        $captured = [];
+        $client->on(PostCreated::class, function (PostCreated $event) use (&$captured): void {
+            $captured[] = $event;
+        });
+
+        $loop->addTimer(0.001, function () use ($socket): void {
+            $socket->emitMessage(json_encode(['status' => 'OK', 'seq_reply' => 1]));
+            $socket->emitMessage(json_encode([
+                'event' => 'posted',
+                'data' => [
+                    'channel_type' => 'D',
+                    'channel_name' => 'lexi__jordan',
+                    'sender_name' => '@jordan',
+                    'post' => json_encode(['id' => 'p1', 'channel_id' => 'c1', 'user_id' => 'u1', 'message' => 'hi']),
+                ],
+                'broadcast' => ['channel_id' => 'c1'],
+                'seq' => 7,
+            ]));
+        });
+        $loop->addTimer(0.01, fn () => $client->disconnect());
+
+        $client->run();
+
+        expect($captured)->toHaveCount(1);
+        expect($captured[0])->toBeInstanceOf(PostCreated::class);
+        expect($captured[0]->message())->toBe('hi');
+    });
+
+    it('dispatches all events to wildcard listeners', function (): void {
+        $loop = new StreamSelectLoop;
+        $socket = new FakeWebSocket;
+        $connector = new FakeConnector;
+        $connector->alwaysResolveWith($socket);
+        $client = makeClient($loop, $connector, new RecordingLogger);
+
+        $names = [];
+        $client->onAny(function ($event) use (&$names): void {
+            $names[] = $event->name();
+        });
+
+        $loop->addTimer(0.001, function () use ($socket): void {
+            $socket->emitMessage(json_encode(['status' => 'OK', 'seq_reply' => 1]));
+            $socket->emitMessage(json_encode([
+                'event' => 'hello',
+                'data' => ['server_version' => '9.5.0'],
+                'broadcast' => [],
+                'seq' => 1,
+            ]));
+            $socket->emitMessage(json_encode([
+                'event' => 'typing',
+                'data' => ['user_id' => 'u1'],
+                'broadcast' => ['channel_id' => 'c1'],
+                'seq' => 2,
+            ]));
+        });
+        $loop->addTimer(0.01, fn () => $client->disconnect());
+
+        $client->run();
+
+        expect($names)->toBe(['hello', 'typing']);
+    });
+
+    it('logs but does not crash when a listener throws', function (): void {
+        $loop = new StreamSelectLoop;
+        $socket = new FakeWebSocket;
+        $connector = new FakeConnector;
+        $connector->alwaysResolveWith($socket);
+        $logger = new RecordingLogger;
+        $client = makeClient($loop, $connector, $logger);
+
+        $client->on(Hello::class, function (): void {
+            throw new RuntimeException('boom');
+        });
+
+        $loop->addTimer(0.001, function () use ($socket): void {
+            $socket->emitMessage(json_encode(['status' => 'OK', 'seq_reply' => 1]));
+            $socket->emitMessage(json_encode([
+                'event' => 'hello',
+                'data' => ['server_version' => '9.5.0'],
+                'broadcast' => [],
+                'seq' => 0,
+            ]));
+        });
+        $loop->addTimer(0.01, fn () => $client->disconnect());
+
+        $client->run();
+
+        expect($logger->has('listener threw'))->toBeTrue();
+    });
+
+    it('schedules a reconnect with exponential backoff on connect failure', function (): void {
+        $loop = new StreamSelectLoop;
+        $connector = new FakeConnector;
+
+        $attempts = 0;
+        $connector->setBehaviour(function (int $attempt, $deferred) use (&$attempts): void {
+            $attempts = $attempt;
+            $deferred->reject(new RuntimeException('refused'));
+        });
+        $logger = new RecordingLogger;
+
+        $backoff = new Backoff(initial: 1, max: 60);
+        $client = makeClient($loop, $connector, $logger, backoff: $backoff);
+
+        // Stop the loop after a brief wall-clock window — we just want
+        // to see the FIRST connect attempt fail and a retry to be
+        // scheduled (we don't wait for the 1s retry to actually fire).
+        $loop->addTimer(0.01, fn () => $client->disconnect());
+        $client->run();
+
+        expect($attempts)->toBe(1);
+        expect($logger->has('connect failed'))->toBeTrue();
+        // Backoff advanced from 1 → next would be 2.
+        expect($backoff->current())->toBe(2);
+    });
+
+    it('reconnects on unexpected close', function (): void {
+        $loop = new StreamSelectLoop;
+        $sockets = [new FakeWebSocket, new FakeWebSocket];
+        $connector = new FakeConnector;
+        $connector->setBehaviour(function (int $attempt, $deferred) use ($sockets): void {
+            $deferred->resolve($sockets[$attempt - 1] ?? new FakeWebSocket);
+        });
+        $logger = new RecordingLogger;
+
+        $backoff = new Backoff(initial: 1, max: 1); // immediate retry
+        $client = makeClient($loop, $connector, $logger, backoff: $backoff);
+
+        $loop->addTimer(0.001, function () use ($sockets): void {
+            // Auth the first socket then trigger a server close.
+            $sockets[0]->emitMessage(json_encode(['status' => 'OK', 'seq_reply' => 1]));
+            $sockets[0]->close(1006, 'abnormal');
+        });
+        // Allow up to 2.5s wall clock for the second connection
+        // (backoff is 1s).
+        $loop->addTimer(2.5, fn () => $client->disconnect());
+
+        $client->run();
+
+        expect($connector->calls)->toHaveCount(2);
+        expect($logger->has('Mattermost WS closed'))->toBeTrue();
+    });
+
+    it('uses an extended delay on server-initiated 1000 close', function (): void {
+        $loop = new StreamSelectLoop;
+        $socket = new FakeWebSocket;
+        $connector = new FakeConnector;
+        $connector->alwaysResolveWith($socket);
+        $logger = new RecordingLogger;
+
+        $client = makeClient($loop, $connector, $logger);
+
+        $loop->addTimer(0.001, function () use ($socket): void {
+            $socket->emitMessage(json_encode(['status' => 'OK', 'seq_reply' => 1]));
+            // server kicks us with normal close → eviction delay
+            $socket->close(1000, 'duplicate session');
+        });
+        $loop->addTimer(0.01, fn () => $client->disconnect());
+
+        $client->run();
+
+        expect($logger->has('extended backoff'))->toBeTrue();
+    });
+
+    it('does not reconnect after disconnect()', function (): void {
+        $loop = new StreamSelectLoop;
+        $socket = new FakeWebSocket;
+        $connector = new FakeConnector;
+        $connector->alwaysResolveWith($socket);
+
+        $client = makeClient($loop, $connector, new RecordingLogger);
+
+        $loop->addTimer(0.001, function () use ($socket, $client): void {
+            $socket->emitMessage(json_encode(['status' => 'OK', 'seq_reply' => 1]));
+            $client->disconnect();
+        });
+        // Hard timeout safeguard.
+        $loop->addTimer(0.5, fn () => $client->disconnect());
+
+        $client->run();
+
+        expect($client->state())->toBe(ConnectionState::Disconnected);
+        expect($connector->calls)->toHaveCount(1);
+    });
+
+    it('logs every state change', function (): void {
+        $loop = new StreamSelectLoop;
+        $socket = new FakeWebSocket;
+        $connector = new FakeConnector;
+        $connector->alwaysResolveWith($socket);
+        $logger = new RecordingLogger;
+
+        $client = makeClient($loop, $connector, $logger);
+
+        $loop->addTimer(0.001, function () use ($socket): void {
+            $socket->emitMessage(json_encode(['status' => 'OK', 'seq_reply' => 1]));
+        });
+        $loop->addTimer(0.01, fn () => $client->disconnect());
+
+        $client->run();
+
+        $stateChanges = array_filter(
+            $logger->records,
+            fn ($r) => $r['message'] === 'Mattermost WS state change'
+        );
+        expect(count($stateChanges))->toBeGreaterThan(0);
+    });
+});

--- a/tests/Unit/WebSocket/Doubles/FakeConnector.php
+++ b/tests/Unit/WebSocket/Doubles/FakeConnector.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\Tests\Unit\WebSocket\Doubles;
+
+use Closure;
+use ConduitUI\Mattermost\WebSocket\Contracts\WebSocketConnector;
+use React\Promise\Deferred;
+use React\Promise\PromiseInterface;
+use Throwable;
+
+/**
+ * Test double for `WebSocketConnector` — drives connect/error sequences
+ * deterministically.
+ *
+ * Each call to `connect()` returns a fresh promise. The factory closure
+ * (passed in via `setBehaviour`) decides whether to resolve, reject, or
+ * leave pending so the test can drive event timings.
+ */
+final class FakeConnector implements WebSocketConnector
+{
+    /** @var list<string> */
+    public array $calls = [];
+
+    /** @var Closure(int, Deferred): void */
+    private Closure $behaviour;
+
+    public function __construct()
+    {
+        // default: leave the promise pending
+        $this->behaviour = static function (int $attempt, Deferred $deferred): void {};
+    }
+
+    /**
+     * @param  Closure(int, Deferred): void  $behaviour
+     */
+    public function setBehaviour(Closure $behaviour): void
+    {
+        $this->behaviour = $behaviour;
+    }
+
+    /**
+     * Convenience: always resolve with the given fake socket.
+     */
+    public function alwaysResolveWith(FakeWebSocket $socket): void
+    {
+        $this->behaviour = static function (int $attempt, Deferred $deferred) use ($socket): void {
+            $deferred->resolve($socket);
+        };
+    }
+
+    /**
+     * Convenience: always reject with the given throwable.
+     */
+    public function alwaysRejectWith(Throwable $error): void
+    {
+        $this->behaviour = static function (int $attempt, Deferred $deferred) use ($error): void {
+            $deferred->reject($error);
+        };
+    }
+
+    #[\Override]
+    public function connect(string $url, array $subProtocols = [], array $headers = []): PromiseInterface
+    {
+        $this->calls[] = $url;
+        $deferred = new Deferred;
+        ($this->behaviour)(count($this->calls), $deferred);
+
+        return $deferred->promise();
+    }
+}

--- a/tests/Unit/WebSocket/Doubles/FakeMessage.php
+++ b/tests/Unit/WebSocket/Doubles/FakeMessage.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\Tests\Unit\WebSocket\Doubles;
+
+use ArrayIterator;
+use IteratorAggregate;
+use Ratchet\RFC6455\Messaging\FrameInterface;
+use Ratchet\RFC6455\Messaging\MessageInterface;
+
+/**
+ * Stand-in for `Ratchet\RFC6455\Messaging\Message` that exposes only the
+ * surface our `Client::handleFrame` needs (`(string) $message`).
+ *
+ * @implements IteratorAggregate<int, FrameInterface>
+ */
+final class FakeMessage implements IteratorAggregate, MessageInterface
+{
+    public function __construct(private readonly string $payload) {}
+
+    #[\Override]
+    public function getIterator(): ArrayIterator
+    {
+        return new ArrayIterator([]);
+    }
+
+    #[\Override]
+    public function count(): int
+    {
+        return 0;
+    }
+
+    #[\Override]
+    public function isCoalesced(): bool
+    {
+        return true;
+    }
+
+    #[\Override]
+    public function getPayloadLength(): int
+    {
+        return strlen($this->payload);
+    }
+
+    #[\Override]
+    public function getPayload(): string
+    {
+        return $this->payload;
+    }
+
+    #[\Override]
+    public function getContents(): string
+    {
+        return $this->payload;
+    }
+
+    #[\Override]
+    public function __toString(): string
+    {
+        return $this->payload;
+    }
+
+    #[\Override]
+    public function addFrame(FrameInterface $fragment): self
+    {
+        return $this;
+    }
+
+    #[\Override]
+    public function getOpcode(): int
+    {
+        return 1; // text
+    }
+
+    #[\Override]
+    public function isBinary(): bool
+    {
+        return false;
+    }
+}

--- a/tests/Unit/WebSocket/Doubles/FakeWebSocket.php
+++ b/tests/Unit/WebSocket/Doubles/FakeWebSocket.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\Tests\Unit\WebSocket\Doubles;
+
+use Evenement\EventEmitterTrait;
+use Ratchet\Client\WebSocket;
+
+/**
+ * Fake `Ratchet\Client\WebSocket` for unit tests.
+ *
+ * Inherits the real type so it satisfies the `Client::$socket` declared
+ * type, but skips the parent constructor (which needs a live socket
+ * stream + PSR-7 messages we don't want to fabricate).
+ *
+ * Provides:
+ *  - `send($payload)` → captures the frame in `$sent` for assertions.
+ *  - `close($code, $reason)` → emits the `close` event so the Client's
+ *    onClose path runs. Records `$closeCalls` for assertions.
+ */
+final class FakeWebSocket extends WebSocket
+{
+    use EventEmitterTrait;
+
+    /** @var list<string> */
+    public array $sent = [];
+
+    /** @var list<array{code: int, reason: string}> */
+    public array $closeCalls = [];
+
+    public function __construct()
+    {
+        // Intentionally do NOT call parent::__construct — we don't have
+        // a real React stream and don't need one for these tests.
+    }
+
+    #[\Override]
+    public function send($msg)
+    {
+        $this->sent[] = (string) $msg;
+
+        return $this;
+    }
+
+    #[\Override]
+    public function close($code = 1000, $reason = '')
+    {
+        $this->closeCalls[] = ['code' => (int) $code, 'reason' => (string) $reason];
+        $this->emit('close', [$code, $reason]);
+    }
+
+    public function emitMessage(string $payload): void
+    {
+        $message = new FakeMessage($payload);
+        $this->emit('message', [$message]);
+    }
+}

--- a/tests/Unit/WebSocket/Doubles/RecordingLogger.php
+++ b/tests/Unit/WebSocket/Doubles/RecordingLogger.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\Tests\Unit\WebSocket\Doubles;
+
+use Psr\Log\AbstractLogger;
+use Stringable;
+
+/**
+ * PSR-3 logger that records every call so tests can assert state changes
+ * and lifecycle messages without reading actual log files.
+ */
+final class RecordingLogger extends AbstractLogger
+{
+    /** @var list<array{level: mixed, message: string, context: array<string, mixed>}> */
+    public array $records = [];
+
+    #[\Override]
+    public function log($level, string|Stringable $message, array $context = []): void
+    {
+        $this->records[] = [
+            'level' => $level,
+            'message' => (string) $message,
+            'context' => $context,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function messages(): array
+    {
+        return array_map(static fn ($r) => $r['message'], $this->records);
+    }
+
+    public function has(string $needle): bool
+    {
+        foreach ($this->records as $record) {
+            if (str_contains($record['message'], $needle)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/Unit/WebSocket/EventFactoryTest.php
+++ b/tests/Unit/WebSocket/EventFactoryTest.php
@@ -1,0 +1,232 @@
+<?php
+
+declare(strict_types=1);
+
+use ConduitUI\Mattermost\WebSocket\Events\ChannelViewed;
+use ConduitUI\Mattermost\WebSocket\Events\EventFactory;
+use ConduitUI\Mattermost\WebSocket\Events\GenericEvent;
+use ConduitUI\Mattermost\WebSocket\Events\Hello;
+use ConduitUI\Mattermost\WebSocket\Events\PostCreated;
+use ConduitUI\Mattermost\WebSocket\Events\PostDeleted;
+use ConduitUI\Mattermost\WebSocket\Events\PostEdited;
+use ConduitUI\Mattermost\WebSocket\Events\ReactionAdded;
+use ConduitUI\Mattermost\WebSocket\Events\ReactionRemoved;
+use ConduitUI\Mattermost\WebSocket\Events\Typing;
+use ConduitUI\Mattermost\WebSocket\Events\UserStatusChanged;
+
+describe('EventFactory', function (): void {
+    it('returns null for malformed JSON', function (): void {
+        expect(EventFactory::fromJson('not json'))->toBeNull();
+    });
+
+    it('returns null for an action ack (no event field)', function (): void {
+        $frame = json_encode(['status' => 'OK', 'seq_reply' => 1]);
+        expect(EventFactory::fromJson($frame))->toBeNull();
+    });
+
+    it('parses a `posted` event into PostCreated and decodes the nested post', function (): void {
+        $frame = [
+            'event' => 'posted',
+            'data' => [
+                'channel_type' => 'D',
+                'channel_name' => 'lexi__jordan',
+                'sender_name' => '@jordan',
+                'post' => json_encode([
+                    'id' => 'p1',
+                    'channel_id' => 'c1',
+                    'user_id' => 'u1',
+                    'message' => 'hi lexi',
+                    'root_id' => '',
+                ]),
+            ],
+            'broadcast' => ['channel_id' => 'c1'],
+            'seq' => 42,
+        ];
+
+        $event = EventFactory::fromArray($frame);
+
+        expect($event)->toBeInstanceOf(PostCreated::class);
+        expect($event->name())->toBe('posted');
+        expect($event->seq)->toBe(42);
+        expect($event->channelId())->toBe('c1');
+        expect($event->channelType())->toBe('D');
+        expect($event->senderName())->toBe('@jordan');
+        expect($event->userId())->toBe('u1');
+        expect($event->message())->toBe('hi lexi');
+        expect($event->rootId())->toBe('');
+    });
+
+    it('parses a `post_edited` event', function (): void {
+        $frame = [
+            'event' => 'post_edited',
+            'data' => [
+                'post' => json_encode([
+                    'id' => 'p2',
+                    'channel_id' => 'c2',
+                    'user_id' => 'u2',
+                    'message' => 'edited message',
+                ]),
+            ],
+            'broadcast' => [],
+            'seq' => 1,
+        ];
+
+        $event = EventFactory::fromArray($frame);
+
+        expect($event)->toBeInstanceOf(PostEdited::class);
+        expect($event->postId())->toBe('p2');
+        expect($event->channelId())->toBe('c2');
+        expect($event->userId())->toBe('u2');
+        expect($event->message())->toBe('edited message');
+    });
+
+    it('parses a `post_deleted` event', function (): void {
+        $frame = [
+            'event' => 'post_deleted',
+            'data' => [
+                'post' => json_encode([
+                    'id' => 'p3',
+                    'channel_id' => 'c3',
+                    'user_id' => 'u3',
+                ]),
+            ],
+            'broadcast' => [],
+            'seq' => 2,
+        ];
+
+        $event = EventFactory::fromArray($frame);
+
+        expect($event)->toBeInstanceOf(PostDeleted::class);
+        expect($event->postId())->toBe('p3');
+    });
+
+    it('parses a `typing` event with the channel id from broadcast', function (): void {
+        $frame = [
+            'event' => 'typing',
+            'data' => ['user_id' => 'u4', 'parent_id' => ''],
+            'broadcast' => ['channel_id' => 'c4'],
+            'seq' => 3,
+        ];
+
+        $event = EventFactory::fromArray($frame);
+
+        expect($event)->toBeInstanceOf(Typing::class);
+        expect($event->userId())->toBe('u4');
+        expect($event->channelId())->toBe('c4');
+    });
+
+    it('parses `reaction_added` and decodes the nested reaction', function (): void {
+        $frame = [
+            'event' => 'reaction_added',
+            'data' => [
+                'reaction' => json_encode([
+                    'emoji_name' => 'white_check_mark',
+                    'post_id' => 'p5',
+                    'user_id' => 'u5',
+                ]),
+            ],
+            'broadcast' => ['channel_id' => 'c5'],
+            'seq' => 4,
+        ];
+
+        $event = EventFactory::fromArray($frame);
+
+        expect($event)->toBeInstanceOf(ReactionAdded::class);
+        expect($event->emoji())->toBe('white_check_mark');
+        expect($event->postId())->toBe('p5');
+        expect($event->userId())->toBe('u5');
+        expect($event->channelId())->toBe('c5');
+    });
+
+    it('parses `reaction_removed`', function (): void {
+        $frame = [
+            'event' => 'reaction_removed',
+            'data' => [
+                'reaction' => json_encode([
+                    'emoji_name' => '+1',
+                    'post_id' => 'p6',
+                    'user_id' => 'u6',
+                ]),
+            ],
+            'broadcast' => [],
+            'seq' => 5,
+        ];
+
+        $event = EventFactory::fromArray($frame);
+
+        expect($event)->toBeInstanceOf(ReactionRemoved::class);
+        expect($event->emoji())->toBe('+1');
+    });
+
+    it('parses `channel_viewed`', function (): void {
+        $frame = [
+            'event' => 'channel_viewed',
+            'data' => ['channel_id' => 'c7'],
+            'broadcast' => ['user_id' => 'u7'],
+            'seq' => 6,
+        ];
+
+        $event = EventFactory::fromArray($frame);
+
+        expect($event)->toBeInstanceOf(ChannelViewed::class);
+        expect($event->channelId())->toBe('c7');
+        expect($event->userId())->toBe('u7');
+    });
+
+    it('parses `status_change` into UserStatusChanged', function (): void {
+        $frame = [
+            'event' => 'status_change',
+            'data' => ['user_id' => 'u8', 'status' => 'online'],
+            'broadcast' => [],
+            'seq' => 7,
+        ];
+
+        $event = EventFactory::fromArray($frame);
+
+        expect($event)->toBeInstanceOf(UserStatusChanged::class);
+        expect($event->userId())->toBe('u8');
+        expect($event->status())->toBe('online');
+    });
+
+    it('parses `hello`', function (): void {
+        $frame = [
+            'event' => 'hello',
+            'data' => ['server_version' => '9.5.0'],
+            'broadcast' => [],
+            'seq' => 0,
+        ];
+
+        $event = EventFactory::fromArray($frame);
+
+        expect($event)->toBeInstanceOf(Hello::class);
+        expect($event->serverVersion())->toBe('9.5.0');
+    });
+
+    it('falls back to GenericEvent for unknown events', function (): void {
+        $frame = [
+            'event' => 'something_brand_new',
+            'data' => ['foo' => 'bar'],
+            'broadcast' => ['team_id' => 't1'],
+            'seq' => 99,
+        ];
+
+        $event = EventFactory::fromArray($frame);
+
+        expect($event)->toBeInstanceOf(GenericEvent::class);
+        expect($event->name())->toBe('something_brand_new');
+        expect($event->data)->toBe(['foo' => 'bar']);
+        expect($event->broadcast)->toBe(['team_id' => 't1']);
+        expect($event->seq)->toBe(99);
+    });
+
+    it('round-trips fromJson for a real frame string', function (): void {
+        $raw = json_encode([
+            'event' => 'hello',
+            'data' => ['server_version' => '9.5.0'],
+            'broadcast' => [],
+            'seq' => 0,
+        ]);
+
+        expect(EventFactory::fromJson($raw))->toBeInstanceOf(Hello::class);
+    });
+});

--- a/tests/Unit/WebSocket/WebSocketUrlTest.php
+++ b/tests/Unit/WebSocket/WebSocketUrlTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use ConduitUI\Mattermost\WebSocket\WebSocketUrl;
+
+describe('WebSocketUrl', function (): void {
+    it('rewrites http to ws and appends the v4 endpoint', function (): void {
+        expect(WebSocketUrl::fromBaseUrl('http://localhost:8065'))
+            ->toBe('ws://localhost:8065/api/v4/websocket');
+    });
+
+    it('rewrites https to wss', function (): void {
+        expect(WebSocketUrl::fromBaseUrl('https://mattermost.example.com'))
+            ->toBe('wss://mattermost.example.com/api/v4/websocket');
+    });
+
+    it('strips a trailing slash before appending the path', function (): void {
+        expect(WebSocketUrl::fromBaseUrl('https://mm.example.com/'))
+            ->toBe('wss://mm.example.com/api/v4/websocket');
+    });
+
+    it('passes through an already-ws url', function (): void {
+        expect(WebSocketUrl::fromBaseUrl('wss://mm.example.com'))
+            ->toBe('wss://mm.example.com/api/v4/websocket');
+    });
+
+    it('rejects an unsupported scheme', function (): void {
+        WebSocketUrl::fromBaseUrl('ftp://mm.example.com');
+    })->throws(InvalidArgumentException::class);
+
+    it('rejects an empty url', function (): void {
+        WebSocketUrl::fromBaseUrl('');
+    })->throws(InvalidArgumentException::class);
+});


### PR DESCRIPTION
Closes #2.

## Summary

Implements the Mattermost WebSocket client under `src/WebSocket/`:

- `Client` — long-lived loop, auth challenge handshake (`{seq:1, action:authentication_challenge, data:{token}}`), exponential-backoff reconnect (1, 2, 4 ... up to 60s), idempotent reconnect scheduling, heartbeat/ping with dead-man timeout, SIGTERM/SIGINT graceful shutdown, connection state logging.
- `Events/` — typed event value objects: `PostCreated`, `PostEdited`, `PostDeleted`, `Typing`, `ReactionAdded`, `ReactionRemoved`, `ChannelViewed`, `UserStatusChanged`, `Hello`, plus `GenericEvent` fallback. `EventFactory` parses raw frames into the right type and decodes Mattermost's nested-JSON post/reaction strings eagerly.
- `WebSocketUrl` — `http://` → `ws://`, `https://` → `wss://`, appends `/api/v4/websocket`.
- `Backoff` — pure value object with `next()` / `reset()` / `current()`.
- `ConnectionState` — enum used for state-change logging.
- `Contracts\WebSocketConnector` + `PawlConnector` — seam so unit tests can drive the lifecycle without opening real sockets.

## Library choice — ratchet/pawl

The issue asked us to weigh `ratchet/pawl` vs `textalk/websocket`. Picked `ratchet/pawl` (with `react/event-loop`):

- Native event-loop integration means heartbeat, reconnect timers, and signal handling all use the same mechanism — no need to layer a scheduler around blocking I/O.
- `textalk/websocket` is synchronous; getting non-blocking reconnect with ping-pong + signal handling on top of it would mean reinventing the loop layer pawl already gives us.
- Operationally proven in `lexi-agent` (the same connector pattern handles duplicate-session 1000 closes correctly here too — extended hold instead of an instant retry that flaps).

The `WebSocketConnector` contract makes pawl a private detail of the package; we could swap it later without touching the public `Client` API.

## What I did NOT touch

Stayed inside `src/WebSocket/` and `tests/Unit/WebSocket/` per the agent contract — no changes to `Streaming/`, `Messages/`, `Notifications/`, `Testing/`, the auto-generated `Client/`, or docs.

No `src/Client/Requests/...` gaps were hit during this work.

## Test plan

- [x] `vendor/bin/pint --test` clean
- [x] `vendor/bin/phpstan analyse` clean (level 6, scope `src/`)
- [x] `vendor/bin/pest --compact` — 46 passing (33 in `tests/Unit/WebSocket/`)
- [x] `vendor/bin/rector process --dry-run` clean
- [ ] Manual: point a Laravel command at a real Mattermost server, verify auth → posted events → SIGTERM clean shutdown

### Coverage in `tests/Unit/WebSocket/`

- `WebSocketUrlTest` — URL transformation + scheme/empty rejection
- `BackoffTest` — doubling, cap, reset
- `EventFactoryTest` — every typed event + GenericEvent + status/malformed handling
- `ClientTest` — auth challenge frame, listener dispatch (typed + wildcard), throwing-listener resilience, connect-failure backoff, reconnect on close, eviction-delay on server 1000, no-reconnect after `disconnect()`, state-change logging