### PR TITLE
feat: vendor:publish config — bootstrap onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,18 @@ composer require conduit-ui/mattermost
 
 ## Quick Start
 
-```php
-// config/mattermost.php is auto-published
+```bash
+php artisan vendor:publish --tag=mattermost-config
+```
 
-// In a service provider or route:
+Set your credentials in `.env`:
+
+```dotenv
+MATTERMOST_URL=https://your-server.example.com
+MATTERMOST_BOT_TOKEN=your-bot-token
+```
+
+```php
 use ConduitUI\Mattermost\Facades\Mattermost;
 
 Mattermost::post('town-square', 'Hello from Laravel!');

--- a/config/mattermost.php
+++ b/config/mattermost.php
@@ -24,6 +24,39 @@ return [
     |
     */
 
+    'url' => env('MATTERMOST_URL', 'http://localhost:8065'),
+
+    'token' => env('MATTERMOST_BOT_TOKEN'),
+
+    'team_id' => env('MATTERMOST_TEAM_ID'),
+
+    'bot_user_id' => env('MATTERMOST_BOT_USER_ID'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Slash Commands
+    |--------------------------------------------------------------------------
+    |
+    | Toggle slash-command support and define registered commands.
+    |
+    */
+
+    'enable_slash_commands' => env('MATTERMOST_ENABLE_SLASH_COMMANDS', false),
+
+    'slash_commands' => [
+        // 'greet' => \App\Mattermost\Commands\GreetCommand::class,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Connections
+    |--------------------------------------------------------------------------
+    |
+    | Named Mattermost server connections. Each connection needs a URL and
+    | bot token at minimum. Add multiple for multi-server support.
+    |
+    */
+
     'connections' => [
         'default' => [
             'url' => env('MATTERMOST_URL', 'http://localhost:8065'),

--- a/tests/Unit/ConfigPublishTest.php
+++ b/tests/Unit/ConfigPublishTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+use ConduitUI\Mattermost\MattermostServiceProvider;
+
+describe('config publishing', function (): void {
+    it('registers the mattermost-config publish group', function (): void {
+        $paths = MattermostServiceProvider::pathsToPublish(
+            MattermostServiceProvider::class,
+            'mattermost-config',
+        );
+
+        expect($paths)->toHaveCount(1);
+
+        $source = array_key_first($paths);
+        $destination = $paths[$source];
+
+        expect($source)->toEndWith('config/mattermost.php')
+            ->and($destination)->toBe(config_path('mattermost.php'));
+    });
+
+    it('maps to an existing config file', function (): void {
+        $paths = MattermostServiceProvider::pathsToPublish(
+            MattermostServiceProvider::class,
+            'mattermost-config',
+        );
+
+        $source = array_key_first($paths);
+
+        expect(file_exists($source))->toBeTrue();
+    });
+});
+
+describe('config keys', function (): void {
+    it('provides top-level url key', function (): void {
+        expect(config('mattermost.url'))->toBe('http://localhost:8065');
+    });
+
+    it('provides top-level token key', function (): void {
+        expect(config()->has('mattermost.token'))->toBeTrue();
+    });
+
+    it('provides team_id key', function (): void {
+        expect(config()->has('mattermost.team_id'))->toBeTrue();
+    });
+
+    it('provides bot_user_id key', function (): void {
+        expect(config()->has('mattermost.bot_user_id'))->toBeTrue();
+    });
+
+    it('provides enable_slash_commands key defaulting to false', function (): void {
+        expect(config('mattermost.enable_slash_commands'))->toBeFalse();
+    });
+
+    it('provides slash_commands array', function (): void {
+        expect(config('mattermost.slash_commands'))->toBeArray();
+    });
+
+    it('retains bot middleware config', function (): void {
+        expect(config('mattermost.bot.middleware'))->toBeArray();
+    });
+
+    it('retains connections config', function (): void {
+        expect(config('mattermost.connections.default.url'))->toBe('http://localhost:8065');
+    });
+});


### PR DESCRIPTION
## Summary

- Add missing top-level config keys (`url`, `token`, `team_id`, `bot_user_id`, `enable_slash_commands`, `slash_commands`) to `config/mattermost.php`
- Update README quickstart with `php artisan vendor:publish --tag=mattermost-config` and `.env` setup
- Add Pest tests for publish group registration and config key presence

## Quality Gate

- Pint: passed
- Pest: 231 passed (10 new assertions)
- PHPStan level 8: no errors
- Rector: clean

## Test plan

- [x] `vendor/bin/pest --compact` — all tests pass
- [x] `vendor/bin/pint --test` — compliant
- [x] `vendor/bin/phpstan analyse --memory-limit=512M` — no errors
- [x] `vendor/bin/rector process --dry-run` — clean

Closes #24