### PR TITLE
feat: interactive messages — action handlers for buttons and menus

### DIFF
--- a/config/mattermost.php
+++ b/config/mattermost.php
@@ -120,6 +120,22 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Interactive Messages
+    |--------------------------------------------------------------------------
+    |
+    | Configure the webhook endpoint that Mattermost POSTs to when a user
+    | clicks a button or selects a menu option on an interactive message.
+    | Set `route` to `null` or `''` to disable automatic route registration.
+    |
+    */
+
+    'interactive' => [
+        'route' => env('MATTERMOST_INTERACTIVE_ROUTE', 'mattermost/interactive'),
+        'middleware' => [],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | WebSocket
     |--------------------------------------------------------------------------
     */

--- a/src/Facades/Mattermost.php
+++ b/src/Facades/Mattermost.php
@@ -29,6 +29,8 @@ use Saloon\Http\Faking\MockResponse;
  * @method static \ConduitUI\Mattermost\Bot\Router router()
  * @method static \ConduitUI\Mattermost\SlashCommands\SlashCommandRouter slash(string $command, string|\Closure $handler)
  * @method static \ConduitUI\Mattermost\SlashCommands\SlashCommandRouter slashCommandRouter()
+ * @method static \ConduitUI\Mattermost\Interactive\InteractiveActionRouter interactive(string $actionId, string|\Closure $handler)
+ * @method static \ConduitUI\Mattermost\Interactive\InteractiveActionRouter interactiveActionRouter()
  * @method static \ConduitUI\Mattermost\Testing\MattermostFake assertSent(string|\Closure $value, ?int $times = null)
  * @method static \ConduitUI\Mattermost\Testing\MattermostFake assertNotSent(string|\Closure $value)
  * @method static \ConduitUI\Mattermost\Testing\MattermostFake assertNothingSent()

--- a/src/Interactive/InteractiveAction.php
+++ b/src/Interactive/InteractiveAction.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\Interactive;
+
+/**
+ * Value object representing an incoming Mattermost interactive action payload.
+ *
+ * Mattermost POSTs a JSON payload when a user clicks a button or selects a
+ * menu option on an interactive message attachment. This DTO wraps that
+ * payload and provides typed convenience accessors.
+ */
+class InteractiveAction
+{
+    /**
+     * @param  array<string, mixed>  $payload  The raw webhook payload.
+     */
+    public function __construct(
+        private readonly array $payload,
+    ) {}
+
+    /**
+     * Build an InteractiveAction from a raw Mattermost webhook payload.
+     *
+     * @param  array<string, mixed>  $payload
+     */
+    public static function fromPayload(array $payload): self
+    {
+        return new self($payload);
+    }
+
+    /**
+     * The action ID identifying which button or menu option was triggered.
+     */
+    public function actionId(): string
+    {
+        $action = $this->payload['action'] ?? '';
+
+        return is_string($action) ? $action : '';
+    }
+
+    /**
+     * The value submitted with the action (button value or selected option).
+     */
+    public function value(): mixed
+    {
+        return $this->payload['value'] ?? null;
+    }
+
+    /**
+     * The type of interactive element ("button" or "select").
+     */
+    public function type(): string
+    {
+        $type = $this->payload['type'] ?? '';
+
+        return is_string($type) ? $type : '';
+    }
+
+    /**
+     * The user ID of the user who triggered the action.
+     */
+    public function userId(): string
+    {
+        $userId = $this->payload['user_id'] ?? '';
+
+        return is_string($userId) ? $userId : '';
+    }
+
+    /**
+     * The username (without @) of the user who triggered the action.
+     */
+    public function userName(): string
+    {
+        $userName = $this->payload['user_name'] ?? '';
+
+        return is_string($userName) ? $userName : '';
+    }
+
+    /**
+     * The channel ID where the interactive message was posted.
+     */
+    public function channelId(): string
+    {
+        $channelId = $this->payload['channel_id'] ?? '';
+
+        return is_string($channelId) ? $channelId : '';
+    }
+
+    /**
+     * The channel name where the interactive message was posted.
+     */
+    public function channelName(): string
+    {
+        $channelName = $this->payload['channel_name'] ?? '';
+
+        return is_string($channelName) ? $channelName : '';
+    }
+
+    /**
+     * The post ID of the message containing the action.
+     */
+    public function postId(): string
+    {
+        $postId = $this->payload['post_id'] ?? '';
+
+        return is_string($postId) ? $postId : '';
+    }
+
+    /**
+     * The team ID where the action was triggered.
+     */
+    public function teamId(): string
+    {
+        $teamId = $this->payload['team_id'] ?? '';
+
+        return is_string($teamId) ? $teamId : '';
+    }
+
+    /**
+     * The team domain where the action was triggered.
+     */
+    public function teamDomain(): string
+    {
+        $domain = $this->payload['team_domain'] ?? '';
+
+        return is_string($domain) ? $domain : '';
+    }
+
+    /**
+     * The trigger ID for opening interactive dialogs.
+     */
+    public function triggerId(): string
+    {
+        $id = $this->payload['trigger_id'] ?? '';
+
+        return is_string($id) ? $id : '';
+    }
+
+    /**
+     * The data source for select menus (e.g. "users", "channels").
+     */
+    public function dataSource(): string
+    {
+        $source = $this->payload['data_source'] ?? '';
+
+        return is_string($source) ? $source : '';
+    }
+
+    /**
+     * Custom context data passed through the integration payload.
+     *
+     * @return array<string, mixed>
+     */
+    public function context(): array
+    {
+        $context = $this->payload['context'] ?? [];
+
+        return is_array($context) ? $context : [];
+    }
+
+    /**
+     * The raw webhook payload array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return $this->payload;
+    }
+}

--- a/src/Interactive/InteractiveActionController.php
+++ b/src/Interactive/InteractiveActionController.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\Interactive;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * HTTP controller for receiving Mattermost interactive action webhooks.
+ *
+ * Mattermost POSTs a JSON payload when a user clicks a button or selects
+ * a menu option on an interactive message. This controller parses the
+ * payload, dispatches it through the {@see InteractiveActionRouter}, and
+ * returns the JSON response.
+ */
+class InteractiveActionController
+{
+    public function __construct(
+        private readonly InteractiveActionRouter $router,
+    ) {}
+
+    public function __invoke(Request $request): JsonResponse
+    {
+        /** @var array<string, mixed> $payload */
+        $payload = $request->all();
+
+        $action = InteractiveAction::fromPayload($payload);
+        $response = $this->router->dispatch($action);
+
+        if (! $response instanceof InteractiveActionResponse) {
+            return new JsonResponse([
+                'ephemeral_text' => sprintf('No handler registered for action: %s', $action->actionId()),
+            ]);
+        }
+
+        return new JsonResponse($response->toArray());
+    }
+}

--- a/src/Interactive/InteractiveActionHandler.php
+++ b/src/Interactive/InteractiveActionHandler.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\Interactive;
+
+/**
+ * Base class for interactive action handler classes.
+ *
+ * Subclass this and implement `handle()` to return a response. The router
+ * resolves handlers from the container so constructor DI is available.
+ *
+ *   class ApproveHandler extends InteractiveActionHandler {
+ *       public function handle(InteractiveAction $action): InteractiveActionResponse {
+ *           return InteractiveActionResponse::make()->update('Approved!');
+ *       }
+ *   }
+ */
+abstract class InteractiveActionHandler
+{
+    /**
+     * Handle the incoming interactive action and return a response.
+     */
+    abstract public function handle(InteractiveAction $action): InteractiveActionResponse;
+}

--- a/src/Interactive/InteractiveActionResponse.php
+++ b/src/Interactive/InteractiveActionResponse.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\Interactive;
+
+/**
+ * Fluent builder for an interactive action response payload.
+ *
+ * Mattermost expects a JSON response from the integration URL. The response
+ * can update the original post, send an ephemeral message, or do nothing.
+ *
+ * @see https://developers.mattermost.com/integrate/plugins/interactive-messages/
+ */
+class InteractiveActionResponse
+{
+    private ?string $updateText = null;
+
+    /** @var array<string, mixed>|null */
+    private ?array $updateProps = null;
+
+    private ?string $ephemeralText = null;
+
+    public static function make(): self
+    {
+        return new self;
+    }
+
+    /**
+     * Update the original post's message text.
+     */
+    public function update(string $text): self
+    {
+        $this->updateText = $text;
+
+        return $this;
+    }
+
+    /**
+     * Replace the original post's props (attachments, etc.).
+     *
+     * @param  array<string, mixed>  $props
+     */
+    public function props(array $props): self
+    {
+        $this->updateProps = $props;
+
+        return $this;
+    }
+
+    /**
+     * Send an ephemeral message visible only to the acting user.
+     */
+    public function ephemeral(string $text): self
+    {
+        $this->ephemeralText = $text;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $payload = [];
+
+        if ($this->updateText !== null) {
+            $payload['update'] = ['message' => $this->updateText];
+
+            if ($this->updateProps !== null) {
+                $payload['update']['props'] = $this->updateProps;
+            }
+        } elseif ($this->updateProps !== null) {
+            $payload['update'] = ['props' => $this->updateProps];
+        }
+
+        if ($this->ephemeralText !== null) {
+            $payload['ephemeral_text'] = $this->ephemeralText;
+        }
+
+        return $payload;
+    }
+}

--- a/src/Interactive/InteractiveActionRouter.php
+++ b/src/Interactive/InteractiveActionRouter.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\Interactive;
+
+use Closure;
+use Illuminate\Contracts\Container\Container;
+
+/**
+ * Route-style registration and dispatch for Mattermost interactive actions.
+ *
+ * Register handlers using `register()` with either a handler class or a closure:
+ *
+ *   $router->register('approve', ApproveHandler::class);
+ *   $router->register('deny', fn (InteractiveAction $a) => InteractiveActionResponse::make()->ephemeral('Denied'));
+ *
+ * The router resolves class-based handlers from the container so DI works.
+ */
+class InteractiveActionRouter
+{
+    /** @var array<string, class-string<InteractiveActionHandler>|Closure(InteractiveAction): InteractiveActionResponse> */
+    private array $handlers = [];
+
+    public function __construct(
+        private readonly Container $container,
+    ) {}
+
+    /**
+     * Register a handler for an interactive action ID.
+     *
+     * @param  class-string<InteractiveActionHandler>|Closure(InteractiveAction): InteractiveActionResponse  $handler
+     */
+    public function register(string $actionId, string|Closure $handler): self
+    {
+        $this->handlers[$actionId] = $handler;
+
+        return $this;
+    }
+
+    /**
+     * Dispatch an incoming interactive action payload to its registered handler.
+     *
+     * Returns null if no handler matches the action ID.
+     */
+    public function dispatch(InteractiveAction $action): ?InteractiveActionResponse
+    {
+        $actionId = $action->actionId();
+
+        $handler = $this->handlers[$actionId] ?? null;
+
+        if ($handler === null) {
+            return null;
+        }
+
+        if ($handler instanceof Closure) {
+            return $handler($action);
+        }
+
+        /** @var InteractiveActionHandler $instance */
+        $instance = $this->container->make($handler);
+
+        return $instance->handle($action);
+    }
+
+    /**
+     * Check whether a handler is registered for a given action ID.
+     */
+    public function hasHandler(string $actionId): bool
+    {
+        return isset($this->handlers[$actionId]);
+    }
+
+    /**
+     * @return array<string, class-string<InteractiveActionHandler>|Closure(InteractiveAction): InteractiveActionResponse>
+     */
+    public function handlers(): array
+    {
+        return $this->handlers;
+    }
+}

--- a/src/MattermostManager.php
+++ b/src/MattermostManager.php
@@ -9,6 +9,10 @@ use ConduitUI\Mattermost\Bot\Handler;
 use ConduitUI\Mattermost\Bot\Middleware\Middleware as BotMiddleware;
 use ConduitUI\Mattermost\Bot\Router as BotRouter;
 use ConduitUI\Mattermost\Client\Mattermost;
+use ConduitUI\Mattermost\Interactive\InteractiveAction;
+use ConduitUI\Mattermost\Interactive\InteractiveActionHandler;
+use ConduitUI\Mattermost\Interactive\InteractiveActionResponse;
+use ConduitUI\Mattermost\Interactive\InteractiveActionRouter;
 use ConduitUI\Mattermost\SlashCommands\SlashCommand;
 use ConduitUI\Mattermost\SlashCommands\SlashCommandHandler;
 use ConduitUI\Mattermost\SlashCommands\SlashCommandResponse;
@@ -97,6 +101,24 @@ class MattermostManager
     public function slash(string $command, string|Closure $handler): SlashCommandRouter
     {
         return $this->slashCommandRouter()->register($command, $handler);
+    }
+
+    /**
+     * Resolve the interactive action router from the container.
+     */
+    public function interactiveActionRouter(): InteractiveActionRouter
+    {
+        return $this->resolveContainer()->make(InteractiveActionRouter::class);
+    }
+
+    /**
+     * Register an interactive action handler — proxy to the interactive action router.
+     *
+     * @param  class-string<InteractiveActionHandler>|Closure(InteractiveAction): InteractiveActionResponse  $handler
+     */
+    public function interactive(string $actionId, string|Closure $handler): InteractiveActionRouter
+    {
+        return $this->interactiveActionRouter()->register($actionId, $handler);
     }
 
     private function resolveContainer(): Container

--- a/src/MattermostServiceProvider.php
+++ b/src/MattermostServiceProvider.php
@@ -7,6 +7,8 @@ namespace ConduitUI\Mattermost;
 use ConduitUI\Mattermost\Bot\Router as BotRouter;
 use ConduitUI\Mattermost\Commands\DemoPostCommand;
 use ConduitUI\Mattermost\Filament\Stats\MattermostStats;
+use ConduitUI\Mattermost\Interactive\InteractiveActionController;
+use ConduitUI\Mattermost\Interactive\InteractiveActionRouter;
 use ConduitUI\Mattermost\Notifications\MattermostBroadcaster;
 use ConduitUI\Mattermost\SlashCommands\SlashCommandController;
 use ConduitUI\Mattermost\SlashCommands\SlashCommandRouter;
@@ -30,6 +32,8 @@ class MattermostServiceProvider extends ServiceProvider
 
         $this->app->singleton(SlashCommandRouter::class, fn (Container $container): SlashCommandRouter => new SlashCommandRouter($container));
 
+        $this->app->singleton(InteractiveActionRouter::class, fn (Container $container): InteractiveActionRouter => new InteractiveActionRouter($container));
+
         $this->app->singleton(MattermostStats::class, fn ($app): MattermostStats => new MattermostStats(
             $app->make(CacheRepository::class),
             (string) ($app['config']->get('mattermost.default') ?? 'default'),
@@ -51,6 +55,7 @@ class MattermostServiceProvider extends ServiceProvider
         $this->registerBroadcaster();
         $this->bootBotRouter();
         $this->bootSlashCommandRoute();
+        $this->bootInteractiveRoute();
         $this->bootFilamentPanel();
     }
 
@@ -100,6 +105,22 @@ class MattermostServiceProvider extends ServiceProvider
         Route::post($uri, SlashCommandController::class)
             ->middleware($middleware)
             ->name('mattermost.slash-command');
+    }
+
+    private function bootInteractiveRoute(): void
+    {
+        $uri = config('mattermost.interactive.route', 'mattermost/interactive');
+
+        if (! is_string($uri) || $uri === '') {
+            return;
+        }
+
+        $middleware = config('mattermost.interactive.middleware', []);
+        $middleware = is_array($middleware) ? $middleware : [];
+
+        Route::post($uri, InteractiveActionController::class)
+            ->middleware($middleware)
+            ->name('mattermost.interactive');
     }
 
     /**

--- a/tests/Unit/Interactive/InteractiveActionControllerTest.php
+++ b/tests/Unit/Interactive/InteractiveActionControllerTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+use ConduitUI\Mattermost\Interactive\InteractiveAction;
+use ConduitUI\Mattermost\Interactive\InteractiveActionResponse;
+use ConduitUI\Mattermost\Interactive\InteractiveActionRouter;
+use ConduitUI\Mattermost\Testing\MattermostFixtures;
+
+describe('InteractiveActionController', function (): void {
+    it('routes a webhook POST to the registered handler and returns JSON', function (): void {
+        /** @var InteractiveActionRouter $router */
+        $router = app(InteractiveActionRouter::class);
+        $router->register('approve', fn (InteractiveAction $a): InteractiveActionResponse => InteractiveActionResponse::make()->update('Approved!'));
+
+        $payload = MattermostFixtures::fakeButtonClick('approve');
+
+        $response = $this->postJson('mattermost/interactive', $payload);
+
+        $response->assertOk();
+        $response->assertJson([
+            'update' => ['message' => 'Approved!'],
+        ]);
+    });
+
+    it('returns an ephemeral fallback for unregistered actions', function (): void {
+        $payload = MattermostFixtures::fakeButtonClick('unknown');
+
+        $response = $this->postJson('mattermost/interactive', $payload);
+
+        $response->assertOk();
+        $response->assertJson([
+            'ephemeral_text' => 'No handler registered for action: unknown',
+        ]);
+    });
+
+    it('passes context through to the handler', function (): void {
+        /** @var InteractiveActionRouter $router */
+        $router = app(InteractiveActionRouter::class);
+        $router->register('deploy', fn (InteractiveAction $a): InteractiveActionResponse => InteractiveActionResponse::make()->ephemeral('Deploying to '.$a->context()['env']));
+
+        $payload = MattermostFixtures::fakeButtonClick('deploy', context: ['env' => 'production']);
+
+        $response = $this->postJson('mattermost/interactive', $payload);
+
+        $response->assertOk();
+        $response->assertJson([
+            'ephemeral_text' => 'Deploying to production',
+        ]);
+    });
+
+    it('supports update with props response', function (): void {
+        /** @var InteractiveActionRouter $router */
+        $router = app(InteractiveActionRouter::class);
+        $router->register('clear', fn (InteractiveAction $a): InteractiveActionResponse => InteractiveActionResponse::make()->update('Cleared')->props(['attachments' => []]));
+
+        $payload = MattermostFixtures::fakeButtonClick('clear');
+
+        $response = $this->postJson('mattermost/interactive', $payload);
+
+        $response->assertOk();
+        $response->assertJson([
+            'update' => [
+                'message' => 'Cleared',
+                'props' => ['attachments' => []],
+            ],
+        ]);
+    });
+});

--- a/tests/Unit/Interactive/InteractiveActionResponseTest.php
+++ b/tests/Unit/Interactive/InteractiveActionResponseTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+use ConduitUI\Mattermost\Interactive\InteractiveActionResponse;
+
+describe('InteractiveActionResponse', function (): void {
+    it('builds an empty response by default', function (): void {
+        $response = InteractiveActionResponse::make();
+
+        expect($response->toArray())->toBe([]);
+    });
+
+    it('builds an update response with message text', function (): void {
+        $response = InteractiveActionResponse::make()->update('Approved!');
+
+        expect($response->toArray())->toBe([
+            'update' => ['message' => 'Approved!'],
+        ]);
+    });
+
+    it('builds an update response with props', function (): void {
+        $response = InteractiveActionResponse::make()
+            ->update('Done')
+            ->props(['attachments' => []]);
+
+        expect($response->toArray())->toBe([
+            'update' => [
+                'message' => 'Done',
+                'props' => ['attachments' => []],
+            ],
+        ]);
+    });
+
+    it('builds a props-only update without message', function (): void {
+        $response = InteractiveActionResponse::make()
+            ->props(['attachments' => [['text' => 'Updated']]]);
+
+        expect($response->toArray())->toBe([
+            'update' => [
+                'props' => ['attachments' => [['text' => 'Updated']]],
+            ],
+        ]);
+    });
+
+    it('builds an ephemeral response', function (): void {
+        $response = InteractiveActionResponse::make()->ephemeral('Only you can see this');
+
+        expect($response->toArray())->toBe([
+            'ephemeral_text' => 'Only you can see this',
+        ]);
+    });
+
+    it('combines update and ephemeral in one response', function (): void {
+        $response = InteractiveActionResponse::make()
+            ->update('Post updated')
+            ->ephemeral('Action recorded');
+
+        expect($response->toArray())->toBe([
+            'update' => ['message' => 'Post updated'],
+            'ephemeral_text' => 'Action recorded',
+        ]);
+    });
+
+    it('is chainable via fluent methods', function (): void {
+        $response = InteractiveActionResponse::make()
+            ->update('text')
+            ->props(['key' => 'value'])
+            ->ephemeral('note');
+
+        expect($response)->toBeInstanceOf(InteractiveActionResponse::class);
+    });
+});

--- a/tests/Unit/Interactive/InteractiveActionRouterTest.php
+++ b/tests/Unit/Interactive/InteractiveActionRouterTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+use ConduitUI\Mattermost\Interactive\InteractiveAction;
+use ConduitUI\Mattermost\Interactive\InteractiveActionHandler;
+use ConduitUI\Mattermost\Interactive\InteractiveActionResponse;
+use ConduitUI\Mattermost\Interactive\InteractiveActionRouter;
+use ConduitUI\Mattermost\Testing\MattermostFixtures;
+
+describe('InteractiveActionRouter', function (): void {
+    it('dispatches to a registered class-based handler', function (): void {
+        $router = app(InteractiveActionRouter::class);
+        $router->register('approve', StubApproveHandler::class);
+
+        $action = InteractiveAction::fromPayload(MattermostFixtures::fakeButtonClick('approve'));
+        $response = $router->dispatch($action);
+
+        expect($response)->not->toBeNull()
+            ->and($response->toArray())->toHaveKey('update')
+            ->and($response->toArray()['update']['message'])->toBe('Request approved');
+    });
+
+    it('dispatches to a registered closure handler', function (): void {
+        $router = app(InteractiveActionRouter::class);
+        $router->register('deny', fn (InteractiveAction $a): InteractiveActionResponse => InteractiveActionResponse::make()->ephemeral('Denied'));
+
+        $action = InteractiveAction::fromPayload(MattermostFixtures::fakeButtonClick('deny'));
+        $response = $router->dispatch($action);
+
+        expect($response)->not->toBeNull()
+            ->and($response->toArray()['ephemeral_text'])->toBe('Denied');
+    });
+
+    it('returns null for unregistered actions', function (): void {
+        $router = app(InteractiveActionRouter::class);
+
+        $action = InteractiveAction::fromPayload(MattermostFixtures::fakeButtonClick('unknown'));
+
+        expect($router->dispatch($action))->toBeNull();
+    });
+
+    it('checks handler registration via hasHandler', function (): void {
+        $router = app(InteractiveActionRouter::class);
+        $router->register('approve', StubApproveHandler::class);
+
+        expect($router->hasHandler('approve'))->toBeTrue()
+            ->and($router->hasHandler('unknown'))->toBeFalse();
+    });
+
+    it('returns all registered handlers', function (): void {
+        $router = app(InteractiveActionRouter::class);
+        $router->register('approve', StubApproveHandler::class);
+        $router->register('deny', fn (InteractiveAction $a): InteractiveActionResponse => InteractiveActionResponse::make());
+
+        expect($router->handlers())->toHaveCount(2)
+            ->and($router->handlers())->toHaveKeys(['approve', 'deny']);
+    });
+
+    it('allows overwriting a previously registered handler', function (): void {
+        $router = app(InteractiveActionRouter::class);
+        $router->register('approve', fn (InteractiveAction $a): InteractiveActionResponse => InteractiveActionResponse::make()->ephemeral('v1'));
+        $router->register('approve', fn (InteractiveAction $a): InteractiveActionResponse => InteractiveActionResponse::make()->ephemeral('v2'));
+
+        $action = InteractiveAction::fromPayload(MattermostFixtures::fakeButtonClick('approve'));
+        $response = $router->dispatch($action);
+
+        expect($response->toArray()['ephemeral_text'])->toBe('v2');
+    });
+
+    it('is chainable via register', function (): void {
+        $router = app(InteractiveActionRouter::class);
+
+        $result = $router
+            ->register('a', fn (InteractiveAction $a): InteractiveActionResponse => InteractiveActionResponse::make())
+            ->register('b', fn (InteractiveAction $a): InteractiveActionResponse => InteractiveActionResponse::make());
+
+        expect($result)->toBeInstanceOf(InteractiveActionRouter::class)
+            ->and($router->handlers())->toHaveCount(2);
+    });
+});
+
+// --- Stub handler for testing ---
+
+class StubApproveHandler extends InteractiveActionHandler
+{
+    #[Override]
+    public function handle(InteractiveAction $action): InteractiveActionResponse
+    {
+        return InteractiveActionResponse::make()->update('Request approved');
+    }
+}

--- a/tests/Unit/Interactive/InteractiveActionTest.php
+++ b/tests/Unit/Interactive/InteractiveActionTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+use ConduitUI\Mattermost\Interactive\InteractiveAction;
+use ConduitUI\Mattermost\Testing\MattermostFixtures;
+
+describe('InteractiveAction', function (): void {
+    it('parses action ID from payload', function (): void {
+        $action = InteractiveAction::fromPayload(MattermostFixtures::fakeButtonClick('approve'));
+
+        expect($action->actionId())->toBe('approve');
+    });
+
+    it('parses user ID from payload', function (): void {
+        $action = InteractiveAction::fromPayload(MattermostFixtures::fakeButtonClick('approve', userId: 'user123'));
+
+        expect($action->userId())->toBe('user123');
+    });
+
+    it('parses channel ID from payload', function (): void {
+        $action = InteractiveAction::fromPayload(MattermostFixtures::fakeButtonClick('approve', channelId: 'chan123'));
+
+        expect($action->channelId())->toBe('chan123');
+    });
+
+    it('parses post ID from payload', function (): void {
+        $action = InteractiveAction::fromPayload(MattermostFixtures::fakeButtonClick('approve', postId: 'post123'));
+
+        expect($action->postId())->toBe('post123');
+    });
+
+    it('parses type from payload', function (): void {
+        $action = InteractiveAction::fromPayload(MattermostFixtures::fakeButtonClick('approve'));
+
+        expect($action->type())->toBe('button');
+    });
+
+    it('parses context from payload', function (): void {
+        $action = InteractiveAction::fromPayload(MattermostFixtures::fakeButtonClick('approve', context: ['env' => 'production']));
+
+        expect($action->context())->toHaveKey('env', 'production')
+            ->and($action->context())->toHaveKey('action', 'approve');
+    });
+
+    it('parses value from payload', function (): void {
+        $action = InteractiveAction::fromPayload(MattermostFixtures::fakeButtonClick('approve', value: 'yes'));
+
+        expect($action->value())->toBe('yes');
+    });
+
+    it('returns null value when not present', function (): void {
+        $action = InteractiveAction::fromPayload(MattermostFixtures::fakeButtonClick('approve'));
+
+        expect($action->value())->toBeNull();
+    });
+
+    it('parses team ID and domain from payload', function (): void {
+        $action = InteractiveAction::fromPayload(MattermostFixtures::fakeButtonClick('approve'));
+
+        expect($action->teamId())->not->toBeEmpty()
+            ->and($action->teamDomain())->toBe('test-team');
+    });
+
+    it('parses trigger ID from payload', function (): void {
+        $action = InteractiveAction::fromPayload(MattermostFixtures::fakeButtonClick('approve'));
+
+        expect($action->triggerId())->not->toBeEmpty();
+    });
+
+    it('parses username from payload', function (): void {
+        $action = InteractiveAction::fromPayload(MattermostFixtures::fakeButtonClick('approve'));
+
+        expect($action->userName())->toBe('testuser');
+    });
+
+    it('parses channel name from payload', function (): void {
+        $action = InteractiveAction::fromPayload(MattermostFixtures::fakeButtonClick('approve'));
+
+        expect($action->channelName())->toBe('town-square');
+    });
+
+    it('parses data source from payload', function (): void {
+        $action = InteractiveAction::fromPayload(MattermostFixtures::fakeButtonClick('approve'));
+
+        expect($action->dataSource())->toBe('');
+    });
+
+    it('returns the raw payload via toArray', function (): void {
+        $payload = MattermostFixtures::fakeButtonClick('approve');
+        $action = InteractiveAction::fromPayload($payload);
+
+        expect($action->toArray())->toBe($payload);
+    });
+
+    it('returns empty strings for missing string fields', function (): void {
+        $action = InteractiveAction::fromPayload([]);
+
+        expect($action->actionId())->toBe('')
+            ->and($action->userId())->toBe('')
+            ->and($action->channelId())->toBe('')
+            ->and($action->postId())->toBe('')
+            ->and($action->type())->toBe('')
+            ->and($action->teamId())->toBe('')
+            ->and($action->triggerId())->toBe('');
+    });
+
+    it('returns empty array for missing context', function (): void {
+        $action = InteractiveAction::fromPayload([]);
+
+        expect($action->context())->toBe([]);
+    });
+});


### PR DESCRIPTION
## Summary

- **InteractiveAction** DTO wrapping Mattermost's interactive webhook payload with typed accessors (action ID, user, channel, post, context, type, trigger ID)
- **InteractiveActionHandler** abstract base class resolved from the container for constructor DI
- **InteractiveActionRouter** with route-style `register(actionId, handler|closure)` and `dispatch()` — mirrors `SlashCommandRouter`
- **InteractiveActionResponse** fluent builder supporting `update()` (replace original post text), `props()` (replace attachments), and `ephemeral()` (whisper to acting user)
- **InteractiveActionController** webhook endpoint auto-registered at `mattermost/interactive` via config
- **Manager + Facade** integration: `Mattermost::interactive('action-id', Handler::class)` and `Mattermost::interactiveActionRouter()`
- Config section `mattermost.interactive` with route and middleware options
- Full Pest test coverage (describe/it BDD) — DTO, response builder, router, and controller HTTP tests

## Test plan

- [x] `vendor/bin/pint --test` passes
- [x] `vendor/bin/pest --compact` — 302 passed (all new Interactive tests green)
- [x] `vendor/bin/phpstan analyse` — no errors at level 8
- [x] `vendor/bin/rector process --dry-run` — no changes suggested

Closes #8

Demo: http://localhost:8065/jordan-partridge-enterprises-llc/pl/fwp7wfnq67bdmqkkp1jp3x874y