### PR TITLE
feat: middleware guards — permission-based handler access control

### DIFF
--- a/src/Bot/Middleware/Guards/ChannelMember.php
+++ b/src/Bot/Middleware/Guards/ChannelMember.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\Bot\Middleware\Guards;
+
+use Closure;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelMember;
+use ConduitUI\Mattermost\MattermostManager;
+use ConduitUI\Mattermost\WebSocket\Events\Event;
+use ConduitUI\Mattermost\WebSocket\Events\PostCreated;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
+use Throwable;
+
+/**
+ * Guard that only allows events from users who are members of the post's channel.
+ *
+ * Uses `GET /channels/{id}/members/{userId}` to verify membership. A 200
+ * response means the user is a member; any error (404, 403, etc.) means they
+ * are not. Results are cached per user+channel pair for
+ * `mattermost.bot.guard_cache_ttl` seconds (default 300).
+ */
+class ChannelMember implements Guard
+{
+    public function __construct(
+        private readonly MattermostManager $mattermost,
+        private readonly CacheRepository $cache,
+    ) {}
+
+    #[\Override]
+    public function handle(Event $event, Closure $next): void
+    {
+        if (! $event instanceof PostCreated) {
+            $next($event);
+
+            return;
+        }
+
+        $userId = $event->userId();
+        $channelId = $event->channelId();
+
+        if ($userId === '' || $channelId === '') {
+            return;
+        }
+
+        if (! $this->authorize($userId, $channelId)) {
+            return;
+        }
+
+        $next($event);
+    }
+
+    #[\Override]
+    public function authorize(string $userId, string $channelId): bool
+    {
+        return $this->isMember($userId, $channelId);
+    }
+
+    private function isMember(string $userId, string $channelId): bool
+    {
+        $key = sprintf('mattermost:bot:guard:channel_member:%s:%s', $channelId, $userId);
+        $ttl = $this->resolveTtl();
+
+        $cached = $this->cache->get($key);
+
+        if (is_bool($cached)) {
+            return $cached;
+        }
+
+        $result = $this->fetchMembership($userId, $channelId);
+
+        $this->cache->put($key, $result, $ttl);
+
+        return $result;
+    }
+
+    private function fetchMembership(string $userId, string $channelId): bool
+    {
+        try {
+            $response = $this->mattermost->connection()->send(
+                new GetChannelMember($channelId, $userId),
+            );
+
+            return $response->successful();
+        } catch (Throwable) {
+            return false;
+        }
+    }
+
+    private function resolveTtl(): int
+    {
+        $configured = config('mattermost.bot.guard_cache_ttl', 300);
+
+        return is_numeric($configured) ? max(1, (int) $configured) : 300;
+    }
+}

--- a/src/Bot/Middleware/Guards/Guard.php
+++ b/src/Bot/Middleware/Guards/Guard.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\Bot\Middleware\Guards;
+
+use ConduitUI\Mattermost\Bot\Middleware\Middleware;
+
+/**
+ * Contract for permission-based middleware guards.
+ *
+ * Guards extend the standard middleware contract with a semantic `authorize`
+ * method. Implementations should return `true` to allow the event through,
+ * or `false` to short-circuit the pipeline.
+ */
+interface Guard extends Middleware
+{
+    /**
+     * Determine whether the given user is authorized for the given context.
+     */
+    public function authorize(string $userId, string $channelId): bool;
+}

--- a/src/Bot/Middleware/Guards/RequiresPermission.php
+++ b/src/Bot/Middleware/Guards/RequiresPermission.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\Bot\Middleware\Guards;
+
+use Closure;
+use ConduitUI\Mattermost\Client\Requests\Users\GetUser;
+use ConduitUI\Mattermost\MattermostManager;
+use ConduitUI\Mattermost\WebSocket\Events\Event;
+use ConduitUI\Mattermost\WebSocket\Events\PostCreated;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
+use Throwable;
+
+/**
+ * Guard that requires the post author to have a specific Mattermost permission.
+ *
+ * Mattermost encodes permissions into role strings on the user object. This
+ * guard checks for well-known role→permission mappings. For example, the
+ * `manage_team` permission maps to `team_admin` or `system_admin` roles.
+ *
+ * The result is cached per-user for `mattermost.bot.guard_cache_ttl` seconds
+ * (default 300).
+ */
+class RequiresPermission implements Guard
+{
+    /**
+     * Map of permission names to the roles that grant them.
+     *
+     * @var array<string, array<int, string>>
+     */
+    private const array PERMISSION_ROLE_MAP = [
+        'manage_team' => ['team_admin', 'system_admin'],
+        'manage_channel' => ['channel_admin', 'team_admin', 'system_admin'],
+        'manage_system' => ['system_admin'],
+        'create_post' => ['system_user', 'team_admin', 'system_admin'],
+        'manage_webhooks' => ['team_admin', 'system_admin'],
+        'manage_slash_commands' => ['team_admin', 'system_admin'],
+        'manage_others_webhooks' => ['system_admin'],
+        'manage_oauth' => ['system_admin'],
+        'manage_roles' => ['system_admin'],
+    ];
+
+    public function __construct(
+        private readonly MattermostManager $mattermost,
+        private readonly CacheRepository $cache,
+        private readonly string $permission = 'manage_team',
+    ) {}
+
+    #[\Override]
+    public function handle(Event $event, Closure $next): void
+    {
+        if (! $event instanceof PostCreated) {
+            $next($event);
+
+            return;
+        }
+
+        $userId = $event->userId();
+
+        if ($userId === '') {
+            return;
+        }
+
+        if (! $this->authorize($userId, $event->channelId())) {
+            return;
+        }
+
+        $next($event);
+    }
+
+    #[\Override]
+    public function authorize(string $userId, string $channelId): bool
+    {
+        return $this->hasPermission($userId);
+    }
+
+    private function hasPermission(string $userId): bool
+    {
+        $key = sprintf('mattermost:bot:guard:permission:%s:%s', $this->permission, $userId);
+        $ttl = $this->resolveTtl();
+
+        $cached = $this->cache->get($key);
+
+        if (is_bool($cached)) {
+            return $cached;
+        }
+
+        $result = $this->fetchHasPermission($userId);
+
+        $this->cache->put($key, $result, $ttl);
+
+        return $result;
+    }
+
+    private function fetchHasPermission(string $userId): bool
+    {
+        try {
+            $response = $this->mattermost->connection()->send(new GetUser($userId));
+            $payload = $response->json();
+        } catch (Throwable) {
+            return false;
+        }
+
+        $roles = $payload['roles'] ?? '';
+
+        if (! is_string($roles) || $roles === '') {
+            return false;
+        }
+
+        $userRoles = preg_split('/\s+/', trim($roles)) ?: [];
+        $requiredRoles = self::PERMISSION_ROLE_MAP[$this->permission] ?? [];
+
+        if ($requiredRoles === []) {
+            return false;
+        }
+
+        return array_any($requiredRoles, fn (string $role): bool => in_array($role, $userRoles, true));
+    }
+
+    private function resolveTtl(): int
+    {
+        $configured = config('mattermost.bot.guard_cache_ttl', 300);
+
+        return is_numeric($configured) ? max(1, (int) $configured) : 300;
+    }
+}

--- a/src/Bot/Middleware/Guards/RequiresRole.php
+++ b/src/Bot/Middleware/Guards/RequiresRole.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\Bot\Middleware\Guards;
+
+use Closure;
+use ConduitUI\Mattermost\Client\Requests\Users\GetUser;
+use ConduitUI\Mattermost\MattermostManager;
+use ConduitUI\Mattermost\WebSocket\Events\Event;
+use ConduitUI\Mattermost\WebSocket\Events\PostCreated;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
+use Throwable;
+
+/**
+ * Guard that requires the post author to have a specific Mattermost role.
+ *
+ * Checks the `roles` field from `GET /users/{id}` for the configured role
+ * string (e.g. `system_admin`, `team_admin`). The result is cached per-user
+ * for `mattermost.bot.guard_cache_ttl` seconds (default 300).
+ */
+class RequiresRole implements Guard
+{
+    public function __construct(
+        private readonly MattermostManager $mattermost,
+        private readonly CacheRepository $cache,
+        private readonly string $role = 'system_admin',
+    ) {}
+
+    #[\Override]
+    public function handle(Event $event, Closure $next): void
+    {
+        if (! $event instanceof PostCreated) {
+            $next($event);
+
+            return;
+        }
+
+        $userId = $event->userId();
+
+        if ($userId === '') {
+            return;
+        }
+
+        if (! $this->authorize($userId, $event->channelId())) {
+            return;
+        }
+
+        $next($event);
+    }
+
+    #[\Override]
+    public function authorize(string $userId, string $channelId): bool
+    {
+        return $this->hasRole($userId);
+    }
+
+    private function hasRole(string $userId): bool
+    {
+        $key = sprintf('mattermost:bot:guard:role:%s:%s', $this->role, $userId);
+        $ttl = $this->resolveTtl();
+
+        $cached = $this->cache->get($key);
+
+        if (is_bool($cached)) {
+            return $cached;
+        }
+
+        $result = $this->fetchHasRole($userId);
+
+        $this->cache->put($key, $result, $ttl);
+
+        return $result;
+    }
+
+    private function fetchHasRole(string $userId): bool
+    {
+        try {
+            $response = $this->mattermost->connection()->send(new GetUser($userId));
+            $payload = $response->json();
+        } catch (Throwable) {
+            return false;
+        }
+
+        $roles = $payload['roles'] ?? '';
+
+        if (! is_string($roles) || $roles === '') {
+            return false;
+        }
+
+        $userRoles = preg_split('/\s+/', trim($roles)) ?: [];
+
+        return in_array($this->role, $userRoles, true);
+    }
+
+    private function resolveTtl(): int
+    {
+        $configured = config('mattermost.bot.guard_cache_ttl', 300);
+
+        return is_numeric($configured) ? max(1, (int) $configured) : 300;
+    }
+}

--- a/tests/Unit/Bot/Middleware/Guards/ChannelMemberTest.php
+++ b/tests/Unit/Bot/Middleware/Guards/ChannelMemberTest.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+use ConduitUI\Mattermost\Bot\Middleware\Guards\ChannelMember;
+use ConduitUI\Mattermost\Client\Requests\Channels\GetChannelMember;
+use ConduitUI\Mattermost\Facades\Mattermost;
+use ConduitUI\Mattermost\WebSocket\Events\PostCreated;
+use ConduitUI\Mattermost\WebSocket\Events\Typing;
+use Illuminate\Cache\ArrayStore;
+use Illuminate\Cache\Repository;
+use Saloon\Http\Faking\MockResponse;
+
+function memberPost(string $userId, string $channelId = 'c1'): PostCreated
+{
+    return new PostCreated(
+        data: [
+            'post' => json_encode([
+                'id' => 'p1',
+                'channel_id' => $channelId,
+                'user_id' => $userId,
+            ]),
+        ],
+        broadcast: ['channel_id' => $channelId],
+        seq: 1,
+    );
+}
+
+describe('ChannelMember', function (): void {
+    it('allows channel members through', function (): void {
+        $fake = Mattermost::fake([
+            GetChannelMember::class => MockResponse::make([
+                'channel_id' => 'c1',
+                'user_id' => 'u1',
+                'roles' => 'channel_user',
+            ]),
+        ]);
+
+        $mw = new ChannelMember($fake, new Repository(new ArrayStore));
+        $hit = 0;
+
+        $mw->handle(memberPost('u1', 'c1'), function () use (&$hit): void {
+            $hit++;
+        });
+
+        expect($hit)->toBe(1);
+    });
+
+    it('blocks non-members', function (): void {
+        $fake = Mattermost::fake([
+            GetChannelMember::class => MockResponse::make(
+                ['status_code' => 404, 'message' => 'not a member'],
+                404,
+            ),
+        ]);
+
+        $mw = new ChannelMember($fake, new Repository(new ArrayStore));
+        $hit = 0;
+
+        $mw->handle(memberPost('u1', 'c1'), function () use (&$hit): void {
+            $hit++;
+        });
+
+        expect($hit)->toBe(0);
+    });
+
+    it('caches membership per user+channel pair', function (): void {
+        $fake = Mattermost::fake([
+            GetChannelMember::class => MockResponse::make([
+                'channel_id' => 'c1',
+                'user_id' => 'u1',
+            ]),
+        ]);
+
+        $cache = new Repository(new ArrayStore);
+        $mw = new ChannelMember($fake, $cache);
+
+        $mw->handle(memberPost('u1', 'c1'), fn () => null);
+        $mw->handle(memberPost('u1', 'c1'), fn () => null);
+
+        expect($fake->recorded(GetChannelMember::class))->toHaveCount(1);
+    });
+
+    it('checks separately for different channels', function (): void {
+        $fake = Mattermost::fake([
+            GetChannelMember::class => MockResponse::make([
+                'channel_id' => 'c1',
+                'user_id' => 'u1',
+            ]),
+        ]);
+
+        $cache = new Repository(new ArrayStore);
+        $mw = new ChannelMember($fake, $cache);
+
+        $mw->handle(memberPost('u1', 'c1'), fn () => null);
+        $mw->handle(memberPost('u1', 'c2'), fn () => null);
+
+        expect($fake->recorded(GetChannelMember::class))->toHaveCount(2);
+    });
+
+    it('treats API failures as non-member', function (): void {
+        $fake = Mattermost::fake([
+            GetChannelMember::class => MockResponse::make(['error' => 'boom'], 500),
+        ]);
+
+        $mw = new ChannelMember($fake, new Repository(new ArrayStore));
+        $hit = 0;
+
+        $mw->handle(memberPost('u1', 'c1'), function () use (&$hit): void {
+            $hit++;
+        });
+
+        expect($hit)->toBe(0);
+    });
+
+    it('passes non-PostCreated events through', function (): void {
+        $fake = Mattermost::fake();
+
+        $mw = new ChannelMember($fake, new Repository(new ArrayStore));
+        $hit = 0;
+
+        $event = new Typing(data: [], broadcast: [], seq: 1);
+
+        $mw->handle($event, function () use (&$hit): void {
+            $hit++;
+        });
+
+        expect($hit)->toBe(1);
+    });
+
+    it('drops events with empty user id', function (): void {
+        $fake = Mattermost::fake();
+
+        $mw = new ChannelMember($fake, new Repository(new ArrayStore));
+        $hit = 0;
+
+        $mw->handle(memberPost('', 'c1'), function () use (&$hit): void {
+            $hit++;
+        });
+
+        expect($hit)->toBe(0);
+    });
+
+    it('drops events with empty channel id', function (): void {
+        $fake = Mattermost::fake();
+
+        $mw = new ChannelMember($fake, new Repository(new ArrayStore));
+        $hit = 0;
+
+        $mw->handle(memberPost('u1', ''), function () use (&$hit): void {
+            $hit++;
+        });
+
+        expect($hit)->toBe(0);
+    });
+
+    it('implements the Guard interface', function (): void {
+        $fake = Mattermost::fake([
+            GetChannelMember::class => MockResponse::make([
+                'channel_id' => 'c1',
+                'user_id' => 'u1',
+            ]),
+        ]);
+
+        $mw = new ChannelMember($fake, new Repository(new ArrayStore));
+
+        expect($mw->authorize('u1', 'c1'))->toBeTrue();
+    });
+});

--- a/tests/Unit/Bot/Middleware/Guards/RequiresPermissionTest.php
+++ b/tests/Unit/Bot/Middleware/Guards/RequiresPermissionTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+use ConduitUI\Mattermost\Bot\Middleware\Guards\RequiresPermission;
+use ConduitUI\Mattermost\Client\Requests\Users\GetUser;
+use ConduitUI\Mattermost\Facades\Mattermost;
+use ConduitUI\Mattermost\WebSocket\Events\PostCreated;
+use ConduitUI\Mattermost\WebSocket\Events\Typing;
+use Illuminate\Cache\ArrayStore;
+use Illuminate\Cache\Repository;
+use Saloon\Http\Faking\MockResponse;
+
+function permissionPost(string $userId, string $channelId = 'c1'): PostCreated
+{
+    return new PostCreated(
+        data: [
+            'post' => json_encode([
+                'id' => 'p1',
+                'channel_id' => $channelId,
+                'user_id' => $userId,
+            ]),
+        ],
+        broadcast: ['channel_id' => $channelId],
+        seq: 1,
+    );
+}
+
+describe('RequiresPermission', function (): void {
+    it('allows users with a role that grants the permission', function (): void {
+        $fake = Mattermost::fake([
+            GetUser::class => MockResponse::make(['id' => 'u1', 'roles' => 'system_user team_admin']),
+        ]);
+
+        $mw = new RequiresPermission($fake, new Repository(new ArrayStore), 'manage_team');
+        $hit = 0;
+
+        $mw->handle(permissionPost('u1'), function () use (&$hit): void {
+            $hit++;
+        });
+
+        expect($hit)->toBe(1);
+    });
+
+    it('blocks users without a role that grants the permission', function (): void {
+        $fake = Mattermost::fake([
+            GetUser::class => MockResponse::make(['id' => 'u1', 'roles' => 'system_user']),
+        ]);
+
+        $mw = new RequiresPermission($fake, new Repository(new ArrayStore), 'manage_team');
+        $hit = 0;
+
+        $mw->handle(permissionPost('u1'), function () use (&$hit): void {
+            $hit++;
+        });
+
+        expect($hit)->toBe(0);
+    });
+
+    it('allows system_admin for manage_system permission', function (): void {
+        $fake = Mattermost::fake([
+            GetUser::class => MockResponse::make(['id' => 'u1', 'roles' => 'system_user system_admin']),
+        ]);
+
+        $mw = new RequiresPermission($fake, new Repository(new ArrayStore), 'manage_system');
+        $hit = 0;
+
+        $mw->handle(permissionPost('u1'), function () use (&$hit): void {
+            $hit++;
+        });
+
+        expect($hit)->toBe(1);
+    });
+
+    it('denies unknown permissions', function (): void {
+        $fake = Mattermost::fake([
+            GetUser::class => MockResponse::make(['id' => 'u1', 'roles' => 'system_admin']),
+        ]);
+
+        $mw = new RequiresPermission($fake, new Repository(new ArrayStore), 'nonexistent_perm');
+        $hit = 0;
+
+        $mw->handle(permissionPost('u1'), function () use (&$hit): void {
+            $hit++;
+        });
+
+        expect($hit)->toBe(0);
+    });
+
+    it('caches permission lookups per user', function (): void {
+        $fake = Mattermost::fake([
+            GetUser::class => MockResponse::make(['id' => 'u1', 'roles' => 'team_admin']),
+        ]);
+
+        $cache = new Repository(new ArrayStore);
+        $mw = new RequiresPermission($fake, $cache, 'manage_team');
+
+        $mw->handle(permissionPost('u1'), fn () => null);
+        $mw->handle(permissionPost('u1'), fn () => null);
+
+        expect($fake->recorded(GetUser::class))->toHaveCount(1);
+    });
+
+    it('treats API failures as unauthorized', function (): void {
+        $fake = Mattermost::fake([
+            GetUser::class => MockResponse::make(['error' => 'boom'], 500),
+        ]);
+
+        $mw = new RequiresPermission($fake, new Repository(new ArrayStore), 'manage_team');
+        $hit = 0;
+
+        $mw->handle(permissionPost('u1'), function () use (&$hit): void {
+            $hit++;
+        });
+
+        expect($hit)->toBe(0);
+    });
+
+    it('passes non-PostCreated events through', function (): void {
+        $fake = Mattermost::fake();
+
+        $mw = new RequiresPermission($fake, new Repository(new ArrayStore), 'manage_team');
+        $hit = 0;
+
+        $event = new Typing(data: [], broadcast: [], seq: 1);
+
+        $mw->handle($event, function () use (&$hit): void {
+            $hit++;
+        });
+
+        expect($hit)->toBe(1);
+    });
+
+    it('implements the Guard interface', function (): void {
+        $fake = Mattermost::fake([
+            GetUser::class => MockResponse::make(['id' => 'u1', 'roles' => 'system_admin']),
+        ]);
+
+        $mw = new RequiresPermission($fake, new Repository(new ArrayStore), 'manage_system');
+
+        expect($mw->authorize('u1', 'c1'))->toBeTrue();
+    });
+});

--- a/tests/Unit/Bot/Middleware/Guards/RequiresRoleTest.php
+++ b/tests/Unit/Bot/Middleware/Guards/RequiresRoleTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+use ConduitUI\Mattermost\Bot\Middleware\Guards\RequiresRole;
+use ConduitUI\Mattermost\Client\Requests\Users\GetUser;
+use ConduitUI\Mattermost\Facades\Mattermost;
+use ConduitUI\Mattermost\WebSocket\Events\PostCreated;
+use ConduitUI\Mattermost\WebSocket\Events\Typing;
+use Illuminate\Cache\ArrayStore;
+use Illuminate\Cache\Repository;
+use Saloon\Http\Faking\MockResponse;
+
+function guardPost(string $userId, string $channelId = 'c1'): PostCreated
+{
+    return new PostCreated(
+        data: [
+            'post' => json_encode([
+                'id' => 'p1',
+                'channel_id' => $channelId,
+                'user_id' => $userId,
+            ]),
+        ],
+        broadcast: ['channel_id' => $channelId],
+        seq: 1,
+    );
+}
+
+describe('RequiresRole', function (): void {
+    it('allows users with the required role', function (): void {
+        $fake = Mattermost::fake([
+            GetUser::class => MockResponse::make(['id' => 'u1', 'roles' => 'system_user system_admin']),
+        ]);
+
+        $mw = new RequiresRole($fake, new Repository(new ArrayStore), 'system_admin');
+        $hit = 0;
+
+        $mw->handle(guardPost('u1'), function () use (&$hit): void {
+            $hit++;
+        });
+
+        expect($hit)->toBe(1);
+    });
+
+    it('blocks users without the required role', function (): void {
+        $fake = Mattermost::fake([
+            GetUser::class => MockResponse::make(['id' => 'u1', 'roles' => 'system_user']),
+        ]);
+
+        $mw = new RequiresRole($fake, new Repository(new ArrayStore), 'system_admin');
+        $hit = 0;
+
+        $mw->handle(guardPost('u1'), function () use (&$hit): void {
+            $hit++;
+        });
+
+        expect($hit)->toBe(0);
+    });
+
+    it('caches role lookups per user', function (): void {
+        $fake = Mattermost::fake([
+            GetUser::class => MockResponse::make(['id' => 'u1', 'roles' => 'system_admin']),
+        ]);
+
+        $cache = new Repository(new ArrayStore);
+        $mw = new RequiresRole($fake, $cache, 'system_admin');
+
+        $mw->handle(guardPost('u1'), fn () => null);
+        $mw->handle(guardPost('u1'), fn () => null);
+
+        expect($fake->recorded(GetUser::class))->toHaveCount(1);
+    });
+
+    it('treats API failures as unauthorized', function (): void {
+        $fake = Mattermost::fake([
+            GetUser::class => MockResponse::make(['error' => 'boom'], 500),
+        ]);
+
+        $mw = new RequiresRole($fake, new Repository(new ArrayStore), 'system_admin');
+        $hit = 0;
+
+        $mw->handle(guardPost('u1'), function () use (&$hit): void {
+            $hit++;
+        });
+
+        expect($hit)->toBe(0);
+    });
+
+    it('passes non-PostCreated events through', function (): void {
+        $fake = Mattermost::fake();
+
+        $mw = new RequiresRole($fake, new Repository(new ArrayStore), 'system_admin');
+        $hit = 0;
+
+        $event = new Typing(data: [], broadcast: [], seq: 1);
+
+        $mw->handle($event, function () use (&$hit): void {
+            $hit++;
+        });
+
+        expect($hit)->toBe(1);
+    });
+
+    it('drops events with empty user id', function (): void {
+        $fake = Mattermost::fake();
+
+        $mw = new RequiresRole($fake, new Repository(new ArrayStore), 'system_admin');
+        $hit = 0;
+
+        $mw->handle(guardPost(''), function () use (&$hit): void {
+            $hit++;
+        });
+
+        expect($hit)->toBe(0);
+    });
+
+    it('implements the Guard interface', function (): void {
+        $fake = Mattermost::fake([
+            GetUser::class => MockResponse::make(['id' => 'u1', 'roles' => 'system_admin']),
+        ]);
+
+        $mw = new RequiresRole($fake, new Repository(new ArrayStore), 'system_admin');
+
+        expect($mw->authorize('u1', 'c1'))->toBeTrue();
+    });
+});


### PR DESCRIPTION
## Summary

Adds permission-based middleware guards under `src/Bot/Middleware/Guards/`:

- **`Guard` interface** — contract with `authorize(userId, channelId): bool` for custom guards
- **`RequiresRole`** — short-circuits if user lacks a specific Mattermost role (e.g. `system_admin`)
- **`RequiresPermission`** — maps permission names to roles (e.g. `manage_team` → `team_admin|system_admin`)
- **`ChannelMember`** — verifies user is a member of the post's channel via `GET /channels/{id}/members/{userId}`

All guards follow the existing cache-backed pattern from `AdminOnly` with configurable TTL via `mattermost.bot.guard_cache_ttl` (default 300s).

Closes #13

## Test plan

- [x] `RequiresRole` — 7 tests: allows/blocks by role, caches lookups, handles API failures, passes non-PostCreated events, drops empty userId, implements Guard interface
- [x] `RequiresPermission` — 8 tests: allows/blocks by permission→role mapping, denies unknown permissions, caches, handles API failures, passes non-PostCreated, implements Guard
- [x] `ChannelMember` — 9 tests: allows members, blocks non-members, caches per user+channel, checks different channels separately, handles API failures, passes non-PostCreated, drops empty userId/channelId, implements Guard
- [x] `pint --test` — passed
- [x] `pest` — 292 passed, 0 failed
- [x] `phpstan analyse` (level 8) — 0 errors
- [x] `rector --dry-run` — no changes

Demo: pending — orchestrator will post