### PR TITLE
feat(39): users()->updateProfilePhoto + deleteProfilePhoto — admin-token multipart upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,6 +502,47 @@ Pick the connection per call:
 Mattermost::connection('staging')->posts()->createPost([...]);
 ```
 
+### Admin-token operations
+
+A handful of endpoints — most notably `users()->updateProfilePhoto()` — only
+work when the caller holds a token with admin privileges, because Mattermost
+won't let a bot update its own avatar with its own token. Model that as a
+second named connection:
+
+```php
+'connections' => [
+    'default' => [
+        'url'   => env('MATTERMOST_URL'),
+        'token' => env('MATTERMOST_BOT_TOKEN'),
+    ],
+    'admin' => [
+        'url'   => env('MATTERMOST_URL'),
+        'token' => env('MATTERMOST_ADMIN_TOKEN'),
+    ],
+],
+```
+
+Then route the privileged calls through the admin connection while leaving
+day-to-day bot traffic on the default token:
+
+```php
+// Day-to-day — bot token, default connection.
+Mattermost::posts()->createPost([...]);
+
+// Privileged — admin token, explicit connection.
+Mattermost::connection('admin')
+    ->users()
+    ->updateProfilePhoto($botUserId, '/path/to/avatar.png');
+
+Mattermost::connection('admin')
+    ->users()
+    ->deleteProfilePhoto($botUserId);
+```
+
+In tests, `Mattermost::fake()` records the connection name on every request,
+and the bundled `assertProfilePhotoUpdated($userId)` /
+`assertProfilePhotoReset($userId)` assertions cover both endpoints.
+
 ## Local development
 
 A `docker-compose.yml` ships a local Mattermost for development:

--- a/src/Client/Requests/Users/SetDefaultProfileImage.php
+++ b/src/Client/Requests/Users/SetDefaultProfileImage.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+/**
+ * SetDefaultProfileImage
+ *
+ * Reset a user's profile image to the default avatar Mattermost generates
+ * from their initials. Hits `DELETE /api/v4/users/{user_id}/image`.
+ * Requires an admin-grade token when targeting another user.
+ */
+class SetDefaultProfileImage extends Request
+{
+    protected Method $method = Method::DELETE;
+
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/image";
+    }
+
+    /**
+     * @param  string  $userId  Target user GUID.
+     */
+    public function __construct(
+        protected string $userId,
+    ) {}
+}

--- a/src/Client/Requests/Users/SetProfileImage.php
+++ b/src/Client/Requests/Users/SetProfileImage.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ConduitUI\Mattermost\Client\Requests\Users;
+
+use InvalidArgumentException;
+use RuntimeException;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Data\MultipartValue;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasMultipartBody;
+use SplFileInfo;
+
+/**
+ * SetProfileImage
+ *
+ * Set a user's profile image using a multipart upload to
+ * `POST /api/v4/users/{user_id}/image`. Mattermost rejects bot tokens here
+ * for the bot's own account — call this on a connection that has been
+ * configured with an admin-grade token.
+ */
+class SetProfileImage extends Request implements HasBody
+{
+    use HasMultipartBody;
+
+    protected Method $method = Method::POST;
+
+    /**
+     * @param  string  $userId  Target user GUID.
+     * @param  string|SplFileInfo|resource  $image  File path, SplFileInfo, or open stream resource.
+     * @param  string|null  $filename  Filename sent to the server. Inferred when a path/SplFileInfo is given.
+     */
+    public function __construct(
+        protected string $userId,
+        protected mixed $image,
+        protected ?string $filename = null,
+    ) {}
+
+    public function resolveEndpoint(): string
+    {
+        return "/api/v4/users/{$this->userId}/image";
+    }
+
+    /**
+     * @return array<int, MultipartValue>
+     */
+    protected function defaultBody(): array
+    {
+        return [new MultipartValue('image', $this->resolveStream(), $this->resolveFilename())];
+    }
+
+    /**
+     * @return resource
+     */
+    private function resolveStream(): mixed
+    {
+        if (is_resource($this->image)) {
+            return $this->image;
+        }
+
+        if ($this->image instanceof SplFileInfo) {
+            return $this->openPath($this->image->getPathname());
+        }
+
+        if (is_string($this->image)) {
+            return $this->openPath($this->image);
+        }
+
+        throw new InvalidArgumentException('Profile image must be a file path, SplFileInfo, or resource.');
+    }
+
+    private function resolveFilename(): string
+    {
+        if ($this->filename !== null) {
+            return $this->filename;
+        }
+
+        if ($this->image instanceof SplFileInfo) {
+            return $this->image->getFilename();
+        }
+
+        if (is_string($this->image)) {
+            return basename($this->image);
+        }
+
+        return 'profile-image';
+    }
+
+    /**
+     * @return resource
+     */
+    private function openPath(string $path): mixed
+    {
+        if (! is_file($path)) {
+            throw new InvalidArgumentException("Profile image file not found: {$path}");
+        }
+
+        $handle = @fopen($path, 'rb');
+
+        if ($handle === false) {
+            throw new RuntimeException("Could not open profile image: {$path}");
+        }
+
+        return $handle;
+    }
+}

--- a/src/Client/Resource/Users.php
+++ b/src/Client/Resource/Users.php
@@ -51,6 +51,8 @@ use ConduitUI\Mattermost\Client\Requests\Users\SearchUserAccessTokens;
 use ConduitUI\Mattermost\Client\Requests\Users\SearchUsers;
 use ConduitUI\Mattermost\Client\Requests\Users\SendPasswordResetEmail;
 use ConduitUI\Mattermost\Client\Requests\Users\SendVerificationEmail;
+use ConduitUI\Mattermost\Client\Requests\Users\SetDefaultProfileImage;
+use ConduitUI\Mattermost\Client\Requests\Users\SetProfileImage;
 use ConduitUI\Mattermost\Client\Requests\Users\SwitchAccountType;
 use ConduitUI\Mattermost\Client\Requests\Users\UpdateUser;
 use ConduitUI\Mattermost\Client\Requests\Users\UpdateUserActive;
@@ -62,6 +64,7 @@ use ConduitUI\Mattermost\Client\Requests\Users\VerifyUserEmail;
 use ConduitUI\Mattermost\Client\Requests\Users\VerifyUserEmailWithoutToken;
 use Saloon\Http\BaseResource;
 use Saloon\Http\Response;
+use SplFileInfo;
 
 class Users extends BaseResource
 {
@@ -533,5 +536,31 @@ class Users extends BaseResource
     public function getUploadsForUser(string $userId): Response
     {
         return $this->connector->send(new GetUploadsForUser($userId));
+    }
+
+    /**
+     * Set the user's profile image. The targeted Mattermost connection must
+     * carry an admin-grade token — bots cannot update their own avatar with
+     * their own token.
+     *
+     * @param  string  $userId  Target user GUID.
+     * @param  string|SplFileInfo|resource  $image  File path, SplFileInfo, or open stream resource.
+     * @param  string|null  $filename  Override the filename sent to the server.
+     */
+    public function updateProfilePhoto(string $userId, mixed $image, ?string $filename = null): Response
+    {
+        return $this->connector->send(new SetProfileImage($userId, $image, $filename));
+    }
+
+    /**
+     * Reset the user's profile image to the auto-generated default. Hits
+     * `DELETE /api/v4/users/{user_id}/image` — requires an admin-grade token
+     * when targeting another user.
+     *
+     * @param  string  $userId  Target user GUID.
+     */
+    public function deleteProfilePhoto(string $userId): Response
+    {
+        return $this->connector->send(new SetDefaultProfileImage($userId));
     }
 }

--- a/src/Facades/Mattermost.php
+++ b/src/Facades/Mattermost.php
@@ -44,6 +44,8 @@ use Saloon\Http\Faking\MockResponse;
  * @method static \ConduitUI\Mattermost\Testing\MattermostFake assertReacted(?string $postId = null, ?string $emoji = null)
  * @method static \ConduitUI\Mattermost\Testing\MattermostFake assertNotReacted(?string $postId = null, ?string $emoji = null)
  * @method static \ConduitUI\Mattermost\Testing\MattermostFake assertFileUploaded(?\Closure $callback = null, ?int $times = null)
+ * @method static \ConduitUI\Mattermost\Testing\MattermostFake assertProfilePhotoUpdated(?string $userId = null, ?\Closure $callback = null, ?int $times = null)
+ * @method static \ConduitUI\Mattermost\Testing\MattermostFake assertProfilePhotoReset(?string $userId = null, ?\Closure $callback = null, ?int $times = null)
  * @method static \ConduitUI\Mattermost\Testing\MattermostFake preventStrayPosts(bool $prevent = true)
  * @method static array<int, \ConduitUI\Mattermost\Testing\RecordedRequest> recorded(?string $requestClass = null)
  *

--- a/src/Testing/MattermostFake.php
+++ b/src/Testing/MattermostFake.php
@@ -12,6 +12,8 @@ use ConduitUI\Mattermost\Client\Requests\Posts\DeletePost;
 use ConduitUI\Mattermost\Client\Requests\Posts\PatchPost;
 use ConduitUI\Mattermost\Client\Requests\Posts\UpdatePost;
 use ConduitUI\Mattermost\Client\Requests\Reactions\SaveReaction;
+use ConduitUI\Mattermost\Client\Requests\Users\SetDefaultProfileImage;
+use ConduitUI\Mattermost\Client\Requests\Users\SetProfileImage;
 use ConduitUI\Mattermost\Facades\Mattermost;
 use ConduitUI\Mattermost\MattermostManager;
 use PHPUnit\Framework\Assert as PHPUnit;
@@ -335,6 +337,53 @@ class MattermostFake extends MattermostManager
     public function assertFileUploaded(?Closure $callback = null, ?int $times = null): self
     {
         return $this->assertSentForRequest(UploadFile::class, $callback, $times, 'No matching Mattermost file upload was sent.');
+    }
+
+    // ------------------------------------------------------------------
+    // Users API
+    // ------------------------------------------------------------------
+
+    /**
+     * Assert a profile-photo update was sent. Optionally narrow by user id
+     * or with a callback receiving the RecordedRequest.
+     *
+     * @param  Closure(RecordedRequest):bool|null  $callback
+     */
+    public function assertProfilePhotoUpdated(?string $userId = null, ?Closure $callback = null, ?int $times = null): self
+    {
+        $combined = static function (RecordedRequest $record) use ($userId, $callback): bool {
+            if ($userId !== null && ! str_contains($record->url, "/users/{$userId}/image")) {
+                return false;
+            }
+
+            return $callback === null || $callback($record);
+        };
+
+        return $this->assertSentForRequest(SetProfileImage::class, $combined, $times, sprintf(
+            'No matching Mattermost profile-photo update was sent (user_id=%s).',
+            $userId ?? '*',
+        ));
+    }
+
+    /**
+     * Assert the default-image (DELETE) reset was sent.
+     *
+     * @param  Closure(RecordedRequest):bool|null  $callback
+     */
+    public function assertProfilePhotoReset(?string $userId = null, ?Closure $callback = null, ?int $times = null): self
+    {
+        $combined = static function (RecordedRequest $record) use ($userId, $callback): bool {
+            if ($userId !== null && ! str_contains($record->url, "/users/{$userId}/image")) {
+                return false;
+            }
+
+            return $callback === null || $callback($record);
+        };
+
+        return $this->assertSentForRequest(SetDefaultProfileImage::class, $combined, $times, sprintf(
+            'No matching Mattermost profile-photo reset was sent (user_id=%s).',
+            $userId ?? '*',
+        ));
     }
 
     // ------------------------------------------------------------------

--- a/tests/Integration/UsersIntegrationTest.php
+++ b/tests/Integration/UsersIntegrationTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use ConduitUI\Mattermost\Client\Mattermost as MattermostConnector;
 use ConduitUI\Mattermost\Client\Requests\Users\SearchUsers;
 use ConduitUI\Mattermost\Facades\Mattermost;
 
@@ -31,5 +32,55 @@ describe('Users integration', function (): void {
         $usernames = array_map(static fn (array $u): string => (string) ($u['username'] ?? ''), $users);
         // The integration-bot we just created should match the term.
         expect($usernames)->toContain('integration-bot');
+    });
+
+    it('updates and resets a user profile photo via an admin connection', function (): void {
+        $credentials = $this->credentials();
+
+        $admin = new MattermostConnector(
+            baseUrl: $credentials->baseUrl,
+            token: $credentials->adminToken,
+        );
+
+        $fixture = sys_get_temp_dir().'/mm-int-avatar-'.bin2hex(random_bytes(4)).'.png';
+        file_put_contents($fixture, base64_decode(
+            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGNgYGD4DwABBAEAfbLI3wAAAABJRU5ErkJggg==',
+        ));
+
+        try {
+            $upload = $admin->users()->updateProfilePhoto($credentials->botUserId, $fixture);
+            expect($upload->status())->toBe(200);
+
+            $reset = $admin->users()->deleteProfilePhoto($credentials->botUserId);
+            expect($reset->status())->toBe(200);
+        } finally {
+            if (is_file($fixture)) {
+                unlink($fixture);
+            }
+        }
+    });
+
+    it('rejects a profile photo update made with the bot token', function (): void {
+        // Bots cannot update their own avatar via their own token. This
+        // test documents the constraint that motivates the admin-connection
+        // pattern from the Multi-server section of the README.
+        $fixture = sys_get_temp_dir().'/mm-int-bot-avatar-'.bin2hex(random_bytes(4)).'.png';
+        file_put_contents($fixture, base64_decode(
+            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGNgYGD4DwABBAEAfbLI3wAAAABJRU5ErkJggg==',
+        ));
+
+        try {
+            $response = Mattermost::users()->updateProfilePhoto(
+                $this->credentials()->botUserId,
+                $fixture,
+            );
+
+            expect($response->failed())->toBeTrue();
+            expect($response->status())->toBeGreaterThanOrEqual(400);
+        } finally {
+            if (is_file($fixture)) {
+                unlink($fixture);
+            }
+        }
     });
 });

--- a/tests/Unit/Client/UsersProfilePhotoTest.php
+++ b/tests/Unit/Client/UsersProfilePhotoTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+use ConduitUI\Mattermost\Client\Requests\Users\SetProfileImage;
+use ConduitUI\Mattermost\Facades\Mattermost;
+use Saloon\Data\MultipartValue;
+use Saloon\Http\Faking\MockResponse;
+
+describe('Users::updateProfilePhoto()', function (): void {
+    beforeEach(function (): void {
+        $this->fixture = sys_get_temp_dir().'/mm-avatar-'.bin2hex(random_bytes(4)).'.png';
+        // 1×1 transparent PNG
+        file_put_contents($this->fixture, base64_decode(
+            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGNgYGD4DwABBAEAfbLI3wAAAABJRU5ErkJggg==',
+        ));
+    });
+
+    afterEach(function (): void {
+        if (isset($this->fixture) && is_file($this->fixture)) {
+            unlink($this->fixture);
+        }
+    });
+
+    it('sends a multipart POST to /users/{id}/image with field name "image"', function (): void {
+        Mattermost::fake([
+            SetProfileImage::class => MockResponse::make([], 200),
+        ]);
+
+        Mattermost::users()->updateProfilePhoto('user-1', $this->fixture);
+
+        Mattermost::assertProfilePhotoUpdated('user-1', function ($record): bool {
+            $body = $record->request->body();
+            $values = $body->all();
+
+            expect($values)->toHaveCount(1);
+            expect($values[0])->toBeInstanceOf(MultipartValue::class);
+            expect($values[0]->name)->toBe('image');
+            expect($values[0]->filename)->toBe(basename($this->fixture));
+
+            return $record->method === 'POST'
+                && str_ends_with($record->url, '/api/v4/users/user-1/image');
+        });
+    });
+
+    it('accepts an SplFileInfo as the image source', function (): void {
+        Mattermost::fake();
+
+        Mattermost::users()->updateProfilePhoto('user-2', new SplFileInfo($this->fixture));
+
+        Mattermost::assertProfilePhotoUpdated('user-2', function ($record): bool {
+            $values = $record->request->body()->all();
+
+            return $values[0]->filename === basename($this->fixture);
+        });
+    });
+
+    it('accepts an open stream resource', function (): void {
+        Mattermost::fake();
+
+        $stream = fopen($this->fixture, 'rb');
+        Mattermost::users()->updateProfilePhoto('user-3', $stream, 'avatar.png');
+
+        Mattermost::assertProfilePhotoUpdated('user-3', function ($record): bool {
+            $values = $record->request->body()->all();
+
+            return is_resource($values[0]->value) && $values[0]->filename === 'avatar.png';
+        });
+    });
+
+    it('throws when the file path does not exist', function (): void {
+        Mattermost::fake();
+
+        expect(fn () => Mattermost::users()->updateProfilePhoto('user-4', '/nonexistent/avatar.png'))
+            ->toThrow(InvalidArgumentException::class, 'Profile image file not found');
+    });
+
+    it('routes through a named admin connection without touching the default', function (): void {
+        config(['mattermost.connections.admin' => [
+            'url' => 'https://fake.mattermost.test',
+            'token' => 'admin-token',
+        ]]);
+
+        $fake = Mattermost::fake();
+
+        Mattermost::connection('admin')->users()->updateProfilePhoto('user-5', $this->fixture);
+
+        $fake->assertProfilePhotoUpdated('user-5');
+
+        $records = $fake->recorded(SetProfileImage::class);
+        expect($records[0]->connection)->toBe('admin');
+    });
+});
+
+describe('Users::deleteProfilePhoto()', function (): void {
+    it('sends a DELETE to /users/{id}/image', function (): void {
+        Mattermost::fake();
+
+        Mattermost::users()->deleteProfilePhoto('user-9');
+
+        Mattermost::assertProfilePhotoReset('user-9', function ($record): bool {
+            return $record->method === 'DELETE'
+                && str_ends_with($record->url, '/api/v4/users/user-9/image');
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- New multipart `POST /api/v4/users/{user_id}/image` request and the matching `DELETE` for reset-to-default.
- `Users::updateProfilePhoto(string $userId, string|SplFileInfo|resource $image, ?string $filename = null)` and `Users::deleteProfilePhoto(string $userId)` on the resource.
- `MattermostFake::assertProfilePhotoUpdated()` / `assertProfilePhotoReset()` (filter by user id, exposed on the facade).
- README "Multi-server > Admin-token operations" walks through pairing a default bot connection with an admin-token connection — bots can't update their own avatar via their own token, so callers route the privileged call through `Mattermost::connection('admin')`.

This unblocks the last direct `MattermostService` call site in synapse-sentinel/lexi.

## Test plan

- [x] `vendor/bin/pest --compact` — 347 passed (619 assertions), 16 integration skipped (no docker)
- [x] `vendor/bin/pint --test` — clean
- [x] `vendor/bin/phpstan analyse` — level 8, no errors
- [ ] Reviewer: spin up `docker compose up -d` and run `vendor/bin/pest --testsuite=Integration` to exercise the admin-token round-trip and the bot-token rejection path

Closes #39