### PR TITLE
feat: mattermost:demo-post artisan command

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,26 @@ use ConduitUI\Mattermost\Facades\Mattermost;
 Mattermost::post('town-square', 'Hello from Laravel!');
 ```
 
+## Try it
+
+Post a message to any channel from the command line:
+
+```bash
+# Set your connection details in .env
+MATTERMOST_URL=http://localhost:8065
+MATTERMOST_BOT_TOKEN=your-bot-token
+MATTERMOST_TEAM=your-team-name
+
+# Post to the default channel (town-square)
+php artisan mattermost:demo-post
+
+# Post to a specific channel with a custom message
+php artisan mattermost:demo-post general "Deployed v2.0 🚀"
+
+# Override the team name
+php artisan mattermost:demo-post town-square "Hello!" --team=other-team
+```
+
 ## License
 
 MIT

--- a/config/mattermost.php
+++ b/config/mattermost.php
@@ -29,6 +29,7 @@ return [
             'url' => env('MATTERMOST_URL', 'http://localhost:8065'),
             'token' => env('MATTERMOST_BOT_TOKEN'),
             'bot_user_id' => env('MATTERMOST_BOT_USER_ID'),
+            'team' => env('MATTERMOST_TEAM'),
         ],
     ],
 

--- a/src/Commands/DemoPostCommand.php
+++ b/src/Commands/DemoPostCommand.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\Commands;
+
+use ConduitUI\Mattermost\Facades\Mattermost;
+use Illuminate\Console\Command;
+
+class DemoPostCommand extends Command
+{
+    /** @var string */
+    protected $signature = 'mattermost:demo-post
+        {channel=town-square : The channel name to post to}
+        {text=Hello from Laravel! : The message text to post}
+        {--team= : The team name (defaults to mattermost.connections.*.team config)}';
+
+    /** @var string */
+    protected $description = 'Post a message to a Mattermost channel via the Saloon API client';
+
+    public function handle(): int
+    {
+        /** @var string $channelName */
+        $channelName = $this->argument('channel');
+
+        /** @var string $text */
+        $text = $this->argument('text');
+
+        $teamName = $this->resolveTeamName();
+
+        if ($teamName === null) {
+            $this->error('No team name configured. Set MATTERMOST_TEAM in your .env or pass --team=<name>.');
+
+            return self::FAILURE;
+        }
+
+        $this->info("Resolving channel [{$channelName}] on team [{$teamName}]...");
+
+        $teamResponse = Mattermost::teams()->getTeamByName($teamName);
+
+        /** @var array{id: string} $teamData */
+        $teamData = $teamResponse->json();
+        $teamId = $teamData['id'];
+
+        $channelResponse = Mattermost::channels()->getChannelByName($teamId, $channelName);
+
+        /** @var array{id: string} $channelData */
+        $channelData = $channelResponse->json();
+        $channelId = $channelData['id'];
+
+        Mattermost::posts()->createPost(channelId: $channelId, message: $text);
+
+        $this->info("Posted to [{$channelName}]: {$text}");
+
+        return self::SUCCESS;
+    }
+
+    private function resolveTeamName(): ?string
+    {
+        /** @var string|null $option */
+        $option = $this->option('team');
+
+        if ($option !== null && $option !== '') {
+            return $option;
+        }
+
+        /** @var string|null $connectionName */
+        $connectionName = config('mattermost.default', 'default');
+
+        /** @var string|null $team */
+        $team = config("mattermost.connections.{$connectionName}.team");
+
+        return $team !== null && $team !== '' ? $team : null;
+    }
+}

--- a/src/MattermostServiceProvider.php
+++ b/src/MattermostServiceProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ConduitUI\Mattermost;
 
 use ConduitUI\Mattermost\Bot\Router as BotRouter;
+use ConduitUI\Mattermost\Commands\DemoPostCommand;
 use ConduitUI\Mattermost\Filament\Stats\MattermostStats;
 use ConduitUI\Mattermost\Notifications\MattermostBroadcaster;
 use Filament\Panel;
@@ -36,6 +37,10 @@ class MattermostServiceProvider extends ServiceProvider
             $this->publishes([
                 __DIR__.'/../config/mattermost.php' => config_path('mattermost.php'),
             ], 'mattermost-config');
+
+            $this->commands([
+                DemoPostCommand::class,
+            ]);
         }
 
         $this->registerBroadcaster();

--- a/tests/Feature/DemoPostCommandTest.php
+++ b/tests/Feature/DemoPostCommandTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelByName;
+use ConduitUI\Mattermost\Client\Requests\Posts\CreatePost;
+use ConduitUI\Mattermost\Client\Requests\Teams\GetTeamByName;
+use ConduitUI\Mattermost\Facades\Mattermost;
+use ConduitUI\Mattermost\Testing\RecordedRequest;
+use Saloon\Http\Faking\MockResponse;
+
+describe('mattermost:demo-post', function (): void {
+    beforeEach(function (): void {
+        Mattermost::fake([
+            GetTeamByName::class => MockResponse::make(['id' => 'team-abc-123']),
+            GetChannelByName::class => MockResponse::make(['id' => 'channel-xyz-789']),
+            CreatePost::class => MockResponse::make(['id' => 'post-1', 'message' => 'Hello from Laravel!']),
+        ]);
+
+        config()->set('mattermost.connections.default.team', 'my-team');
+    });
+
+    it('posts a message to the resolved channel', function (): void {
+        $this->artisan('mattermost:demo-post', ['channel' => 'town-square', 'text' => 'Hello from Laravel!'])
+            ->assertSuccessful();
+
+        Mattermost::assertSent(GetTeamByName::class);
+        Mattermost::assertSent(GetChannelByName::class);
+        Mattermost::assertPosted(fn (RecordedRequest $r): bool => $r->get('channel_id') === 'channel-xyz-789'
+            && $r->get('message') === 'Hello from Laravel!');
+    });
+
+    it('uses default channel and text when no arguments given', function (): void {
+        $this->artisan('mattermost:demo-post')
+            ->assertSuccessful();
+
+        Mattermost::assertPosted(fn (RecordedRequest $r): bool => $r->get('message') === 'Hello from Laravel!');
+    });
+
+    it('accepts a --team option to override config', function (): void {
+        $this->artisan('mattermost:demo-post', ['--team' => 'other-team'])
+            ->assertSuccessful();
+
+        Mattermost::assertSent(GetTeamByName::class);
+        Mattermost::assertPosted();
+    });
+
+    it('fails when no team is configured', function (): void {
+        config()->set('mattermost.connections.default.team', null);
+
+        $this->artisan('mattermost:demo-post')
+            ->assertFailed();
+
+        Mattermost::assertNothingSent();
+    });
+
+    it('sends exactly one post per invocation', function (): void {
+        $this->artisan('mattermost:demo-post');
+
+        Mattermost::assertPostCount(1);
+    });
+});


### PR DESCRIPTION
## Summary

- Add `mattermost:demo-post {channel} {text}` artisan command that resolves a channel by team + name via the Saloon client, then posts a message using `posts()->createPost()`
- Add `team` config key to the default connection for team name resolution
- Register the command in `MattermostServiceProvider` alongside existing console setup
- Add Pest feature tests using `Mattermost::fake()` with mock responses for team lookup, channel lookup, and post creation assertions
- Update README with a "Try it" section showing demo command usage

## Test plan

- [x] `vendor/bin/pest --compact` — 226 passed, 0 failures
- [x] `vendor/bin/pint --test` — passed
- [x] `vendor/bin/phpstan analyse` — no errors at level 8
- [x] `vendor/bin/rector process --dry-run` — clean

Closes #25