### PR TITLE
feat: slash command routing — register and handle slash commands

### DIFF
--- a/config/mattermost.php
+++ b/config/mattermost.php
@@ -70,6 +70,22 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Slash Commands
+    |--------------------------------------------------------------------------
+    |
+    | Configure the webhook endpoint that Mattermost POSTs to when a user
+    | invokes a registered slash command. Set `route` to `null` or `''` to
+    | disable the automatic route registration and register your own.
+    |
+    */
+
+    'slash_commands' => [
+        'route' => env('MATTERMOST_SLASH_ROUTE', 'mattermost/slash-command'),
+        'middleware' => [],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | WebSocket
     |--------------------------------------------------------------------------
     */

--- a/src/Facades/Mattermost.php
+++ b/src/Facades/Mattermost.php
@@ -27,6 +27,8 @@ use Saloon\Http\Faking\MockResponse;
  * @method static \ConduitUI\Mattermost\Bot\Router on(string $eventClassOrWildcard, string $handler)
  * @method static \ConduitUI\Mattermost\Bot\Router middleware(string ...$middleware)
  * @method static \ConduitUI\Mattermost\Bot\Router router()
+ * @method static \ConduitUI\Mattermost\SlashCommands\SlashCommandRouter slash(string $command, string|\Closure $handler)
+ * @method static \ConduitUI\Mattermost\SlashCommands\SlashCommandRouter slashCommandRouter()
  * @method static \ConduitUI\Mattermost\Testing\MattermostFake assertSent(string|\Closure $value, ?int $times = null)
  * @method static \ConduitUI\Mattermost\Testing\MattermostFake assertNotSent(string|\Closure $value)
  * @method static \ConduitUI\Mattermost\Testing\MattermostFake assertNothingSent()

--- a/src/MattermostManager.php
+++ b/src/MattermostManager.php
@@ -4,10 +4,15 @@ declare(strict_types=1);
 
 namespace ConduitUI\Mattermost;
 
+use Closure;
 use ConduitUI\Mattermost\Bot\Handler;
 use ConduitUI\Mattermost\Bot\Middleware\Middleware as BotMiddleware;
 use ConduitUI\Mattermost\Bot\Router as BotRouter;
 use ConduitUI\Mattermost\Client\Mattermost;
+use ConduitUI\Mattermost\SlashCommands\SlashCommand;
+use ConduitUI\Mattermost\SlashCommands\SlashCommandHandler;
+use ConduitUI\Mattermost\SlashCommands\SlashCommandResponse;
+use ConduitUI\Mattermost\SlashCommands\SlashCommandRouter;
 use ConduitUI\Mattermost\WebSocket\Events\Event;
 use Illuminate\Contracts\Container\Container;
 use InvalidArgumentException;
@@ -74,6 +79,24 @@ class MattermostManager
     public function middleware(string ...$middleware): BotRouter
     {
         return $this->router()->middleware(...$middleware);
+    }
+
+    /**
+     * Resolve the slash command router from the container.
+     */
+    public function slashCommandRouter(): SlashCommandRouter
+    {
+        return $this->resolveContainer()->make(SlashCommandRouter::class);
+    }
+
+    /**
+     * Register a slash command handler — proxy to the slash command router.
+     *
+     * @param  class-string<SlashCommandHandler>|Closure(SlashCommand): SlashCommandResponse  $handler
+     */
+    public function slash(string $command, string|Closure $handler): SlashCommandRouter
+    {
+        return $this->slashCommandRouter()->register($command, $handler);
     }
 
     private function resolveContainer(): Container

--- a/src/MattermostServiceProvider.php
+++ b/src/MattermostServiceProvider.php
@@ -7,10 +7,13 @@ namespace ConduitUI\Mattermost;
 use ConduitUI\Mattermost\Bot\Router as BotRouter;
 use ConduitUI\Mattermost\Filament\Stats\MattermostStats;
 use ConduitUI\Mattermost\Notifications\MattermostBroadcaster;
+use ConduitUI\Mattermost\SlashCommands\SlashCommandController;
+use ConduitUI\Mattermost\SlashCommands\SlashCommandRouter;
 use Filament\Panel;
 use Illuminate\Contracts\Broadcasting\Factory as BroadcastFactory;
 use Illuminate\Contracts\Cache\Repository as CacheRepository;
 use Illuminate\Contracts\Container\Container;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 
 class MattermostServiceProvider extends ServiceProvider
@@ -23,6 +26,8 @@ class MattermostServiceProvider extends ServiceProvider
         $this->app->scoped(MattermostManager::class, fn (Container $container): MattermostManager => new MattermostManager($container));
 
         $this->app->singleton(BotRouter::class, fn (Container $container): BotRouter => new BotRouter($container));
+
+        $this->app->singleton(SlashCommandRouter::class, fn (Container $container): SlashCommandRouter => new SlashCommandRouter($container));
 
         $this->app->singleton(MattermostStats::class, fn ($app): MattermostStats => new MattermostStats(
             $app->make(CacheRepository::class),
@@ -40,6 +45,7 @@ class MattermostServiceProvider extends ServiceProvider
 
         $this->registerBroadcaster();
         $this->bootBotRouter();
+        $this->bootSlashCommandRoute();
         $this->bootFilamentPanel();
     }
 
@@ -73,6 +79,22 @@ class MattermostServiceProvider extends ServiceProvider
 
             $router->setGlobalMiddleware($middleware);
         }
+    }
+
+    private function bootSlashCommandRoute(): void
+    {
+        $uri = config('mattermost.slash_commands.route', 'mattermost/slash-command');
+
+        if (! is_string($uri) || $uri === '') {
+            return;
+        }
+
+        $middleware = config('mattermost.slash_commands.middleware', []);
+        $middleware = is_array($middleware) ? $middleware : [];
+
+        Route::post($uri, SlashCommandController::class)
+            ->middleware($middleware)
+            ->name('mattermost.slash-command');
     }
 
     /**

--- a/src/SlashCommands/SlashCommand.php
+++ b/src/SlashCommands/SlashCommand.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\SlashCommands;
+
+/**
+ * Value object representing an incoming Mattermost slash command webhook payload.
+ *
+ * Mattermost POSTs a form-encoded payload when a user invokes a custom slash
+ * command. This DTO wraps that payload and provides typed convenience accessors
+ * including argument parsing helpers.
+ */
+class SlashCommand
+{
+    /** @var list<string> */
+    private array $parsedArgs;
+
+    /**
+     * @param  array<string, mixed>  $payload  The raw webhook payload.
+     */
+    public function __construct(
+        private readonly array $payload,
+    ) {
+        $text = $this->text();
+        $this->parsedArgs = $text !== ''
+            ? preg_split('/\s+/', $text, -1, PREG_SPLIT_NO_EMPTY) ?: []
+            : [];
+    }
+
+    /**
+     * Build a SlashCommand from a raw Mattermost webhook payload.
+     *
+     * @param  array<string, mixed>  $payload
+     */
+    public static function fromPayload(array $payload): self
+    {
+        return new self($payload);
+    }
+
+    /**
+     * The slash command trigger word including the leading slash (e.g. "/deploy").
+     */
+    public function command(): string
+    {
+        $command = $this->payload['command'] ?? '';
+
+        return is_string($command) ? $command : '';
+    }
+
+    /**
+     * The raw text after the command trigger.
+     */
+    public function text(): string
+    {
+        $text = $this->payload['text'] ?? '';
+
+        return is_string($text) ? $text : '';
+    }
+
+    /**
+     * The user ID of the invoking user.
+     */
+    public function userId(): string
+    {
+        $userId = $this->payload['user_id'] ?? '';
+
+        return is_string($userId) ? $userId : '';
+    }
+
+    /**
+     * The username (without @) of the invoking user.
+     */
+    public function userName(): string
+    {
+        $userName = $this->payload['user_name'] ?? '';
+
+        return is_string($userName) ? $userName : '';
+    }
+
+    /**
+     * The channel ID where the command was invoked.
+     */
+    public function channelId(): string
+    {
+        $channelId = $this->payload['channel_id'] ?? '';
+
+        return is_string($channelId) ? $channelId : '';
+    }
+
+    /**
+     * The channel name where the command was invoked.
+     */
+    public function channelName(): string
+    {
+        $channelName = $this->payload['channel_name'] ?? '';
+
+        return is_string($channelName) ? $channelName : '';
+    }
+
+    /**
+     * The team ID where the command was invoked.
+     */
+    public function teamId(): string
+    {
+        $teamId = $this->payload['team_id'] ?? '';
+
+        return is_string($teamId) ? $teamId : '';
+    }
+
+    /**
+     * The verification token sent by Mattermost.
+     */
+    public function token(): string
+    {
+        $token = $this->payload['token'] ?? '';
+
+        return is_string($token) ? $token : '';
+    }
+
+    /**
+     * The response URL for delayed/async responses.
+     */
+    public function responseUrl(): string
+    {
+        $url = $this->payload['response_url'] ?? '';
+
+        return is_string($url) ? $url : '';
+    }
+
+    /**
+     * The trigger ID for opening interactive dialogs.
+     */
+    public function triggerId(): string
+    {
+        $id = $this->payload['trigger_id'] ?? '';
+
+        return is_string($id) ? $id : '';
+    }
+
+    /**
+     * All whitespace-separated arguments from the command text.
+     *
+     * @return list<string>
+     */
+    public function args(): array
+    {
+        return $this->parsedArgs;
+    }
+
+    /**
+     * Get a single argument by zero-based position, or a default if missing.
+     */
+    public function arg(int $index, ?string $default = null): ?string
+    {
+        return $this->parsedArgs[$index] ?? $default;
+    }
+
+    /**
+     * The raw webhook payload array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return $this->payload;
+    }
+}

--- a/src/SlashCommands/SlashCommandController.php
+++ b/src/SlashCommands/SlashCommandController.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\SlashCommands;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * HTTP controller for receiving Mattermost slash command webhooks.
+ *
+ * Mattermost POSTs form-encoded data when a user triggers a custom slash
+ * command. This controller parses the payload, dispatches it through the
+ * {@see SlashCommandRouter}, and returns the JSON response.
+ */
+class SlashCommandController
+{
+    public function __construct(
+        private readonly SlashCommandRouter $router,
+    ) {}
+
+    public function __invoke(Request $request): JsonResponse
+    {
+        /** @var array<string, mixed> $payload */
+        $payload = $request->all();
+
+        $command = SlashCommand::fromPayload($payload);
+        $response = $this->router->dispatch($command);
+
+        if (! $response instanceof SlashCommandResponse) {
+            return new JsonResponse([
+                'response_type' => 'ephemeral',
+                'text' => sprintf('Unknown command: %s', $command->command()),
+            ]);
+        }
+
+        return new JsonResponse($response->toArray());
+    }
+}

--- a/src/SlashCommands/SlashCommandHandler.php
+++ b/src/SlashCommands/SlashCommandHandler.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\SlashCommands;
+
+/**
+ * Base class for slash command handler classes.
+ *
+ * Subclass this and implement `handle()` to return a response. The router
+ * resolves handlers from the container so constructor DI is available.
+ *
+ *   class DeployHandler extends SlashCommandHandler {
+ *       public function handle(SlashCommand $command): SlashCommandResponse {
+ *           return SlashCommandResponse::make('Deploying...')->inChannel();
+ *       }
+ *   }
+ */
+abstract class SlashCommandHandler
+{
+    /**
+     * Handle the incoming slash command and return a response.
+     */
+    abstract public function handle(SlashCommand $command): SlashCommandResponse;
+}

--- a/src/SlashCommands/SlashCommandResponse.php
+++ b/src/SlashCommands/SlashCommandResponse.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\SlashCommands;
+
+/**
+ * Fluent builder for a slash command response payload.
+ *
+ * Mattermost expects a JSON response with `response_type`, `text`, and optional
+ * attachments. This builder produces that payload.
+ *
+ * @see https://developers.mattermost.com/integrate/slash-commands/#response-parameters
+ */
+class SlashCommandResponse
+{
+    private string $responseType = 'ephemeral';
+
+    private ?string $text = null;
+
+    /** @var list<array<string, mixed>> */
+    private array $attachments = [];
+
+    public static function make(?string $text = null): self
+    {
+        $instance = new self;
+
+        if ($text !== null) {
+            $instance->text = $text;
+        }
+
+        return $instance;
+    }
+
+    /**
+     * The response is visible to everyone in the channel.
+     */
+    public function inChannel(): self
+    {
+        $this->responseType = 'in_channel';
+
+        return $this;
+    }
+
+    /**
+     * The response is visible only to the user who invoked the command (default).
+     */
+    public function ephemeral(): self
+    {
+        $this->responseType = 'ephemeral';
+
+        return $this;
+    }
+
+    public function text(string $text): self
+    {
+        $this->text = $text;
+
+        return $this;
+    }
+
+    /**
+     * @param  array<string, mixed>  $attachment
+     */
+    public function attachment(array $attachment): self
+    {
+        $this->attachments[] = $attachment;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $payload = [
+            'response_type' => $this->responseType,
+            'text' => $this->text ?? '',
+        ];
+
+        if ($this->attachments !== []) {
+            $payload['attachments'] = $this->attachments;
+        }
+
+        return $payload;
+    }
+}

--- a/src/SlashCommands/SlashCommandRouter.php
+++ b/src/SlashCommands/SlashCommandRouter.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\SlashCommands;
+
+use Closure;
+use Illuminate\Contracts\Container\Container;
+
+/**
+ * Route-style registration and dispatch for Mattermost slash commands.
+ *
+ * Register handlers using `register()` with either a handler class or a closure:
+ *
+ *   $router->register('/deploy', DeployHandler::class);
+ *   $router->register('/status', fn (SlashCommand $cmd) => SlashCommandResponse::make('OK'));
+ *
+ * The router resolves class-based handlers from the container so DI works.
+ */
+class SlashCommandRouter
+{
+    /** @var array<string, class-string<SlashCommandHandler>|Closure(SlashCommand): SlashCommandResponse> */
+    private array $handlers = [];
+
+    public function __construct(
+        private readonly Container $container,
+    ) {}
+
+    /**
+     * Register a handler for a slash command trigger.
+     *
+     * The command should include the leading slash (e.g. "/deploy"). If omitted,
+     * it will be prepended automatically.
+     *
+     * @param  class-string<SlashCommandHandler>|Closure(SlashCommand): SlashCommandResponse  $handler
+     */
+    public function register(string $command, string|Closure $handler): self
+    {
+        $command = $this->normalizeCommand($command);
+        $this->handlers[$command] = $handler;
+
+        return $this;
+    }
+
+    /**
+     * Dispatch an incoming slash command payload to its registered handler.
+     *
+     * Returns null if no handler matches the command.
+     */
+    public function dispatch(SlashCommand $command): ?SlashCommandResponse
+    {
+        $trigger = $this->normalizeCommand($command->command());
+
+        $handler = $this->handlers[$trigger] ?? null;
+
+        if ($handler === null) {
+            return null;
+        }
+
+        if ($handler instanceof Closure) {
+            return $handler($command);
+        }
+
+        /** @var SlashCommandHandler $instance */
+        $instance = $this->container->make($handler);
+
+        return $instance->handle($command);
+    }
+
+    /**
+     * Check whether a handler is registered for a given command trigger.
+     */
+    public function hasHandler(string $command): bool
+    {
+        return isset($this->handlers[$this->normalizeCommand($command)]);
+    }
+
+    /**
+     * @return array<string, class-string<SlashCommandHandler>|Closure(SlashCommand): SlashCommandResponse>
+     */
+    public function handlers(): array
+    {
+        return $this->handlers;
+    }
+
+    private function normalizeCommand(string $command): string
+    {
+        return str_starts_with($command, '/') ? $command : '/'.$command;
+    }
+}

--- a/tests/Unit/SlashCommands/ServiceProviderBindingTest.php
+++ b/tests/Unit/SlashCommands/ServiceProviderBindingTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use ConduitUI\Mattermost\Facades\Mattermost;
+use ConduitUI\Mattermost\SlashCommands\SlashCommand;
+use ConduitUI\Mattermost\SlashCommands\SlashCommandResponse;
+use ConduitUI\Mattermost\SlashCommands\SlashCommandRouter;
+
+describe('SlashCommands ServiceProvider', function (): void {
+    it('registers the SlashCommandRouter as a singleton', function (): void {
+        $router1 = app(SlashCommandRouter::class);
+        $router2 = app(SlashCommandRouter::class);
+
+        expect($router1)->toBeInstanceOf(SlashCommandRouter::class)
+            ->and($router1)->toBe($router2);
+    });
+
+    it('registers the webhook route', function (): void {
+        $route = app('router')->getRoutes()->getByName('mattermost.slash-command');
+
+        expect($route)->not->toBeNull()
+            ->and($route->uri())->toBe('mattermost/slash-command')
+            ->and($route->methods())->toContain('POST');
+    });
+
+    it('proxies slash() through the Facade to the router', function (): void {
+        Mattermost::slash('/test', fn (SlashCommand $cmd): SlashCommandResponse => SlashCommandResponse::make('OK'));
+
+        /** @var SlashCommandRouter $router */
+        $router = app(SlashCommandRouter::class);
+
+        expect($router->hasHandler('/test'))->toBeTrue();
+    });
+});

--- a/tests/Unit/SlashCommands/SlashCommandControllerTest.php
+++ b/tests/Unit/SlashCommands/SlashCommandControllerTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+use ConduitUI\Mattermost\SlashCommands\SlashCommand;
+use ConduitUI\Mattermost\SlashCommands\SlashCommandResponse;
+use ConduitUI\Mattermost\SlashCommands\SlashCommandRouter;
+use ConduitUI\Mattermost\Testing\MattermostFixtures;
+
+describe('SlashCommandController', function (): void {
+    it('routes a webhook POST to the registered handler and returns JSON', function (): void {
+        /** @var SlashCommandRouter $router */
+        $router = app(SlashCommandRouter::class);
+        $router->register('/deploy', fn (SlashCommand $cmd): SlashCommandResponse => SlashCommandResponse::make('Deployed!')->inChannel());
+
+        $payload = MattermostFixtures::fakeSlashCommand('/deploy', 'production');
+
+        $response = $this->post('mattermost/slash-command', $payload);
+
+        $response->assertOk();
+        $response->assertJson([
+            'response_type' => 'in_channel',
+            'text' => 'Deployed!',
+        ]);
+    });
+
+    it('returns an ephemeral "unknown command" response for unregistered commands', function (): void {
+        $payload = MattermostFixtures::fakeSlashCommand('/unknown');
+
+        $response = $this->post('mattermost/slash-command', $payload);
+
+        $response->assertOk();
+        $response->assertJson([
+            'response_type' => 'ephemeral',
+            'text' => 'Unknown command: /unknown',
+        ]);
+    });
+
+    it('passes query arguments through to the handler', function (): void {
+        /** @var SlashCommandRouter $router */
+        $router = app(SlashCommandRouter::class);
+        $router->register('/echo', fn (SlashCommand $cmd): SlashCommandResponse => SlashCommandResponse::make($cmd->text()));
+
+        $payload = MattermostFixtures::fakeSlashCommand('/echo', 'hello world');
+
+        $response = $this->post('mattermost/slash-command', $payload);
+
+        $response->assertOk();
+        $response->assertJson(['text' => 'hello world']);
+    });
+});

--- a/tests/Unit/SlashCommands/SlashCommandResponseTest.php
+++ b/tests/Unit/SlashCommands/SlashCommandResponseTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+use ConduitUI\Mattermost\SlashCommands\SlashCommandResponse;
+
+describe('SlashCommandResponse', function (): void {
+    it('defaults to ephemeral response type', function (): void {
+        $response = SlashCommandResponse::make('Hello');
+
+        expect($response->toArray())->toBe([
+            'response_type' => 'ephemeral',
+            'text' => 'Hello',
+        ]);
+    });
+
+    it('supports in_channel response type', function (): void {
+        $response = SlashCommandResponse::make('Deployed!')->inChannel();
+
+        expect($response->toArray()['response_type'])->toBe('in_channel');
+    });
+
+    it('can switch back to ephemeral after in_channel', function (): void {
+        $response = SlashCommandResponse::make('test')->inChannel()->ephemeral();
+
+        expect($response->toArray()['response_type'])->toBe('ephemeral');
+    });
+
+    it('builds with fluent text setter', function (): void {
+        $response = SlashCommandResponse::make()->text('hello world');
+
+        expect($response->toArray()['text'])->toBe('hello world');
+    });
+
+    it('defaults text to empty string when not provided', function (): void {
+        $response = SlashCommandResponse::make();
+
+        expect($response->toArray()['text'])->toBe('');
+    });
+
+    it('includes attachments when added', function (): void {
+        $response = SlashCommandResponse::make('Details below')
+            ->attachment(['title' => 'Build Log', 'text' => 'All green']);
+
+        $array = $response->toArray();
+
+        expect($array)->toHaveKey('attachments')
+            ->and($array['attachments'])->toHaveCount(1)
+            ->and($array['attachments'][0]['title'])->toBe('Build Log');
+    });
+
+    it('omits attachments key when none are added', function (): void {
+        $response = SlashCommandResponse::make('Simple');
+
+        expect($response->toArray())->not->toHaveKey('attachments');
+    });
+
+    it('supports multiple attachments', function (): void {
+        $response = SlashCommandResponse::make('Multi')
+            ->attachment(['title' => 'One'])
+            ->attachment(['title' => 'Two']);
+
+        expect($response->toArray()['attachments'])->toHaveCount(2);
+    });
+});

--- a/tests/Unit/SlashCommands/SlashCommandRouterTest.php
+++ b/tests/Unit/SlashCommands/SlashCommandRouterTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+use ConduitUI\Mattermost\SlashCommands\SlashCommand;
+use ConduitUI\Mattermost\SlashCommands\SlashCommandHandler;
+use ConduitUI\Mattermost\SlashCommands\SlashCommandResponse;
+use ConduitUI\Mattermost\SlashCommands\SlashCommandRouter;
+use ConduitUI\Mattermost\Testing\MattermostFixtures;
+
+describe('SlashCommandRouter', function (): void {
+    it('dispatches to a registered class-based handler', function (): void {
+        $router = app(SlashCommandRouter::class);
+        $router->register('/deploy', StubDeployHandler::class);
+
+        $command = SlashCommand::fromPayload(MattermostFixtures::fakeSlashCommand('/deploy', 'production'));
+        $response = $router->dispatch($command);
+
+        expect($response)->not->toBeNull()
+            ->and($response->toArray()['text'])->toBe('Deploying to production');
+    });
+
+    it('dispatches to a registered closure handler', function (): void {
+        $router = app(SlashCommandRouter::class);
+        $router->register('/status', fn (SlashCommand $cmd): SlashCommandResponse => SlashCommandResponse::make('All systems go'));
+
+        $command = SlashCommand::fromPayload(MattermostFixtures::fakeSlashCommand('/status'));
+        $response = $router->dispatch($command);
+
+        expect($response)->not->toBeNull()
+            ->and($response->toArray()['text'])->toBe('All systems go');
+    });
+
+    it('returns null for unregistered commands', function (): void {
+        $router = app(SlashCommandRouter::class);
+
+        $command = SlashCommand::fromPayload(MattermostFixtures::fakeSlashCommand('/unknown'));
+
+        expect($router->dispatch($command))->toBeNull();
+    });
+
+    it('normalizes commands with missing leading slash', function (): void {
+        $router = app(SlashCommandRouter::class);
+        $router->register('deploy', fn (SlashCommand $cmd): SlashCommandResponse => SlashCommandResponse::make('OK'));
+
+        $command = SlashCommand::fromPayload(MattermostFixtures::fakeSlashCommand('/deploy'));
+        $response = $router->dispatch($command);
+
+        expect($response)->not->toBeNull()
+            ->and($response->toArray()['text'])->toBe('OK');
+    });
+
+    it('checks handler registration via hasHandler', function (): void {
+        $router = app(SlashCommandRouter::class);
+        $router->register('/deploy', StubDeployHandler::class);
+
+        expect($router->hasHandler('/deploy'))->toBeTrue()
+            ->and($router->hasHandler('deploy'))->toBeTrue()
+            ->and($router->hasHandler('/unknown'))->toBeFalse();
+    });
+
+    it('returns all registered handlers', function (): void {
+        $router = app(SlashCommandRouter::class);
+        $router->register('/deploy', StubDeployHandler::class);
+        $router->register('/status', fn (SlashCommand $cmd): SlashCommandResponse => SlashCommandResponse::make('OK'));
+
+        expect($router->handlers())->toHaveCount(2)
+            ->and($router->handlers())->toHaveKeys(['/deploy', '/status']);
+    });
+
+    it('allows overwriting a previously registered handler', function (): void {
+        $router = app(SlashCommandRouter::class);
+        $router->register('/deploy', fn (SlashCommand $cmd): SlashCommandResponse => SlashCommandResponse::make('v1'));
+        $router->register('/deploy', fn (SlashCommand $cmd): SlashCommandResponse => SlashCommandResponse::make('v2'));
+
+        $command = SlashCommand::fromPayload(MattermostFixtures::fakeSlashCommand('/deploy'));
+        $response = $router->dispatch($command);
+
+        expect($response->toArray()['text'])->toBe('v2');
+    });
+
+    it('is chainable via register', function (): void {
+        $router = app(SlashCommandRouter::class);
+
+        $result = $router
+            ->register('/a', fn (SlashCommand $cmd): SlashCommandResponse => SlashCommandResponse::make('a'))
+            ->register('/b', fn (SlashCommand $cmd): SlashCommandResponse => SlashCommandResponse::make('b'));
+
+        expect($result)->toBeInstanceOf(SlashCommandRouter::class)
+            ->and($router->handlers())->toHaveCount(2);
+    });
+});
+
+// --- Stub handler for testing ---
+
+class StubDeployHandler extends SlashCommandHandler
+{
+    #[Override]
+    public function handle(SlashCommand $command): SlashCommandResponse
+    {
+        $env = $command->arg(0, 'staging');
+
+        return SlashCommandResponse::make("Deploying to {$env}")->inChannel();
+    }
+}

--- a/tests/Unit/SlashCommands/SlashCommandTest.php
+++ b/tests/Unit/SlashCommands/SlashCommandTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+use ConduitUI\Mattermost\SlashCommands\SlashCommand;
+use ConduitUI\Mattermost\Testing\MattermostFixtures;
+
+describe('SlashCommand', function (): void {
+    it('parses the command trigger from a payload', function (): void {
+        $command = SlashCommand::fromPayload(MattermostFixtures::fakeSlashCommand('/deploy'));
+
+        expect($command->command())->toBe('/deploy');
+    });
+
+    it('parses user and channel fields', function (): void {
+        $payload = MattermostFixtures::fakeSlashCommand('/deploy', userId: 'user-1', channelId: 'chan-1');
+        $command = SlashCommand::fromPayload($payload);
+
+        expect($command->userId())->toBe('user-1')
+            ->and($command->channelId())->toBe('chan-1')
+            ->and($command->userName())->toBe('testuser')
+            ->and($command->channelName())->toBe('town-square')
+            ->and($command->teamId())->not->toBeEmpty();
+    });
+
+    it('parses the raw text after the command trigger', function (): void {
+        $command = SlashCommand::fromPayload(MattermostFixtures::fakeSlashCommand('/deploy', 'production --force'));
+
+        expect($command->text())->toBe('production --force');
+    });
+
+    it('splits text into whitespace-separated args', function (): void {
+        $command = SlashCommand::fromPayload(MattermostFixtures::fakeSlashCommand('/deploy', 'production us-east-1 --force'));
+
+        expect($command->args())->toBe(['production', 'us-east-1', '--force']);
+    });
+
+    it('returns an empty args list when text is empty', function (): void {
+        $command = SlashCommand::fromPayload(MattermostFixtures::fakeSlashCommand('/status'));
+
+        expect($command->args())->toBe([]);
+    });
+
+    it('retrieves a single arg by index', function (): void {
+        $command = SlashCommand::fromPayload(MattermostFixtures::fakeSlashCommand('/deploy', 'production us-east-1'));
+
+        expect($command->arg(0))->toBe('production')
+            ->and($command->arg(1))->toBe('us-east-1')
+            ->and($command->arg(2))->toBeNull()
+            ->and($command->arg(2, 'default'))->toBe('default');
+    });
+
+    it('exposes the token and trigger ID', function (): void {
+        $command = SlashCommand::fromPayload(MattermostFixtures::fakeSlashCommand('/deploy'));
+
+        expect($command->token())->toBe('slash-command-token')
+            ->and($command->triggerId())->not->toBeEmpty();
+    });
+
+    it('exposes the response URL', function (): void {
+        $command = SlashCommand::fromPayload(MattermostFixtures::fakeSlashCommand('/deploy'));
+
+        expect($command->responseUrl())->toStartWith('https://');
+    });
+
+    it('returns the raw payload via toArray', function (): void {
+        $payload = MattermostFixtures::fakeSlashCommand('/deploy', 'prod');
+        $command = SlashCommand::fromPayload($payload);
+
+        expect($command->toArray())->toBe($payload);
+    });
+
+    it('handles missing payload fields gracefully', function (): void {
+        $command = SlashCommand::fromPayload([]);
+
+        expect($command->command())->toBe('')
+            ->and($command->text())->toBe('')
+            ->and($command->userId())->toBe('')
+            ->and($command->channelId())->toBe('')
+            ->and($command->args())->toBe([]);
+    });
+});


### PR DESCRIPTION
## Summary

Implements route-style slash command registration and handling for Mattermost bots (#7).

- **SlashCommand DTO** — parses incoming webhook payloads with typed accessors for user, channel, text, team, token, trigger ID, response URL, and whitespace-separated argument helpers (`args()`, `arg(index)`)
- **SlashCommandResponse builder** — fluent API producing `in_channel` or `ephemeral` responses with optional attachments
- **SlashCommandHandler** — abstract base class for class-based handlers (container-resolved, supports DI)
- **SlashCommandRouter** — route-style registration with both class and closure handlers, automatic `/` normalization
- **SlashCommandController** — webhook endpoint that parses the POST payload, dispatches through the router, and returns JSON
- **Auto-registered route** — `POST mattermost/slash-command` registered in the service provider, configurable URI and middleware via `config('mattermost.slash_commands')`
- **Facade proxy** — `Mattermost::slash('/deploy', DeployHandler::class)` works out of the box

### Usage

```php
// Class-based handler
Mattermost::slash('/deploy', DeployHandler::class);

// Closure handler
Mattermost::slash('/status', fn (SlashCommand $cmd) => SlashCommandResponse::make('All systems go'));
```

## Test plan

- [x] SlashCommand DTO parses all fields from fixture payload
- [x] Argument parsing (split, positional access, defaults, empty text)
- [x] SlashCommandResponse builds ephemeral/in_channel payloads with attachments
- [x] SlashCommandRouter dispatches to class handlers and closures
- [x] Router normalizes commands, supports hasHandler/overwrite/chaining
- [x] SlashCommandController returns JSON for registered and unknown commands
- [x] ServiceProvider registers singleton, route, and facade proxy
- [x] Pint compliant
- [x] PHPStan level 8 clean
- [x] Rector clean

Closes #7