### PR TITLE
fix(8): read interactive action_id from context, not top-level

### DIFF
--- a/src/Interactive/InteractiveAction.php
+++ b/src/Interactive/InteractiveAction.php
@@ -32,20 +32,26 @@ class InteractiveAction
 
     /**
      * The action ID identifying which button or menu option was triggered.
+     *
+     * Mattermost passes the integration's `context` object back through the
+     * webhook unchanged. By convention this package keys the action name as
+     * `context.action`, set when registering the button via the message
+     * builder's `integration.context.action` field.
      */
     public function actionId(): string
     {
-        $action = $this->payload['action'] ?? '';
+        $action = $this->payload['context']['action'] ?? '';
 
         return is_string($action) ? $action : '';
     }
 
     /**
-     * The value submitted with the action (button value or selected option).
+     * The value associated with the action — read from `context.value` since
+     * Mattermost does not surface a top-level `value` field on the webhook.
      */
     public function value(): mixed
     {
-        return $this->payload['value'] ?? null;
+        return $this->payload['context']['value'] ?? null;
     }
 
     /**

--- a/src/Testing/MattermostFixtures.php
+++ b/src/Testing/MattermostFixtures.php
@@ -320,9 +320,11 @@ class MattermostFixtures
             'trigger_id' => self::id(),
             'type' => 'button',
             'data_source' => '',
-            'context' => array_merge(['action' => $actionId], $context),
-            'action' => $actionId,
-            'value' => $value,
+            'context' => array_merge(
+                ['action' => $actionId],
+                $value !== null ? ['value' => $value] : [],
+                $context,
+            ),
         ];
     }
 

--- a/tests/Unit/Testing/MattermostFixturesTest.php
+++ b/tests/Unit/Testing/MattermostFixturesTest.php
@@ -123,12 +123,17 @@ describe('MattermostFixtures::fakeSlashCommand()', function (): void {
 });
 
 describe('MattermostFixtures::fakeButtonClick()', function (): void {
-    it('builds an interactive button payload', function (): void {
+    it('builds an interactive button payload with action and value nested under context', function (): void {
         $payload = MattermostFixtures::fakeButtonClick('approve', 'yes', ['plan_id' => '42']);
 
-        expect($payload['action'])->toBe('approve')
-            ->and($payload['value'])->toBe('yes')
-            ->and($payload['context'])->toBe(['action' => 'approve', 'plan_id' => '42']);
+        expect($payload['type'])->toBe('button')
+            ->and($payload['context'])->toBe([
+                'action' => 'approve',
+                'value' => 'yes',
+                'plan_id' => '42',
+            ])
+            ->and($payload)->not->toHaveKey('action')
+            ->and($payload)->not->toHaveKey('value');
     });
 });
 


### PR DESCRIPTION
## Summary

Fix-forward for the bug Lexi flagged on PR #33 — her CHANGES_REQUESTED review landed 6 minutes *after* the merge, so the broken DTO is currently in `main`.

`InteractiveAction::actionId()` and `value()` were reading top-level `action` / `value` keys that **do not exist in real Mattermost interactive webhook payloads**. Mattermost passes the integrator's `context` object back unchanged — by convention this package keys the action name as `context.action`. The original tests passed because `MattermostFixtures::fakeButtonClick()` fabricated both shapes (the real `context` key plus spurious top-level shortcuts). In production the top-level shortcuts are absent, so `actionId()` returned `''` and the router never matched any registered handler.

## Note on Lexi's review

She had the right diagnosis (DTO reads from the wrong place) but described the format as Slack's (`application/x-www-form-urlencoded` with a `payload` field holding JSON). Mattermost's actual format is JSON — see [the Mattermost docs](https://developers.mattermost.com/integrate/plugins/server/api/#interactive-messages). The controller's `$request->all()` is correct as-is; only the DTO and fixture needed changes.

## Changes

- **`src/Interactive/InteractiveAction.php`** — `actionId()` reads from `$payload['context']['action']`; `value()` reads from `$payload['context']['value']`. Doc-blocks explain the integrator-supplied-context convention.
- **`src/Testing/MattermostFixtures.php`** — `fakeButtonClick()` no longer emits the spurious top-level `action` / `value` keys. Both nest inside `context` to mirror real Mattermost payloads.
- **`tests/Unit/Testing/MattermostFixturesTest.php`** — assertion updated for the new shape and explicitly checks no top-level `action`/`value` keys leak.

## Test plan

- [x] `vendor/bin/pest --compact` — 341 passed (14 integration skipped)
- [x] `vendor/bin/pint --test` — clean
- [x] `vendor/bin/phpstan analyse` — clean at level 8
- [x] `vendor/bin/rector process --dry-run` — clean

The 34 existing `tests/Unit/Interactive/*` tests still pass without modification — the fixture continues to expose `context.action` (where they read it) but no longer emits the spurious top-level fields.
