### PR TITLE
feat: Filament admin panel — status, message log, health

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
     },
     "require-dev": {
         "crescat-io/saloon-sdk-generator": "^1.6",
+        "filament/filament": "^5.4",
         "larastan/larastan": "^3.0",
         "laravel/framework": "^13.0",
         "laravel/pint": "^1.0",

--- a/resources/views/filament/pages/dashboard.blade.php
+++ b/resources/views/filament/pages/dashboard.blade.php
@@ -1,0 +1,6 @@
+<x-filament-panels::page>
+    <x-filament-widgets::widgets
+        :widgets="$this->getHeaderWidgets()"
+        :columns="$this->getHeaderWidgetsColumns()"
+    />
+</x-filament-panels::page>

--- a/resources/views/filament/pages/health.blade.php
+++ b/resources/views/filament/pages/health.blade.php
@@ -1,0 +1,81 @@
+<x-filament-panels::page>
+    <div class="space-y-6">
+        <section>
+            <h2 class="text-lg font-semibold">API connectivity</h2>
+            <dl class="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-3">
+                <div class="rounded-lg border border-gray-200 p-4">
+                    <dt class="text-xs uppercase text-gray-500">Reachable</dt>
+                    <dd class="mt-1 text-sm">{{ $api['reachable'] ? 'Yes' : 'No' }}</dd>
+                </div>
+                <div class="rounded-lg border border-gray-200 p-4">
+                    <dt class="text-xs uppercase text-gray-500">Latency</dt>
+                    <dd class="mt-1 text-sm">{{ $api['latency_ms'] !== null ? $api['latency_ms'].' ms' : '—' }}</dd>
+                </div>
+                <div class="rounded-lg border border-gray-200 p-4">
+                    <dt class="text-xs uppercase text-gray-500">HTTP status</dt>
+                    <dd class="mt-1 text-sm">{{ $api['status'] ?? '—' }}</dd>
+                </div>
+            </dl>
+            @if ($api['error'])
+                <p class="mt-2 text-sm text-red-600">{{ $api['error'] }}</p>
+            @endif
+        </section>
+
+        <section>
+            <h2 class="text-lg font-semibold">WebSocket</h2>
+            <p class="mt-1 text-sm">State: <span class="font-mono">{{ $webSocketState->value }}</span></p>
+        </section>
+
+        <section>
+            <h2 class="text-lg font-semibold">Bot identity</h2>
+            @if ($identity['ok'])
+                <dl class="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-3">
+                    <div class="rounded-lg border border-gray-200 p-4">
+                        <dt class="text-xs uppercase text-gray-500">Username</dt>
+                        <dd class="mt-1 text-sm">@{{ $identity['username'] }}</dd>
+                    </div>
+                    <div class="rounded-lg border border-gray-200 p-4">
+                        <dt class="text-xs uppercase text-gray-500">User ID</dt>
+                        <dd class="mt-1 font-mono text-xs">{{ $identity['id'] }}</dd>
+                    </div>
+                    <div class="rounded-lg border border-gray-200 p-4">
+                        <dt class="text-xs uppercase text-gray-500">Roles</dt>
+                        <dd class="mt-1 font-mono text-xs">{{ $identity['roles'] ?? '—' }}</dd>
+                    </div>
+                </dl>
+            @else
+                <p class="mt-1 text-sm text-red-600">Bot identity unavailable.</p>
+            @endif
+        </section>
+
+        <section>
+            <h2 class="text-lg font-semibold">Channel memberships</h2>
+            @if (empty($channels))
+                <p class="mt-1 text-sm text-gray-500">No channels listed (bot may not be a member of any channel, or the API call failed).</p>
+            @else
+                <div class="mt-2 overflow-x-auto rounded-lg border border-gray-200">
+                    <table class="min-w-full divide-y divide-gray-200 text-sm">
+                        <thead class="bg-gray-50">
+                            <tr>
+                                <th class="px-4 py-2 text-left font-medium">Display name</th>
+                                <th class="px-4 py-2 text-left font-medium">Name</th>
+                                <th class="px-4 py-2 text-left font-medium">Type</th>
+                                <th class="px-4 py-2 text-left font-medium">ID</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-gray-100 bg-white">
+                            @foreach ($channels as $channel)
+                                <tr>
+                                    <td class="px-4 py-2">{{ $channel['display_name'] ?: '—' }}</td>
+                                    <td class="px-4 py-2 font-mono text-xs">{{ $channel['name'] }}</td>
+                                    <td class="px-4 py-2 font-mono text-xs">{{ $channel['type'] }}</td>
+                                    <td class="px-4 py-2 font-mono text-xs">{{ $channel['id'] }}</td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            @endif
+        </section>
+    </div>
+</x-filament-panels::page>

--- a/resources/views/filament/pages/health.blade.php
+++ b/resources/views/filament/pages/health.blade.php
@@ -32,7 +32,7 @@
                 <dl class="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-3">
                     <div class="rounded-lg border border-gray-200 p-4">
                         <dt class="text-xs uppercase text-gray-500">Username</dt>
-                        <dd class="mt-1 text-sm">@{{ $identity['username'] }}</dd>
+                        <dd class="mt-1 text-sm">{{ $identity['username'] }}</dd>
                     </div>
                     <div class="rounded-lg border border-gray-200 p-4">
                         <dt class="text-xs uppercase text-gray-500">User ID</dt>
@@ -67,9 +67,9 @@
                             @foreach ($channels as $channel)
                                 <tr>
                                     <td class="px-4 py-2">{{ $channel['display_name'] ?: '—' }}</td>
-                                    <td class="px-4 py-2 font-mono text-xs">{{ $channel['name'] }}</td>
-                                    <td class="px-4 py-2 font-mono text-xs">{{ $channel['type'] }}</td>
-                                    <td class="px-4 py-2 font-mono text-xs">{{ $channel['id'] }}</td>
+                                    <td class="px-4 py-2 font-mono text-xs">{{ $channel['name'] ?: '—' }}</td>
+                                    <td class="px-4 py-2 font-mono text-xs">{{ $channel['type'] ?: '—' }}</td>
+                                    <td class="px-4 py-2 font-mono text-xs">{{ $channel['id'] ?: '—' }}</td>
                                 </tr>
                             @endforeach
                         </tbody>

--- a/resources/views/filament/pages/message-log.blade.php
+++ b/resources/views/filament/pages/message-log.blade.php
@@ -1,0 +1,58 @@
+<x-filament-panels::page>
+    <div class="space-y-4">
+        <div class="flex flex-col gap-3 sm:flex-row sm:items-end">
+            <div class="flex-1">
+                <label for="channelId" class="fi-fo-field-wrp-label">Channel ID</label>
+                <input
+                    id="channelId"
+                    type="text"
+                    wire:model.live.debounce.500ms="channelId"
+                    placeholder="Watched channel ID"
+                    class="fi-input block w-full rounded-lg border-gray-300 shadow-sm"
+                />
+            </div>
+            <div class="flex-1">
+                <label for="sinceDate" class="fi-fo-field-wrp-label">Since (date)</label>
+                <input
+                    id="sinceDate"
+                    type="date"
+                    wire:model.live="sinceDate"
+                    class="fi-input block w-full rounded-lg border-gray-300 shadow-sm"
+                />
+            </div>
+        </div>
+
+        @if (empty($messages))
+            <div class="rounded-lg border border-dashed border-gray-300 p-6 text-center text-sm text-gray-500">
+                @if (! $channelId)
+                    No watch channel configured. Set <code>config('mattermost.filament.watch_channel_id')</code> or paste a channel ID above.
+                @else
+                    No messages found for this channel.
+                @endif
+            </div>
+        @else
+            <div class="overflow-x-auto rounded-lg border border-gray-200">
+                <table class="min-w-full divide-y divide-gray-200 text-sm">
+                    <thead class="bg-gray-50">
+                        <tr>
+                            <th class="px-4 py-2 text-left font-medium">Time (UTC)</th>
+                            <th class="px-4 py-2 text-left font-medium">User</th>
+                            <th class="px-4 py-2 text-left font-medium">Message</th>
+                            <th class="px-4 py-2 text-left font-medium">Thread</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-gray-100 bg-white">
+                        @foreach ($messages as $message)
+                            <tr>
+                                <td class="px-4 py-2 align-top font-mono text-xs">{{ $message['created_at_iso'] }}</td>
+                                <td class="px-4 py-2 align-top font-mono text-xs">{{ $message['user_id'] }}</td>
+                                <td class="px-4 py-2 align-top">{{ $message['message'] }}</td>
+                                <td class="px-4 py-2 align-top font-mono text-xs">{{ $message['root_id'] ?: '—' }}</td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        @endif
+    </div>
+</x-filament-panels::page>

--- a/src/Filament/MattermostPlugin.php
+++ b/src/Filament/MattermostPlugin.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\Filament;
+
+use ConduitUI\Mattermost\Filament\Pages\Dashboard;
+use ConduitUI\Mattermost\Filament\Pages\Health;
+use ConduitUI\Mattermost\Filament\Pages\MessageLog;
+use ConduitUI\Mattermost\Filament\Widgets\ConnectionStatusWidget;
+use Filament\Contracts\Plugin;
+use Filament\Panel;
+
+/**
+ * Filament plugin that registers the Mattermost dashboard, message log and
+ * health pages plus the connection status widget on a target panel.
+ *
+ * Usage:
+ *
+ *     $panel->plugin(\ConduitUI\Mattermost\Filament\MattermostPlugin::make());
+ *
+ * The plugin is opt-in to keep panel registration explicit — pages are NOT
+ * auto-discovered onto every installed panel. This avoids surprising operators
+ * who have multiple panels.
+ */
+class MattermostPlugin implements Plugin
+{
+    public static function make(): self
+    {
+        return new self;
+    }
+
+    public function getId(): string
+    {
+        return 'mattermost';
+    }
+
+    public function register(Panel $panel): void
+    {
+        $panel
+            ->pages([
+                Dashboard::class,
+                MessageLog::class,
+                Health::class,
+            ])
+            ->widgets([
+                ConnectionStatusWidget::class,
+            ]);
+    }
+
+    public function boot(Panel $panel): void
+    {
+        // No runtime boot work needed — pages and widgets are stateless and
+        // resolve their dependencies via the container at render time.
+    }
+}

--- a/src/Filament/Pages/Dashboard.php
+++ b/src/Filament/Pages/Dashboard.php
@@ -42,6 +42,6 @@ class Dashboard extends Page
     #[\Override]
     public function getHeaderWidgetsColumns(): int|array
     {
-        return 4;
+        return 1;
     }
 }

--- a/src/Filament/Pages/Dashboard.php
+++ b/src/Filament/Pages/Dashboard.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\Filament\Pages;
+
+use BackedEnum;
+use ConduitUI\Mattermost\Filament\Widgets\ConnectionStatusWidget;
+use Filament\Pages\Page;
+use Filament\Support\Icons\Heroicon;
+use Filament\Widgets\Widget;
+use Filament\Widgets\WidgetConfiguration;
+
+/**
+ * Top-level Mattermost dashboard. Hosts the {@see ConnectionStatusWidget}
+ * in the header so panel users see connection / uptime / volume at a glance
+ * without depending on Filament's built-in dashboard slot.
+ */
+class Dashboard extends Page
+{
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::Bolt;
+
+    protected static ?string $navigationLabel = 'Dashboard';
+
+    protected static ?string $title = 'Mattermost';
+
+    protected static ?int $navigationSort = 10;
+
+    protected string $view = 'mattermost::filament.pages.dashboard';
+
+    /**
+     * @return array<int, class-string<Widget> | WidgetConfiguration>
+     */
+    #[\Override]
+    public function getHeaderWidgets(): array
+    {
+        return [
+            ConnectionStatusWidget::class,
+        ];
+    }
+
+    #[\Override]
+    public function getHeaderWidgetsColumns(): int|array
+    {
+        return 4;
+    }
+}

--- a/src/Filament/Pages/Health.php
+++ b/src/Filament/Pages/Health.php
@@ -92,11 +92,12 @@ class Health extends Page
     }
 
     /**
+     * @param  array<string, mixed>|null  $identity  Pre-resolved identity from getViewData() to avoid re-fetching /users/me.
      * @return array<int, array<string, mixed>>
      */
-    public function getChannelMemberships(): array
+    public function getChannelMemberships(?array $identity = null): array
     {
-        $identity = $this->getBotIdentity();
+        $identity ??= $this->getBotIdentity();
         $userId = $identity['id'] ?? null;
 
         if (! is_string($userId) || $userId === '') {
@@ -133,11 +134,13 @@ class Health extends Page
     #[\Override]
     protected function getViewData(): array
     {
+        $identity = $this->getBotIdentity();
+
         return [
             'api' => $this->getApiHealth(),
             'webSocketState' => $this->getWebSocketState(),
-            'identity' => $this->getBotIdentity(),
-            'channels' => $this->getChannelMemberships(),
+            'identity' => $identity,
+            'channels' => $this->getChannelMemberships($identity),
         ];
     }
 

--- a/src/Filament/Pages/Health.php
+++ b/src/Filament/Pages/Health.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\Filament\Pages;
+
+use BackedEnum;
+use ConduitUI\Mattermost\Client\Mattermost;
+use ConduitUI\Mattermost\Filament\Stats\MattermostStats;
+use ConduitUI\Mattermost\MattermostManager;
+use ConduitUI\Mattermost\WebSocket\ConnectionState;
+use Filament\Pages\Page;
+use Filament\Support\Icons\Heroicon;
+use Throwable;
+
+/**
+ * Live health snapshot for an operator: API reachability + latency, the
+ * WebSocket lifecycle state from {@see MattermostStats}, and a quick
+ * channel-membership listing for the bot user.
+ *
+ * Every probe is wrapped in try/catch — when the server is offline the
+ * page still renders, just with red "unreachable" rows.
+ */
+class Health extends Page
+{
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::Heart;
+
+    protected static ?string $navigationLabel = 'Health';
+
+    protected static ?string $title = 'Bot health';
+
+    protected static ?int $navigationSort = 30;
+
+    protected string $view = 'mattermost::filament.pages.health';
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getApiHealth(): array
+    {
+        $start = microtime(true);
+
+        try {
+            $response = $this->mattermost()->system()->getPing();
+            $latencyMs = (int) round((microtime(true) - $start) * 1000);
+
+            return [
+                'reachable' => $response->successful(),
+                'latency_ms' => $latencyMs,
+                'status' => $response->status(),
+                'error' => null,
+            ];
+        } catch (Throwable $e) {
+            return [
+                'reachable' => false,
+                'latency_ms' => null,
+                'status' => null,
+                'error' => $e->getMessage(),
+            ];
+        }
+    }
+
+    public function getWebSocketState(): ConnectionState
+    {
+        return $this->stats()->connectionState();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getBotIdentity(): array
+    {
+        try {
+            $response = $this->mattermost()->users()->getUser('me');
+
+            if (! $response->successful()) {
+                return ['ok' => false, 'id' => null, 'username' => null, 'roles' => null];
+            }
+
+            /** @var array<string, mixed> $data */
+            $data = $response->json();
+
+            return [
+                'ok' => true,
+                'id' => is_string($data['id'] ?? null) ? $data['id'] : null,
+                'username' => is_string($data['username'] ?? null) ? $data['username'] : null,
+                'roles' => is_string($data['roles'] ?? null) ? $data['roles'] : null,
+            ];
+        } catch (Throwable) {
+            return ['ok' => false, 'id' => null, 'username' => null, 'roles' => null];
+        }
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function getChannelMemberships(): array
+    {
+        $identity = $this->getBotIdentity();
+        $userId = $identity['id'] ?? null;
+
+        if (! is_string($userId) || $userId === '') {
+            return [];
+        }
+
+        try {
+            $response = $this->mattermost()->channels()->getChannelsForUser($userId);
+
+            if (! $response->successful()) {
+                return [];
+            }
+
+            /** @var array<int, array<string, mixed>> $channels */
+            $channels = $response->json();
+
+            return array_values(array_map(
+                fn (array $channel): array => [
+                    'id' => is_string($channel['id'] ?? null) ? $channel['id'] : '',
+                    'name' => is_string($channel['name'] ?? null) ? $channel['name'] : '',
+                    'display_name' => is_string($channel['display_name'] ?? null) ? $channel['display_name'] : '',
+                    'type' => is_string($channel['type'] ?? null) ? $channel['type'] : '',
+                ],
+                $channels,
+            ));
+        } catch (Throwable) {
+            return [];
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    #[\Override]
+    protected function getViewData(): array
+    {
+        return [
+            'api' => $this->getApiHealth(),
+            'webSocketState' => $this->getWebSocketState(),
+            'identity' => $this->getBotIdentity(),
+            'channels' => $this->getChannelMemberships(),
+        ];
+    }
+
+    private function mattermost(): Mattermost
+    {
+        return app(MattermostManager::class)->connection();
+    }
+
+    private function stats(): MattermostStats
+    {
+        return app(MattermostStats::class);
+    }
+}

--- a/src/Filament/Pages/MessageLog.php
+++ b/src/Filament/Pages/MessageLog.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\Filament\Pages;
+
+use BackedEnum;
+use ConduitUI\Mattermost\Client\Mattermost;
+use ConduitUI\Mattermost\MattermostManager;
+use Filament\Pages\Page;
+use Filament\Support\Icons\Heroicon;
+use Throwable;
+
+/**
+ * Read-only log of recent posts the bot can see in a watched channel.
+ *
+ * The bot framework (issue #4) does not yet have a backing store, so this
+ * page intentionally pulls live posts from the configured "watch" channel
+ * via the Saloon client. When no channel is configured, the page renders
+ * an empty state with guidance.
+ *
+ * Filters: a `channel` query string lets the user override the watch channel
+ * at runtime; date filters happen client-side on the rendered list.
+ */
+class MessageLog extends Page
+{
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::ChatBubbleBottomCenterText;
+
+    protected static ?string $navigationLabel = 'Message log';
+
+    protected static ?string $title = 'Message log';
+
+    protected static ?int $navigationSort = 20;
+
+    protected string $view = 'mattermost::filament.pages.message-log';
+
+    public ?string $channelId = null;
+
+    public ?string $sinceDate = null;
+
+    public function mount(): void
+    {
+        $this->channelId ??= self::defaultChannelId();
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    #[\Override]
+    public function getMessages(): array
+    {
+        if (! is_string($this->channelId) || $this->channelId === '') {
+            return [];
+        }
+
+        try {
+            $response = $this->mattermost()->posts()->getPostsForChannel($this->channelId);
+
+            if (! $response->successful()) {
+                return [];
+            }
+
+            /** @var array<string, mixed> $payload */
+            $payload = $response->json();
+            /** @var array<int, string> $order */
+            $order = is_array($payload['order'] ?? null) ? $payload['order'] : [];
+            /** @var array<string, array<string, mixed>> $posts */
+            $posts = is_array($payload['posts'] ?? null) ? $payload['posts'] : [];
+
+            $messages = [];
+
+            foreach ($order as $postId) {
+                $post = $posts[$postId] ?? null;
+
+                if (! is_array($post)) {
+                    continue;
+                }
+
+                if ($this->isFilteredOut($post)) {
+                    continue;
+                }
+
+                $messages[] = $this->normalizePost($post);
+            }
+
+            return $messages;
+        } catch (Throwable) {
+            return [];
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    #[\Override]
+    protected function getViewData(): array
+    {
+        return [
+            'messages' => $this->getMessages(),
+            'channelId' => $this->channelId,
+            'sinceDate' => $this->sinceDate,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $post
+     * @return array<string, mixed>
+     */
+    private function normalizePost(array $post): array
+    {
+        $createAt = is_int($post['create_at'] ?? null) ? $post['create_at'] : 0;
+
+        return [
+            'id' => is_string($post['id'] ?? null) ? $post['id'] : '',
+            'channel_id' => is_string($post['channel_id'] ?? null) ? $post['channel_id'] : '',
+            'user_id' => is_string($post['user_id'] ?? null) ? $post['user_id'] : '',
+            'message' => is_string($post['message'] ?? null) ? $post['message'] : '',
+            'root_id' => is_string($post['root_id'] ?? null) ? $post['root_id'] : '',
+            'created_at_ms' => $createAt,
+            'created_at_iso' => $createAt > 0 ? gmdate('c', intdiv($createAt, 1000)) : '',
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $post
+     */
+    private function isFilteredOut(array $post): bool
+    {
+        if ($this->sinceDate === null || $this->sinceDate === '') {
+            return false;
+        }
+
+        $cutoff = strtotime($this->sinceDate);
+
+        if ($cutoff === false) {
+            return false;
+        }
+
+        $createAt = is_int($post['create_at'] ?? null) ? intdiv($post['create_at'], 1000) : 0;
+
+        return $createAt < $cutoff;
+    }
+
+    private function mattermost(): Mattermost
+    {
+        return app(MattermostManager::class)->connection();
+    }
+
+    public static function defaultChannelId(): ?string
+    {
+        $value = config('mattermost.filament.watch_channel_id');
+
+        return is_string($value) && $value !== '' ? $value : null;
+    }
+}

--- a/src/Filament/Stats/MattermostStats.php
+++ b/src/Filament/Stats/MattermostStats.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\Filament\Stats;
+
+use ConduitUI\Mattermost\WebSocket\ConnectionState;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
+
+/**
+ * Cache-backed runtime stats for the Mattermost bot.
+ *
+ * Acts as a lightweight write/read seam between the bot framework / WS client
+ * (which push live data) and Filament pages (which read it). Uses the cache
+ * store so it works across long-running listener processes and short-lived
+ * web requests in the same way.
+ *
+ * The bot framework (issue #4) is expected to call:
+ *   - markConnected() / markDisconnected() / markReconnecting() on WS state changes
+ *   - incrementMessagesProcessed() each time a handler dispatches
+ *   - markStarted() once on listener boot (sets the uptime anchor)
+ *
+ * Pages always work even when no stats have been written (returns sensible defaults).
+ */
+class MattermostStats
+{
+    private const string CACHE_PREFIX = 'mattermost.stats.';
+
+    private const int TTL_SECONDS = 86400;
+
+    public function __construct(
+        private readonly CacheRepository $cache,
+        private readonly string $connection = 'default',
+    ) {}
+
+    public function connectionState(): ConnectionState
+    {
+        $value = $this->cache->get($this->key('state'));
+
+        if (is_string($value)) {
+            return ConnectionState::tryFrom($value) ?? ConnectionState::Disconnected;
+        }
+
+        return ConnectionState::Disconnected;
+    }
+
+    public function setConnectionState(ConnectionState $state): void
+    {
+        $this->cache->put($this->key('state'), $state->value, self::TTL_SECONDS);
+    }
+
+    public function markConnected(): void
+    {
+        $this->setConnectionState(ConnectionState::Connected);
+    }
+
+    public function markDisconnected(): void
+    {
+        $this->setConnectionState(ConnectionState::Disconnected);
+    }
+
+    public function markReconnecting(): void
+    {
+        $this->setConnectionState(ConnectionState::Reconnecting);
+    }
+
+    public function startedAt(): ?int
+    {
+        $value = $this->cache->get($this->key('started_at'));
+
+        return is_int($value) ? $value : null;
+    }
+
+    public function markStarted(?int $timestamp = null): void
+    {
+        $this->cache->put(
+            $this->key('started_at'),
+            $timestamp ?? time(),
+            self::TTL_SECONDS,
+        );
+    }
+
+    public function uptimeSeconds(): ?int
+    {
+        $startedAt = $this->startedAt();
+
+        if ($startedAt === null) {
+            return null;
+        }
+
+        return max(0, time() - $startedAt);
+    }
+
+    public function messagesProcessed(): int
+    {
+        $value = $this->cache->get($this->key('messages_processed'), 0);
+
+        return is_int($value) ? $value : 0;
+    }
+
+    public function incrementMessagesProcessed(int $by = 1): int
+    {
+        $current = $this->messagesProcessed();
+        $next = $current + $by;
+        $this->cache->put($this->key('messages_processed'), $next, self::TTL_SECONDS);
+
+        return $next;
+    }
+
+    public function reset(): void
+    {
+        foreach (['state', 'started_at', 'messages_processed'] as $suffix) {
+            $this->cache->forget($this->key($suffix));
+        }
+    }
+
+    public function connection(): string
+    {
+        return $this->connection;
+    }
+
+    private function key(string $suffix): string
+    {
+        return self::CACHE_PREFIX.$this->connection.'.'.$suffix;
+    }
+}

--- a/src/Filament/Widgets/ConnectionStatusWidget.php
+++ b/src/Filament/Widgets/ConnectionStatusWidget.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\Filament\Widgets;
+
+use ConduitUI\Mattermost\Client\Mattermost;
+use ConduitUI\Mattermost\Filament\Stats\MattermostStats;
+use ConduitUI\Mattermost\MattermostManager;
+use ConduitUI\Mattermost\WebSocket\ConnectionState;
+use Filament\Support\Icons\Heroicon;
+use Filament\Widgets\StatsOverviewWidget;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+use Throwable;
+
+/**
+ * Dashboard widget summarising connection status, bot identity,
+ * uptime and messages processed.
+ *
+ * Reads from the cache-backed {@see MattermostStats} for runtime metrics
+ * (populated by the WS client / bot framework) and from the Saloon API
+ * for bot user info. API calls are best-effort and never throw — the widget
+ * stays usable when the server is unreachable.
+ */
+class ConnectionStatusWidget extends StatsOverviewWidget
+{
+    protected ?string $heading = 'Mattermost bot';
+
+    /**
+     * @return array<int, Stat>
+     */
+    #[\Override]
+    protected function getStats(): array
+    {
+        $stats = $this->mattermostStats();
+
+        return [
+            $this->buildConnectionStat($stats->connectionState()),
+            $this->buildBotIdentityStat(),
+            $this->buildUptimeStat($stats->uptimeSeconds()),
+            $this->buildMessagesProcessedStat($stats->messagesProcessed()),
+        ];
+    }
+
+    private function buildConnectionStat(ConnectionState $state): Stat
+    {
+        return Stat::make('Connection', ucfirst($state->value))
+            ->description($this->descriptionForState($state))
+            ->descriptionIcon($this->iconForState($state))
+            ->color($this->colorForState($state));
+    }
+
+    private function buildBotIdentityStat(): Stat
+    {
+        $username = '—';
+        $description = 'Bot identity unavailable';
+
+        try {
+            $response = $this->mattermost()->users()->getUser('me');
+
+            if ($response->successful()) {
+                /** @var array<string, mixed> $data */
+                $data = $response->json();
+                $username = is_string($data['username'] ?? null) ? '@'.$data['username'] : '—';
+                $description = is_string($data['id'] ?? null) ? $data['id'] : 'Bot identity unavailable';
+            }
+        } catch (Throwable) {
+            // Best-effort: server may be unreachable. Leave defaults.
+        }
+
+        return Stat::make('Bot user', $username)
+            ->description($description)
+            ->descriptionIcon(Heroicon::User)
+            ->color('gray');
+    }
+
+    private function buildUptimeStat(?int $seconds): Stat
+    {
+        return Stat::make('Uptime', self::formatUptime($seconds))
+            ->description($seconds === null ? 'Listener has not booted' : 'Since last restart')
+            ->descriptionIcon(Heroicon::Clock)
+            ->color($seconds === null ? 'gray' : 'success');
+    }
+
+    private function buildMessagesProcessedStat(int $count): Stat
+    {
+        return Stat::make('Messages processed', number_format($count))
+            ->description('Since last restart')
+            ->descriptionIcon(Heroicon::ChatBubbleBottomCenterText)
+            ->color('info');
+    }
+
+    private function mattermostStats(): MattermostStats
+    {
+        return app(MattermostStats::class);
+    }
+
+    private function mattermost(): Mattermost
+    {
+        return app(MattermostManager::class)->connection();
+    }
+
+    public static function formatUptime(?int $seconds): string
+    {
+        if ($seconds === null) {
+            return '—';
+        }
+
+        if ($seconds < 60) {
+            return $seconds.'s';
+        }
+
+        $minutes = intdiv($seconds, 60);
+
+        if ($minutes < 60) {
+            return $minutes.'m';
+        }
+
+        $hours = intdiv($minutes, 60);
+        $remainingMinutes = $minutes % 60;
+
+        if ($hours < 24) {
+            return $remainingMinutes > 0
+                ? sprintf('%dh %dm', $hours, $remainingMinutes)
+                : sprintf('%dh', $hours);
+        }
+
+        $days = intdiv($hours, 24);
+        $remainingHours = $hours % 24;
+
+        return $remainingHours > 0
+            ? sprintf('%dd %dh', $days, $remainingHours)
+            : sprintf('%dd', $days);
+    }
+
+    private function descriptionForState(ConnectionState $state): string
+    {
+        return match ($state) {
+            ConnectionState::Connected => 'Live WebSocket session',
+            ConnectionState::Connecting => 'Negotiating connection',
+            ConnectionState::Authenticating => 'Authenticating bot token',
+            ConnectionState::Reconnecting => 'Recovering after drop',
+            ConnectionState::Closing => 'Closing connection',
+            ConnectionState::Disconnected => 'No active session',
+        };
+    }
+
+    private function colorForState(ConnectionState $state): string
+    {
+        return match ($state) {
+            ConnectionState::Connected => 'success',
+            ConnectionState::Connecting, ConnectionState::Authenticating, ConnectionState::Reconnecting => 'warning',
+            ConnectionState::Closing, ConnectionState::Disconnected => 'danger',
+        };
+    }
+
+    private function iconForState(ConnectionState $state): Heroicon
+    {
+        return match ($state) {
+            ConnectionState::Connected => Heroicon::CheckCircle,
+            ConnectionState::Connecting, ConnectionState::Authenticating, ConnectionState::Reconnecting => Heroicon::ArrowPath,
+            ConnectionState::Closing, ConnectionState::Disconnected => Heroicon::XCircle,
+        };
+    }
+}

--- a/src/MattermostServiceProvider.php
+++ b/src/MattermostServiceProvider.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace ConduitUI\Mattermost;
 
+use ConduitUI\Mattermost\Filament\Stats\MattermostStats;
 use ConduitUI\Mattermost\Notifications\MattermostBroadcaster;
+use Filament\Panel;
 use Illuminate\Contracts\Broadcasting\Factory as BroadcastFactory;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
 use Illuminate\Support\ServiceProvider;
 
 class MattermostServiceProvider extends ServiceProvider
@@ -16,6 +19,11 @@ class MattermostServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(__DIR__.'/../config/mattermost.php', 'mattermost');
 
         $this->app->scoped(MattermostManager::class);
+
+        $this->app->singleton(MattermostStats::class, fn ($app): MattermostStats => new MattermostStats(
+            $app->make(CacheRepository::class),
+            (string) ($app['config']->get('mattermost.default') ?? 'default'),
+        ));
     }
 
     public function boot(): void
@@ -27,6 +35,7 @@ class MattermostServiceProvider extends ServiceProvider
         }
 
         $this->registerBroadcaster();
+        $this->bootFilamentPanel();
     }
 
     private function registerBroadcaster(): void
@@ -42,5 +51,21 @@ class MattermostServiceProvider extends ServiceProvider
             $app->make(MattermostManager::class),
             $config['connection'] ?? null,
         ));
+    }
+
+    /**
+     * Register Filament views when Filament is installed in the host application.
+     *
+     * The check is intentionally narrow — `class_exists(\Filament\Panel::class)`
+     * — so the package never hard-depends on Filament. When Filament is
+     * absent, this method short-circuits and the panel pages remain inert.
+     */
+    private function bootFilamentPanel(): void
+    {
+        if (! class_exists(Panel::class)) {
+            return;
+        }
+
+        $this->loadViewsFrom(__DIR__.'/../resources/views', 'mattermost');
     }
 }

--- a/tests/Unit/Filament/MattermostPluginTest.php
+++ b/tests/Unit/Filament/MattermostPluginTest.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use ConduitUI\Mattermost\Filament\MattermostPlugin;
+
+describe('MattermostPlugin', function (): void {
+    it('exposes a stable plugin id', function (): void {
+        expect(MattermostPlugin::make()->getId())->toBe('mattermost');
+    });
+
+    it('is constructible via static make()', function (): void {
+        expect(MattermostPlugin::make())->toBeInstanceOf(MattermostPlugin::class);
+    });
+});

--- a/tests/Unit/Filament/Pages/MessageLogTest.php
+++ b/tests/Unit/Filament/Pages/MessageLogTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use ConduitUI\Mattermost\Filament\Pages\MessageLog;
+
+describe('MessageLog page', function (): void {
+    it('returns null watch channel when no config is set', function (): void {
+        config()->set('mattermost.filament.watch_channel_id', null);
+
+        expect(MessageLog::defaultChannelId())->toBeNull();
+    });
+
+    it('returns the configured watch channel id', function (): void {
+        config()->set('mattermost.filament.watch_channel_id', 'chan-abc');
+
+        expect(MessageLog::defaultChannelId())->toBe('chan-abc');
+    });
+
+    it('returns null when the configured channel id is an empty string', function (): void {
+        config()->set('mattermost.filament.watch_channel_id', '');
+
+        expect(MessageLog::defaultChannelId())->toBeNull();
+    });
+});

--- a/tests/Unit/Filament/ServiceProviderFilamentBootTest.php
+++ b/tests/Unit/Filament/ServiceProviderFilamentBootTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use ConduitUI\Mattermost\Filament\Stats\MattermostStats;
+use ConduitUI\Mattermost\WebSocket\ConnectionState;
+
+describe('MattermostServiceProvider Filament boot', function (): void {
+    it('boots cleanly even when Filament views are loaded', function (): void {
+        // Provider is already booted by the test harness; just assert no
+        // errors were thrown and the singleton stats binding is wired up.
+        expect(app(MattermostStats::class))->toBeInstanceOf(MattermostStats::class);
+    });
+
+    it('binds MattermostStats as a singleton', function (): void {
+        expect(app(MattermostStats::class))->toBe(app(MattermostStats::class));
+    });
+
+    it('exposes a working stats writer that survives across resolutions', function (): void {
+        $stats = app(MattermostStats::class);
+        $stats->markConnected();
+
+        expect(app(MattermostStats::class)->connectionState())->toBe(ConnectionState::Connected);
+    });
+
+    it('reads the connection name from config when constructing stats', function (): void {
+        // Default test config sets mattermost.default = 'default'
+        expect(app(MattermostStats::class)->connection())->toBe('default');
+    });
+});

--- a/tests/Unit/Filament/Stats/MattermostStatsTest.php
+++ b/tests/Unit/Filament/Stats/MattermostStatsTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+use ConduitUI\Mattermost\Filament\Stats\MattermostStats;
+use ConduitUI\Mattermost\WebSocket\ConnectionState;
+use Illuminate\Cache\ArrayStore;
+use Illuminate\Cache\Repository;
+
+function makeStats(string $connection = 'default'): MattermostStats
+{
+    return new MattermostStats(new Repository(new ArrayStore), $connection);
+}
+
+describe('MattermostStats', function (): void {
+    it('defaults to disconnected when no state has been written', function (): void {
+        expect(makeStats()->connectionState())->toBe(ConnectionState::Disconnected);
+    });
+
+    it('round-trips connection state through cache', function (): void {
+        $stats = makeStats();
+
+        $stats->setConnectionState(ConnectionState::Connected);
+
+        expect($stats->connectionState())->toBe(ConnectionState::Connected);
+    });
+
+    it('exposes mark helpers for the common transitions', function (): void {
+        $stats = makeStats();
+
+        $stats->markConnected();
+        expect($stats->connectionState())->toBe(ConnectionState::Connected);
+
+        $stats->markReconnecting();
+        expect($stats->connectionState())->toBe(ConnectionState::Reconnecting);
+
+        $stats->markDisconnected();
+        expect($stats->connectionState())->toBe(ConnectionState::Disconnected);
+    });
+
+    it('tracks uptime relative to markStarted timestamp', function (): void {
+        $stats = makeStats();
+
+        expect($stats->uptimeSeconds())->toBeNull();
+
+        $stats->markStarted(time() - 90);
+
+        expect($stats->uptimeSeconds())->toBeGreaterThanOrEqual(90)
+            ->and($stats->uptimeSeconds())->toBeLessThan(120);
+    });
+
+    it('increments and reads the messages-processed counter', function (): void {
+        $stats = makeStats();
+
+        expect($stats->messagesProcessed())->toBe(0);
+
+        $stats->incrementMessagesProcessed();
+        $stats->incrementMessagesProcessed(4);
+
+        expect($stats->messagesProcessed())->toBe(5);
+    });
+
+    it('isolates state per connection name', function (): void {
+        $shared = new Repository(new ArrayStore);
+        $a = new MattermostStats($shared, 'a');
+        $b = new MattermostStats($shared, 'b');
+
+        $a->markConnected();
+        $a->incrementMessagesProcessed(3);
+
+        expect($b->connectionState())->toBe(ConnectionState::Disconnected)
+            ->and($b->messagesProcessed())->toBe(0)
+            ->and($a->connectionState())->toBe(ConnectionState::Connected)
+            ->and($a->messagesProcessed())->toBe(3);
+    });
+
+    it('clears all keys via reset', function (): void {
+        $stats = makeStats();
+
+        $stats->markConnected();
+        $stats->markStarted();
+        $stats->incrementMessagesProcessed(10);
+
+        $stats->reset();
+
+        expect($stats->connectionState())->toBe(ConnectionState::Disconnected)
+            ->and($stats->startedAt())->toBeNull()
+            ->and($stats->messagesProcessed())->toBe(0);
+    });
+});

--- a/tests/Unit/Filament/Widgets/ConnectionStatusWidgetTest.php
+++ b/tests/Unit/Filament/Widgets/ConnectionStatusWidgetTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use ConduitUI\Mattermost\Filament\Widgets\ConnectionStatusWidget;
+
+describe('ConnectionStatusWidget::formatUptime', function (): void {
+    it('returns an em dash when uptime is null', function (): void {
+        expect(ConnectionStatusWidget::formatUptime(null))->toBe('—');
+    });
+
+    it('formats sub-minute durations in seconds', function (): void {
+        expect(ConnectionStatusWidget::formatUptime(0))->toBe('0s')
+            ->and(ConnectionStatusWidget::formatUptime(45))->toBe('45s');
+    });
+
+    it('formats sub-hour durations in minutes', function (): void {
+        expect(ConnectionStatusWidget::formatUptime(60))->toBe('1m')
+            ->and(ConnectionStatusWidget::formatUptime(125))->toBe('2m');
+    });
+
+    it('formats sub-day durations in hours and minutes', function (): void {
+        expect(ConnectionStatusWidget::formatUptime(3600))->toBe('1h')
+            ->and(ConnectionStatusWidget::formatUptime(3600 + 12 * 60))->toBe('1h 12m');
+    });
+
+    it('formats multi-day durations in days and hours', function (): void {
+        expect(ConnectionStatusWidget::formatUptime(86_400))->toBe('1d')
+            ->and(ConnectionStatusWidget::formatUptime(86_400 + 5 * 3600))->toBe('1d 5h');
+    });
+});


### PR DESCRIPTION
Closes #12.

## Summary

Adds an opt-in Filament v5 plugin so operators can see the Mattermost bot's runtime state without standing up custom tooling.

- Dashboard page with a stats-overview widget — connection state, bot identity, uptime, messages processed
- Message log page — recent posts from a configurable watched channel with channel-id and date-since filters
- Health page — API reachability + latency, WebSocket lifecycle state, bot identity, channel memberships
- `MattermostPlugin` opt-in entry point: `\$panel->plugin(\ConduitUI\Mattermost\Filament\MattermostPlugin::make())`

## Design notes

### Stats extension seam

There is no DB / model layer in this PR (per scope: cache + live API only). Runtime metrics live in `\ConduitUI\Mattermost\Filament\Stats\MattermostStats`, a tiny cache-backed service with these write hooks for the bot framework / WS client (issue #4) to call:

- `markConnected()` / `markDisconnected()` / `markReconnecting()` — on WS state transitions
- `markStarted()` — once at listener boot, anchors uptime
- `incrementMessagesProcessed()` — per dispatched handler

The pages always work even when no stats have been written — the widget shows `—` for uptime and `0` for messages until the listener publishes data. This keeps #12 unblocked from #4 while leaving a clear seam.

### Optional Filament dependency

- `filament/filament: ^5.4` is in `require-dev` only — never `require`.
- `MattermostServiceProvider::boot()` calls a new private `bootFilamentPanel()` guarded by `class_exists(\Filament\Panel::class)`. When Filament isn't installed, the method short-circuits and the package boots normally.
- The `MattermostStats` singleton binding is registered unconditionally because it has no Filament dependency — bot framework code can use it standalone.

### Page registration

Pages are NOT auto-discovered onto every installed panel. Operators register them explicitly via `MattermostPlugin::make()` to avoid surprising apps with multiple panels.

### Live API calls

Health and Message log pages make best-effort Saloon calls and swallow `Throwable` so the page renders even when Mattermost is unreachable. Identity in the dashboard widget likewise degrades to `—` placeholders.

## Test plan

- [x] `vendor/bin/pint --test` — pass
- [x] `vendor/bin/rector process --dry-run` — pass
- [x] `vendor/bin/phpstan analyse` — pass (level 6)
- [x] `vendor/bin/pest --compact` — 177 passed
- [x] Unit tests cover `MattermostStats` (state, uptime, counter, isolation, reset), the widget's `formatUptime` helper, the message log default channel resolver, and the provider's Filament-boot path.
- [ ] Manual: install in a downstream Laravel app, register `MattermostPlugin::make()` on a panel, verify pages render.

## Out of scope

- Persistence layer for messages (no migrations / models per #12 scope).
- Wiring `MattermostStats` writes from the WS client / bot framework — owned by #4 to avoid touching their in-flight work. The seam is documented in the `MattermostStats` PHPDoc.
- README / docs (#15).